### PR TITLE
chore: wait longer for login to work

### DIFF
--- a/dgraphtest/cluster.go
+++ b/dgraphtest/cluster.go
@@ -297,7 +297,9 @@ loop:
 		time.Sleep(waitDurBeforeRetry)
 
 		resp, err := c.AlphasHealth()
-		if err != nil {
+		if err != nil && strings.Contains(err.Error(), "the server is in draining mode") {
+			continue loop
+		} else if err != nil {
 			return err
 		}
 		for _, hr := range resp {

--- a/dgraphtest/local_cluster.go
+++ b/dgraphtest/local_cluster.go
@@ -373,7 +373,7 @@ func (c *LocalCluster) containerHealthCheck(url string) error {
 
 		ctx, cancel := context.WithTimeout(context.Background(), requestTimeout)
 		defer cancel()
-		for i := 0; i < 3; i++ {
+		for i := 0; i < 10; i++ {
 			if err = client.Login(ctx, DefaultUser, DefaultPassword); err == nil {
 				break
 			}


### PR DESCRIPTION
Seems like it takes longer for a 6 alpha cluster to be available for running queries.