### PR TITLE
chore(test): fix frequently failing NFS-backup tests

### DIFF
--- a/systest/backup/nfs-backup/Dockerfile
+++ b/systest/backup/nfs-backup/Dockerfile
@@ -1,26 +1,6 @@
-# This file is used to add the nightly Dgraph binaries and assets to Dgraph base
-# image.
-
-# This gets built as part of release.sh. Must be run from /tmp/build, with the linux binaries
-# already built and placed there.
-
-FROM ubuntu:20.04
+FROM dgraph/dgraph:local
 LABEL maintainer="Dgraph Labs <contact@dgraph.io>"
 
-# need to remove the cache of sources lists
-# apt-get Error Code 100
-# https://www.marnel.net/2015/08/apt-get-error-code-100/
-RUN rm -rf /var/lib/apt/lists/*
-
-# only update, don't run upgrade
-# use cache busting to avoid old versions
-# remove /var/lib/apt/lists/* to reduce image size. 
-# see: https://docs.docker.com/develop/develop-images/dockerfile_best-practices 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     nfs-client
-
-RUN mkdir /dgraph
-WORKDIR /dgraph
-
-ENV GODEBUG=madvdontneed=1
 CMD ["dgraph"] # Shows the dgraph version and commands available.

--- a/systest/backup/nfs-backup/Dockerfile
+++ b/systest/backup/nfs-backup/Dockerfile
@@ -1,0 +1,26 @@
+# This file is used to add the nightly Dgraph binaries and assets to Dgraph base
+# image.
+
+# This gets built as part of release.sh. Must be run from /tmp/build, with the linux binaries
+# already built and placed there.
+
+FROM ubuntu:20.04
+LABEL maintainer="Dgraph Labs <contact@dgraph.io>"
+
+# need to remove the cache of sources lists
+# apt-get Error Code 100
+# https://www.marnel.net/2015/08/apt-get-error-code-100/
+RUN rm -rf /var/lib/apt/lists/*
+
+# only update, don't run upgrade
+# use cache busting to avoid old versions
+# remove /var/lib/apt/lists/* to reduce image size. 
+# see: https://docs.docker.com/develop/develop-images/dockerfile_best-practices 
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    nfs-client
+
+RUN mkdir /dgraph
+WORKDIR /dgraph
+
+ENV GODEBUG=madvdontneed=1
+CMD ["dgraph"] # Shows the dgraph version and commands available.

--- a/systest/backup/nfs-backup/docker-compose.yml
+++ b/systest/backup/nfs-backup/docker-compose.yml
@@ -334,7 +334,7 @@ services:
         /gobin/dgraph  ${COVERAGE_OUTPUT}  alpha   --my=alpha8_restore_clust_non_ha:7080  --zero=zero8_restore_clust_non_ha:5080 --logtostderr -v=2  --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
 
   nfs:
-    image: itsthenetwork/nfs-server-alpine:${NFS_SERVER_IMAGE_ARCH:-latest}
+    image: itsthenetwork/nfs-server-alpine:${NFS_SERVER_IMAGE_ARCH:-12}
     restart: unless-stopped
     privileged: true
 

--- a/systest/backup/nfs-backup/docker-compose.yml
+++ b/systest/backup/nfs-backup/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3.5"
 services:
 #HA backup cluster
   alpha1_backup_clust_ha:
-    image: dgraph-xnfs-client
+    image: dgraph-nfs-client
     build: 
       context: .
       dockerfile: ./Dockerfile
@@ -29,7 +29,7 @@ services:
         /gobin/dgraph  ${COVERAGE_OUTPUT}  alpha   --my=alpha1_backup_clust_ha:7080  --zero=zero1_backup_clust_ha:5080,zero2_backup_clust_ha:5080,zero3_backup_clust_ha:5080 --logtostderr -v=2  --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
 
   alpha2_backup_clust_ha:
-    image: dgraph-xnfs-client
+    image: dgraph-nfs-client
     working_dir: /data/alpha2
     links:
       - "nfs:nfs"
@@ -46,7 +46,7 @@ services:
     command: /gobin/dgraph  ${COVERAGE_OUTPUT}  alpha   --my=alpha2_backup_clust_ha:7080  --zero=zero1_backup_clust_ha:5080,zero2_backup_clust_ha:5080,zero3_backup_clust_ha:5080 --logtostderr -v=2  --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
 
   alpha3_backup_clust_ha:
-    image: dgraph-xnfs-client
+    image: dgraph-nfs-client
     working_dir: /data/alpha3
     links:
       - "nfs:nfs"
@@ -63,7 +63,7 @@ services:
     command: /gobin/dgraph  ${COVERAGE_OUTPUT}  alpha   --my=alpha3_backup_clust_ha:7080  --zero=zero1_backup_clust_ha:5080,zero2_backup_clust_ha:5080,zero3_backup_clust_ha:5080 --logtostderr -v=2  --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
 
   zero1_backup_clust_ha:
-    image: dgraph-xnfs-client
+    image: dgraph-nfs-client
     working_dir: /data/zero1
     links:
       - "nfs:nfs"
@@ -80,7 +80,7 @@ services:
     command: /gobin/dgraph  ${COVERAGE_OUTPUT} zero --raft "idx=1;" --my=zero1_backup_clust_ha:5080 --replicas=3 --logtostderr -v=2 --bindall
 
   zero2_backup_clust_ha:
-    image: dgraph-xnfs-client
+    image: dgraph-nfs-client
     working_dir: /data/zero2
     depends_on:
       - zero1_backup_clust_ha
@@ -98,7 +98,7 @@ services:
     command: /gobin/dgraph  ${COVERAGE_OUTPUT} zero --raft "idx=2;" --my=zero2_backup_clust_ha:5080 --replicas=3 --logtostderr -v=2 --bindall  --peer=zero1_backup_clust_ha:5080
 
   zero3_backup_clust_ha:
-    image: dgraph-xnfs-client
+    image: dgraph-nfs-client
     working_dir: /data/zero3
     depends_on:
       - zero2_backup_clust_ha
@@ -118,7 +118,7 @@ services:
 
 #HA restore cluster
   alpha4_restore_clust_ha:
-    image: dgraph-xnfs-client
+    image: dgraph-nfs-client
     working_dir: /data/alpha4
     links:
       - "nfs:nfs"
@@ -141,7 +141,7 @@ services:
         /gobin/dgraph  ${COVERAGE_OUTPUT}  alpha   --my=alpha4_restore_clust_ha:7080  --zero=zero4_restore_clust_ha:5080,zero5_restore_clust_ha:5080,zero6_restore_clust_ha:5080 --logtostderr -v=2  --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
 
   alpha5_restore_clust_ha:
-    image: dgraph-xnfs-client
+    image: dgraph-nfs-client
     working_dir: /data/alpha5
     links:
       - "nfs:nfs"
@@ -158,7 +158,7 @@ services:
     command: /gobin/dgraph  ${COVERAGE_OUTPUT}  alpha   --my=alpha5_restore_clust_ha:7080  --zero=zero4_restore_clust_ha:5080,zero5_restore_clust_ha:5080,zero6_restore_clust_ha:5080 --logtostderr -v=2  --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
 
   alpha6_restore_clust_ha:
-    image: dgraph-xnfs-client
+    image: dgraph-nfs-client
     working_dir: /data/alpha6  
     links:
       - "nfs:nfs"
@@ -175,7 +175,7 @@ services:
     command: /gobin/dgraph  ${COVERAGE_OUTPUT}  alpha   --my=alpha6_restore_clust_ha:7080  --zero=zero4_restore_clust_ha:5080,zero5_restore_clust_ha:5080,zero6_restore_clust_ha:5080 --logtostderr -v=2  --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
 
   zero4_restore_clust_ha:
-    image: dgraph-xnfs-client
+    image: dgraph-nfs-client
     working_dir: /data/zero4
     links:
       - "nfs:nfs"
@@ -192,7 +192,7 @@ services:
     command: /gobin/dgraph  ${COVERAGE_OUTPUT} zero --raft "idx=1;" --my=zero4_restore_clust_ha:5080 --replicas=3 --logtostderr -v=2 --bindall
 
   zero5_restore_clust_ha:
-    image: dgraph-xnfs-client
+    image: dgraph-nfs-client
     working_dir: /data/zero5
     depends_on:
       - zero4_restore_clust_ha
@@ -210,7 +210,7 @@ services:
     command: /gobin/dgraph  ${COVERAGE_OUTPUT} zero --raft "idx=2;" --my=zero5_restore_clust_ha:5080 --replicas=3 --logtostderr -v=2 --bindall  --peer=zero4_restore_clust_ha:5080
 
   zero6_restore_clust_ha:
-    image: dgraph-xnfs-client
+    image: dgraph-nfs-client
     working_dir: /data/zero3
     depends_on:
       - zero5_restore_clust_ha
@@ -230,7 +230,7 @@ services:
 
 #non HA cluster backup cluster
   zero7_backup_clust_non_ha:
-    image: dgraph-xnfs-client
+    image: dgraph-nfs-client
     working_dir: /data/zero7
     links:
       - "nfs:nfs"
@@ -247,7 +247,7 @@ services:
     command: /gobin/dgraph  ${COVERAGE_OUTPUT} zero --raft "idx=1;" --my=zero7_backup_clust_non_ha:5080 --replicas=1 --logtostderr -v=2 --bindall
 
   alpha7_backup_clust_non_ha:
-    image: dgraph-xnfs-client
+    image: dgraph-nfs-client
     working_dir: /data/alpha7
     links:
       - "nfs:nfs"
@@ -272,7 +272,7 @@ services:
 
 #non HA restore cluster
   zero8_restore_clust_non_ha:
-    image: dgraph-xnfs-client
+    image: dgraph-nfs-client
     working_dir: /data/zero8
     links:
       - "nfs:nfs"
@@ -289,7 +289,7 @@ services:
     command: /gobin/dgraph  ${COVERAGE_OUTPUT} zero --raft "idx=1;" --my=zero8_restore_clust_non_ha:5080 --replicas=1 --logtostderr -v=2 --bindall
 
   alpha8_restore_clust_non_ha:
-    image: dgraph-xnfs-client
+    image: dgraph-nfs-client
     working_dir: /data/alpha8
     links:
       - "nfs:nfs"
@@ -312,7 +312,7 @@ services:
         /gobin/dgraph  ${COVERAGE_OUTPUT}  alpha   --my=alpha8_restore_clust_non_ha:7080  --zero=zero8_restore_clust_non_ha:5080 --logtostderr -v=2  --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
 
   nfs:
-    image: itsthenetwork/nfs-server-alpine:${NFS_SERVER_IMAGE_ARCH:-12}
+    image: itsthenetwork/nfs-server-alpine:${NFS_SERVER_IMAGE_ARCH:-latest}
     restart: unless-stopped
     privileged: true
 

--- a/systest/backup/nfs-backup/docker-compose.yml
+++ b/systest/backup/nfs-backup/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3.5"
 services:
 #HA backup cluster
   alpha1_backup_clust_ha:
-    image: dgraphxnfsclient
+    image: dgraph-xnfs-client
     build: 
       context: .
       dockerfile: ./Dockerfile
@@ -29,7 +29,7 @@ services:
         /gobin/dgraph  ${COVERAGE_OUTPUT}  alpha   --my=alpha1_backup_clust_ha:7080  --zero=zero1_backup_clust_ha:5080,zero2_backup_clust_ha:5080,zero3_backup_clust_ha:5080 --logtostderr -v=2  --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
 
   alpha2_backup_clust_ha:
-    image: dgraphxnfsclient
+    image: dgraph-xnfs-client
     working_dir: /data/alpha2
     links:
       - "nfs:nfs"
@@ -46,7 +46,7 @@ services:
     command: /gobin/dgraph  ${COVERAGE_OUTPUT}  alpha   --my=alpha2_backup_clust_ha:7080  --zero=zero1_backup_clust_ha:5080,zero2_backup_clust_ha:5080,zero3_backup_clust_ha:5080 --logtostderr -v=2  --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
 
   alpha3_backup_clust_ha:
-    image: dgraphxnfsclient
+    image: dgraph-xnfs-client
     working_dir: /data/alpha3
     links:
       - "nfs:nfs"
@@ -63,7 +63,7 @@ services:
     command: /gobin/dgraph  ${COVERAGE_OUTPUT}  alpha   --my=alpha3_backup_clust_ha:7080  --zero=zero1_backup_clust_ha:5080,zero2_backup_clust_ha:5080,zero3_backup_clust_ha:5080 --logtostderr -v=2  --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
 
   zero1_backup_clust_ha:
-    image: dgraphxnfsclient
+    image: dgraph-xnfs-client
     working_dir: /data/zero1
     links:
       - "nfs:nfs"
@@ -80,7 +80,7 @@ services:
     command: /gobin/dgraph  ${COVERAGE_OUTPUT} zero --raft "idx=1;" --my=zero1_backup_clust_ha:5080 --replicas=3 --logtostderr -v=2 --bindall
 
   zero2_backup_clust_ha:
-    image: dgraphxnfsclient
+    image: dgraph-xnfs-client
     working_dir: /data/zero2
     depends_on:
       - zero1_backup_clust_ha
@@ -98,7 +98,7 @@ services:
     command: /gobin/dgraph  ${COVERAGE_OUTPUT} zero --raft "idx=2;" --my=zero2_backup_clust_ha:5080 --replicas=3 --logtostderr -v=2 --bindall  --peer=zero1_backup_clust_ha:5080
 
   zero3_backup_clust_ha:
-    image: dgraphxnfsclient
+    image: dgraph-xnfs-client
     working_dir: /data/zero3
     depends_on:
       - zero2_backup_clust_ha
@@ -118,7 +118,7 @@ services:
 
 #HA restore cluster
   alpha4_restore_clust_ha:
-    image: dgraphxnfsclient
+    image: dgraph-xnfs-client
     working_dir: /data/alpha4
     links:
       - "nfs:nfs"
@@ -141,7 +141,7 @@ services:
         /gobin/dgraph  ${COVERAGE_OUTPUT}  alpha   --my=alpha4_restore_clust_ha:7080  --zero=zero4_restore_clust_ha:5080,zero5_restore_clust_ha:5080,zero6_restore_clust_ha:5080 --logtostderr -v=2  --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
 
   alpha5_restore_clust_ha:
-    image: dgraphxnfsclient
+    image: dgraph-xnfs-client
     working_dir: /data/alpha5
     links:
       - "nfs:nfs"
@@ -158,7 +158,7 @@ services:
     command: /gobin/dgraph  ${COVERAGE_OUTPUT}  alpha   --my=alpha5_restore_clust_ha:7080  --zero=zero4_restore_clust_ha:5080,zero5_restore_clust_ha:5080,zero6_restore_clust_ha:5080 --logtostderr -v=2  --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
 
   alpha6_restore_clust_ha:
-    image: dgraphxnfsclient
+    image: dgraph-xnfs-client
     working_dir: /data/alpha6  
     links:
       - "nfs:nfs"
@@ -175,7 +175,7 @@ services:
     command: /gobin/dgraph  ${COVERAGE_OUTPUT}  alpha   --my=alpha6_restore_clust_ha:7080  --zero=zero4_restore_clust_ha:5080,zero5_restore_clust_ha:5080,zero6_restore_clust_ha:5080 --logtostderr -v=2  --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
 
   zero4_restore_clust_ha:
-    image: dgraphxnfsclient
+    image: dgraph-xnfs-client
     working_dir: /data/zero4
     links:
       - "nfs:nfs"
@@ -192,7 +192,7 @@ services:
     command: /gobin/dgraph  ${COVERAGE_OUTPUT} zero --raft "idx=1;" --my=zero4_restore_clust_ha:5080 --replicas=3 --logtostderr -v=2 --bindall
 
   zero5_restore_clust_ha:
-    image: dgraphxnfsclient
+    image: dgraph-xnfs-client
     working_dir: /data/zero5
     depends_on:
       - zero4_restore_clust_ha
@@ -210,7 +210,7 @@ services:
     command: /gobin/dgraph  ${COVERAGE_OUTPUT} zero --raft "idx=2;" --my=zero5_restore_clust_ha:5080 --replicas=3 --logtostderr -v=2 --bindall  --peer=zero4_restore_clust_ha:5080
 
   zero6_restore_clust_ha:
-    image: dgraphxnfsclient
+    image: dgraph-xnfs-client
     working_dir: /data/zero3
     depends_on:
       - zero5_restore_clust_ha
@@ -230,7 +230,7 @@ services:
 
 #non HA cluster backup cluster
   zero7_backup_clust_non_ha:
-    image: dgraphxnfsclient
+    image: dgraph-xnfs-client
     working_dir: /data/zero7
     links:
       - "nfs:nfs"
@@ -247,7 +247,7 @@ services:
     command: /gobin/dgraph  ${COVERAGE_OUTPUT} zero --raft "idx=1;" --my=zero7_backup_clust_non_ha:5080 --replicas=1 --logtostderr -v=2 --bindall
 
   alpha7_backup_clust_non_ha:
-    image: dgraphxnfsclient
+    image: dgraph-xnfs-client
     working_dir: /data/alpha7
     links:
       - "nfs:nfs"
@@ -272,7 +272,7 @@ services:
 
 #non HA restore cluster
   zero8_restore_clust_non_ha:
-    image: dgraphxnfsclient
+    image: dgraph-xnfs-client
     working_dir: /data/zero8
     links:
       - "nfs:nfs"
@@ -289,7 +289,7 @@ services:
     command: /gobin/dgraph  ${COVERAGE_OUTPUT} zero --raft "idx=1;" --my=zero8_restore_clust_non_ha:5080 --replicas=1 --logtostderr -v=2 --bindall
 
   alpha8_restore_clust_non_ha:
-    image: dgraphxnfsclient
+    image: dgraph-xnfs-client
     working_dir: /data/alpha8
     links:
       - "nfs:nfs"

--- a/systest/backup/nfs-backup/docker-compose.yml
+++ b/systest/backup/nfs-backup/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3.5"
 services:
 #HA backup cluster
   alpha1_backup_clust_ha:
-    image: dgraph-nfs-client
+    image: dgraph-nfs-client:local
     build: 
       context: .
       dockerfile: ./Dockerfile
@@ -29,8 +29,10 @@ services:
         /gobin/dgraph  ${COVERAGE_OUTPUT}  alpha   --my=alpha1_backup_clust_ha:7080  --zero=zero1_backup_clust_ha:5080,zero2_backup_clust_ha:5080,zero3_backup_clust_ha:5080 --logtostderr -v=2  --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
 
   alpha2_backup_clust_ha:
-    image: dgraph-nfs-client
+    image: dgraph-nfs-client:local
     working_dir: /data/alpha2
+    depends_on:
+      - alpha1_backup_clust_ha
     links:
       - "nfs:nfs"
     labels:
@@ -46,8 +48,10 @@ services:
     command: /gobin/dgraph  ${COVERAGE_OUTPUT}  alpha   --my=alpha2_backup_clust_ha:7080  --zero=zero1_backup_clust_ha:5080,zero2_backup_clust_ha:5080,zero3_backup_clust_ha:5080 --logtostderr -v=2  --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
 
   alpha3_backup_clust_ha:
-    image: dgraph-nfs-client
+    image: dgraph-nfs-client:local
     working_dir: /data/alpha3
+    depends_on:
+      - alpha1_backup_clust_ha
     links:
       - "nfs:nfs"
     labels:
@@ -63,8 +67,10 @@ services:
     command: /gobin/dgraph  ${COVERAGE_OUTPUT}  alpha   --my=alpha3_backup_clust_ha:7080  --zero=zero1_backup_clust_ha:5080,zero2_backup_clust_ha:5080,zero3_backup_clust_ha:5080 --logtostderr -v=2  --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
 
   zero1_backup_clust_ha:
-    image: dgraph-nfs-client
+    image: dgraph-nfs-client:local
     working_dir: /data/zero1
+    depends_on:
+      - alpha1_backup_clust_ha
     links:
       - "nfs:nfs"
     labels:
@@ -80,7 +86,7 @@ services:
     command: /gobin/dgraph  ${COVERAGE_OUTPUT} zero --raft "idx=1;" --my=zero1_backup_clust_ha:5080 --replicas=3 --logtostderr -v=2 --bindall
 
   zero2_backup_clust_ha:
-    image: dgraph-nfs-client
+    image: dgraph-nfs-client:local
     working_dir: /data/zero2
     depends_on:
       - zero1_backup_clust_ha
@@ -98,7 +104,7 @@ services:
     command: /gobin/dgraph  ${COVERAGE_OUTPUT} zero --raft "idx=2;" --my=zero2_backup_clust_ha:5080 --replicas=3 --logtostderr -v=2 --bindall  --peer=zero1_backup_clust_ha:5080
 
   zero3_backup_clust_ha:
-    image: dgraph-nfs-client
+    image: dgraph-nfs-client:local
     working_dir: /data/zero3
     depends_on:
       - zero2_backup_clust_ha
@@ -118,8 +124,10 @@ services:
 
 #HA restore cluster
   alpha4_restore_clust_ha:
-    image: dgraph-nfs-client
+    image: dgraph-nfs-client:local
     working_dir: /data/alpha4
+    depends_on:
+      - alpha1_backup_clust_ha
     links:
       - "nfs:nfs"
     privileged: true
@@ -141,8 +149,10 @@ services:
         /gobin/dgraph  ${COVERAGE_OUTPUT}  alpha   --my=alpha4_restore_clust_ha:7080  --zero=zero4_restore_clust_ha:5080,zero5_restore_clust_ha:5080,zero6_restore_clust_ha:5080 --logtostderr -v=2  --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
 
   alpha5_restore_clust_ha:
-    image: dgraph-nfs-client
+    image: dgraph-nfs-client:local
     working_dir: /data/alpha5
+    depends_on:
+      - alpha1_backup_clust_ha
     links:
       - "nfs:nfs"
     labels:
@@ -158,8 +168,10 @@ services:
     command: /gobin/dgraph  ${COVERAGE_OUTPUT}  alpha   --my=alpha5_restore_clust_ha:7080  --zero=zero4_restore_clust_ha:5080,zero5_restore_clust_ha:5080,zero6_restore_clust_ha:5080 --logtostderr -v=2  --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
 
   alpha6_restore_clust_ha:
-    image: dgraph-nfs-client
-    working_dir: /data/alpha6  
+    image: dgraph-nfs-client:local
+    working_dir: /data/alpha6
+    depends_on:
+      - alpha1_backup_clust_ha
     links:
       - "nfs:nfs"
     labels:
@@ -175,8 +187,10 @@ services:
     command: /gobin/dgraph  ${COVERAGE_OUTPUT}  alpha   --my=alpha6_restore_clust_ha:7080  --zero=zero4_restore_clust_ha:5080,zero5_restore_clust_ha:5080,zero6_restore_clust_ha:5080 --logtostderr -v=2  --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
 
   zero4_restore_clust_ha:
-    image: dgraph-nfs-client
+    image: dgraph-nfs-client:local
     working_dir: /data/zero4
+    depends_on:
+      - alpha1_backup_clust_ha
     links:
       - "nfs:nfs"
     labels:
@@ -192,7 +206,7 @@ services:
     command: /gobin/dgraph  ${COVERAGE_OUTPUT} zero --raft "idx=1;" --my=zero4_restore_clust_ha:5080 --replicas=3 --logtostderr -v=2 --bindall
 
   zero5_restore_clust_ha:
-    image: dgraph-nfs-client
+    image: dgraph-nfs-client:local
     working_dir: /data/zero5
     depends_on:
       - zero4_restore_clust_ha
@@ -210,7 +224,7 @@ services:
     command: /gobin/dgraph  ${COVERAGE_OUTPUT} zero --raft "idx=2;" --my=zero5_restore_clust_ha:5080 --replicas=3 --logtostderr -v=2 --bindall  --peer=zero4_restore_clust_ha:5080
 
   zero6_restore_clust_ha:
-    image: dgraph-nfs-client
+    image: dgraph-nfs-client:local
     working_dir: /data/zero3
     depends_on:
       - zero5_restore_clust_ha
@@ -230,8 +244,10 @@ services:
 
 #non HA cluster backup cluster
   zero7_backup_clust_non_ha:
-    image: dgraph-nfs-client
+    image: dgraph-nfs-client:local
     working_dir: /data/zero7
+    depends_on:
+      - alpha1_backup_clust_ha
     links:
       - "nfs:nfs"
     labels:
@@ -247,8 +263,10 @@ services:
     command: /gobin/dgraph  ${COVERAGE_OUTPUT} zero --raft "idx=1;" --my=zero7_backup_clust_non_ha:5080 --replicas=1 --logtostderr -v=2 --bindall
 
   alpha7_backup_clust_non_ha:
-    image: dgraph-nfs-client
+    image: dgraph-nfs-client:local
     working_dir: /data/alpha7
+    depends_on:
+      - alpha1_backup_clust_ha
     links:
       - "nfs:nfs"
     privileged: true
@@ -272,8 +290,10 @@ services:
 
 #non HA restore cluster
   zero8_restore_clust_non_ha:
-    image: dgraph-nfs-client
+    image: dgraph-nfs-client:local
     working_dir: /data/zero8
+    depends_on:
+      - alpha1_backup_clust_ha
     links:
       - "nfs:nfs"
     labels:
@@ -289,8 +309,10 @@ services:
     command: /gobin/dgraph  ${COVERAGE_OUTPUT} zero --raft "idx=1;" --my=zero8_restore_clust_non_ha:5080 --replicas=1 --logtostderr -v=2 --bindall
 
   alpha8_restore_clust_non_ha:
-    image: dgraph-nfs-client
+    image: dgraph-nfs-client:local
     working_dir: /data/alpha8
+    depends_on:
+      - alpha1_backup_clust_ha
     links:
       - "nfs:nfs"
     privileged: true

--- a/systest/backup/nfs-backup/docker-compose.yml
+++ b/systest/backup/nfs-backup/docker-compose.yml
@@ -3,7 +3,10 @@ version: "3.5"
 services:
 #HA backup cluster
   alpha1_backup_clust_ha:
-    image: dgraph/dgraph:local
+    image: dgraphxnfsclient
+    build: 
+      context: .
+      dockerfile: ./Dockerfile
     working_dir: /data/alpha1
     links:
       - "nfs:nfs"
@@ -22,12 +25,11 @@ services:
       - /bin/sh
       - -c
       - |
-        apt-get update -qq && apt install nfs-client -y
         mount -v -o vers=4,loud nfs:/ /mnt 2>&1 &
         /gobin/dgraph  ${COVERAGE_OUTPUT}  alpha   --my=alpha1_backup_clust_ha:7080  --zero=zero1_backup_clust_ha:5080,zero2_backup_clust_ha:5080,zero3_backup_clust_ha:5080 --logtostderr -v=2  --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
 
   alpha2_backup_clust_ha:
-    image: dgraph/dgraph:local
+    image: dgraphxnfsclient
     working_dir: /data/alpha2
     links:
       - "nfs:nfs"
@@ -44,7 +46,7 @@ services:
     command: /gobin/dgraph  ${COVERAGE_OUTPUT}  alpha   --my=alpha2_backup_clust_ha:7080  --zero=zero1_backup_clust_ha:5080,zero2_backup_clust_ha:5080,zero3_backup_clust_ha:5080 --logtostderr -v=2  --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
 
   alpha3_backup_clust_ha:
-    image: dgraph/dgraph:local
+    image: dgraphxnfsclient
     working_dir: /data/alpha3
     links:
       - "nfs:nfs"
@@ -61,7 +63,7 @@ services:
     command: /gobin/dgraph  ${COVERAGE_OUTPUT}  alpha   --my=alpha3_backup_clust_ha:7080  --zero=zero1_backup_clust_ha:5080,zero2_backup_clust_ha:5080,zero3_backup_clust_ha:5080 --logtostderr -v=2  --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
 
   zero1_backup_clust_ha:
-    image: dgraph/dgraph:local
+    image: dgraphxnfsclient
     working_dir: /data/zero1
     links:
       - "nfs:nfs"
@@ -78,7 +80,7 @@ services:
     command: /gobin/dgraph  ${COVERAGE_OUTPUT} zero --raft "idx=1;" --my=zero1_backup_clust_ha:5080 --replicas=3 --logtostderr -v=2 --bindall
 
   zero2_backup_clust_ha:
-    image: dgraph/dgraph:local
+    image: dgraphxnfsclient
     working_dir: /data/zero2
     depends_on:
       - zero1_backup_clust_ha
@@ -96,7 +98,7 @@ services:
     command: /gobin/dgraph  ${COVERAGE_OUTPUT} zero --raft "idx=2;" --my=zero2_backup_clust_ha:5080 --replicas=3 --logtostderr -v=2 --bindall  --peer=zero1_backup_clust_ha:5080
 
   zero3_backup_clust_ha:
-    image: dgraph/dgraph:local
+    image: dgraphxnfsclient
     working_dir: /data/zero3
     depends_on:
       - zero2_backup_clust_ha
@@ -116,7 +118,7 @@ services:
 
 #HA restore cluster
   alpha4_restore_clust_ha:
-    image: dgraph/dgraph:local
+    image: dgraphxnfsclient
     working_dir: /data/alpha4
     links:
       - "nfs:nfs"
@@ -135,12 +137,11 @@ services:
       - /bin/sh
       - -c
       - |
-        apt-get update -qq && apt install nfs-client -y
         mount -v -o vers=4,loud nfs:/ /mnt 2>&1 &
         /gobin/dgraph  ${COVERAGE_OUTPUT}  alpha   --my=alpha4_restore_clust_ha:7080  --zero=zero4_restore_clust_ha:5080,zero5_restore_clust_ha:5080,zero6_restore_clust_ha:5080 --logtostderr -v=2  --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
 
   alpha5_restore_clust_ha:
-    image: dgraph/dgraph:local
+    image: dgraphxnfsclient
     working_dir: /data/alpha5
     links:
       - "nfs:nfs"
@@ -157,8 +158,8 @@ services:
     command: /gobin/dgraph  ${COVERAGE_OUTPUT}  alpha   --my=alpha5_restore_clust_ha:7080  --zero=zero4_restore_clust_ha:5080,zero5_restore_clust_ha:5080,zero6_restore_clust_ha:5080 --logtostderr -v=2  --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
 
   alpha6_restore_clust_ha:
-    image: dgraph/dgraph:local
-    working_dir: /data/alpha6
+    image: dgraphxnfsclient
+    working_dir: /data/alpha6  
     links:
       - "nfs:nfs"
     labels:
@@ -174,7 +175,7 @@ services:
     command: /gobin/dgraph  ${COVERAGE_OUTPUT}  alpha   --my=alpha6_restore_clust_ha:7080  --zero=zero4_restore_clust_ha:5080,zero5_restore_clust_ha:5080,zero6_restore_clust_ha:5080 --logtostderr -v=2  --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
 
   zero4_restore_clust_ha:
-    image: dgraph/dgraph:local
+    image: dgraphxnfsclient
     working_dir: /data/zero4
     links:
       - "nfs:nfs"
@@ -191,7 +192,7 @@ services:
     command: /gobin/dgraph  ${COVERAGE_OUTPUT} zero --raft "idx=1;" --my=zero4_restore_clust_ha:5080 --replicas=3 --logtostderr -v=2 --bindall
 
   zero5_restore_clust_ha:
-    image: dgraph/dgraph:local
+    image: dgraphxnfsclient
     working_dir: /data/zero5
     depends_on:
       - zero4_restore_clust_ha
@@ -209,7 +210,7 @@ services:
     command: /gobin/dgraph  ${COVERAGE_OUTPUT} zero --raft "idx=2;" --my=zero5_restore_clust_ha:5080 --replicas=3 --logtostderr -v=2 --bindall  --peer=zero4_restore_clust_ha:5080
 
   zero6_restore_clust_ha:
-    image: dgraph/dgraph:local
+    image: dgraphxnfsclient
     working_dir: /data/zero3
     depends_on:
       - zero5_restore_clust_ha
@@ -229,7 +230,7 @@ services:
 
 #non HA cluster backup cluster
   zero7_backup_clust_non_ha:
-    image: dgraph/dgraph:local
+    image: dgraphxnfsclient
     working_dir: /data/zero7
     links:
       - "nfs:nfs"
@@ -246,7 +247,7 @@ services:
     command: /gobin/dgraph  ${COVERAGE_OUTPUT} zero --raft "idx=1;" --my=zero7_backup_clust_non_ha:5080 --replicas=1 --logtostderr -v=2 --bindall
 
   alpha7_backup_clust_non_ha:
-    image: dgraph/dgraph:local
+    image: dgraphxnfsclient
     working_dir: /data/alpha7
     links:
       - "nfs:nfs"
@@ -265,14 +266,13 @@ services:
       - /bin/sh
       - -c
       - |
-        apt-get update -qq && apt install nfs-client -y
         mount -v -o vers=4,loud nfs:/ /mnt 2>&1 &
         /gobin/dgraph  ${COVERAGE_OUTPUT}  alpha   --my=alpha7_backup_clust_non_ha:7080  --zero=zero7_backup_clust_non_ha:5080 --logtostderr -v=2  --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
 
 
 #non HA restore cluster
   zero8_restore_clust_non_ha:
-    image: dgraph/dgraph:local
+    image: dgraphxnfsclient
     working_dir: /data/zero8
     links:
       - "nfs:nfs"
@@ -289,7 +289,7 @@ services:
     command: /gobin/dgraph  ${COVERAGE_OUTPUT} zero --raft "idx=1;" --my=zero8_restore_clust_non_ha:5080 --replicas=1 --logtostderr -v=2 --bindall
 
   alpha8_restore_clust_non_ha:
-    image: dgraph/dgraph:local
+    image: dgraphxnfsclient
     working_dir: /data/alpha8
     links:
       - "nfs:nfs"
@@ -308,7 +308,6 @@ services:
       - /bin/sh
       - -c
       - |
-        apt-get update -qq && apt install nfs-client -y
         mount -v -o vers=4,loud nfs:/ /mnt 2>&1 &
         /gobin/dgraph  ${COVERAGE_OUTPUT}  alpha   --my=alpha8_restore_clust_non_ha:7080  --zero=zero8_restore_clust_non_ha:5080 --logtostderr -v=2  --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
 


### PR DESCRIPTION
NFS backup tests fail frequently in CI. The test installs the NFS client before starting the alpha service because of this the Alpha container takes more time to reach a healthy state and may not pass the health check. To solve this, created new Docker file which is a combination of NFS-client and Dgraph, This has been added under the build key of docker-compose file. https://github.com/dgraph-io/dgraph/actions/runs/4744244095/jobs/8424889366