### PR TITLE
chore(ci): add workflow for OSS build + unit tests

### DIFF
--- a/.github/workflows/ci-dgraph-oss-build.yml
+++ b/.github/workflows/ci-dgraph-oss-build.yml
@@ -55,5 +55,7 @@ jobs:
           #!/bin/bash
           # go env settings
           export GOPATH=~/go
+          # move the binary
+          cp dgraph/dgraph ~/go/bin/dgraph
           # run OSS unit tests
-          go test -timeout=60m -failfast -tags=oss ./...
+          go test -timeout=60m -failfast -tags=oss -count=1 ./...

--- a/.github/workflows/ci-dgraph-oss-build.yml
+++ b/.github/workflows/ci-dgraph-oss-build.yml
@@ -1,0 +1,59 @@
+name: ci-dgraph-oss-build
+on:
+  push:
+    paths-ignore:
+      - '.github/CODEOWNERS'
+      - '.vscode/**'
+      - 'compose/**'
+      - 'contrib/systemd/**'
+      - 'licenses/**'
+      - 'paper/**'
+      - 'present/**'
+      - 'RFC/**'
+      - 'static/**'
+      - 'wiki/**'
+      - '**/**.dockerignore'
+      - '**/**.gitignore'
+      - '**/**.md'
+      - '**/**.png'
+      - '**/**.jpg'
+      - '**/**.gif'
+      - '**/**.ini'
+    branches:
+      - main
+      - 'release/**'
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+    branches:
+      - main
+      - 'release/**'
+  schedule:
+    - cron: "0 0,6,12,18 * * *"
+jobs:
+  dgraph-tests:
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+      - name: Get Go Version
+        run: |
+          #!/bin/bash
+          GOVERSION=$({ [ -f .go-version ] && cat .go-version; })
+          echo "GOVERSION=$GOVERSION" >> $GITHUB_ENV
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ env.GOVERSION }}
+      - name: Make OSS Linux Build
+        run: make oss # verify that we can make OSS build
+      - name: Run OSS Unit Tests
+        run: |
+          #!/bin/bash
+          # go env settings
+          export GOPATH=~/go
+          # run OSS unit tests
+          go test -timeout=60m -failfast -tags=oss ./...

--- a/.github/workflows/ci-dgraph-oss-build.yml
+++ b/.github/workflows/ci-dgraph-oss-build.yml
@@ -34,7 +34,7 @@ on:
   schedule:
     - cron: "0 0,6,12,18 * * *"
 jobs:
-  dgraph-tests:
+  dgraph-oss-build:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-20.04
     steps:


### PR DESCRIPTION
## Problem

Previous commits broke OSS build.  Since we didn't have a test for this, it was undetected by CI.

## Solution

Add a CI job to verify that we can make the dgraph OSS build, and run all dgraph OSS unit tests.  We do this in a separate workflow because this does not require a separate self-hosted runner (we can use github hosted runners for this job).

See also: https://github.com/dgraph-io/dgraph/pull/8832