### PR TITLE
dgraphtest: small fixes to dgraphtest lib

### DIFF
--- a/dgraphtest/config.go
+++ b/dgraphtest/config.go
@@ -49,7 +49,7 @@ type ClusterConfig struct {
 }
 
 func NewClusterConfig() ClusterConfig {
-	prefix := fmt.Sprintf("test-%d", rand.NewSource(time.Now().Unix()).Int63()%10000)
+	prefix := fmt.Sprintf("test-%d", rand.NewSource(time.Now().Unix()).Int63()%1000000)
 	defaultBackupVol := fmt.Sprintf("%v_backup", prefix)
 	defaultExportVol := fmt.Sprintf("%v_export", prefix)
 	return ClusterConfig{

--- a/dgraphtest/local_cluster.go
+++ b/dgraphtest/local_cluster.go
@@ -202,6 +202,10 @@ func (c *LocalCluster) createContainer(dc dnode) (string, error) {
 }
 
 func (c *LocalCluster) Cleanup(verbose bool) {
+	if c == nil {
+		return
+	}
+
 	if verbose {
 		if err := c.printAllLogs(); err != nil {
 			log.Printf("[WARN] error printing container logs: %v", err)


### PR DESCRIPTION
1. check whether c is nil before cleanup. Sometimes, cleanup function can be called after cluster creation has failed. In that case, the pointer receiver c could be nil.
2. use a larger prefix for numbering containers. Sometimes in CI runs, I see something about a conflict and that the removal of volume has failed. By reducing the probability of collision of the container name prefix could eliminate the problem.