### PR TITLE
chore: waitForRestore should check for receiving snapshot

### DIFF
--- a/dgraphtest/cluster.go
+++ b/dgraphtest/cluster.go
@@ -324,7 +324,10 @@ loop2:
 		}
 
 		for _, alphaLogs := range alphasLogs {
-			if !strings.Contains(alphaLogs, "Operation completed with id: opRestore") {
+			// It is possible that the alpha didn't do a restore but streamed snapshot from any other alpha
+			if !strings.Contains(alphaLogs, "Operation completed with id: opRestore") &&
+				!strings.Contains(alphaLogs, "Operation completed with id: opSnapshot") {
+
 				continue loop2
 			}
 		}


### PR DESCRIPTION
when we do a restore, it is possible that one of the alphas do not do a restore but instead just stream the snapshot from one of the other alpahs. In the dgraphtest package, in the WaitForRestore function, we should wait for either restore to complete or snapshot to be streamed.