### PR TITLE
chore(ci): checkout merge commit on pull-request-target

### DIFF
--- a/.github/workflows/ci-dgraph-code-coverage.yml
+++ b/.github/workflows/ci-dgraph-code-coverage.yml
@@ -39,7 +39,9 @@ jobs:
     runs-on: [self-hosted, x64]
     # runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v3 # checkout merge commit
+        with:
+          ref: "refs/pull/${{ github.event.number }}/merge"
       - name: Get Go Version
         run: |
           #!/bin/bash


### PR DESCRIPTION
## Problem

We were checking out main instead of the merge commit in one workflow (code coverage).  This is because we use `pull_request_target`, which has different defaults.

## Solution

Specify the commit we should checkout.