### PR TITLE
chore: use `git` cmd tool for checkout a git hash

### DIFF
--- a/.github/workflows/ci-dgraph-upgrade-tests.yml
+++ b/.github/workflows/ci-dgraph-upgrade-tests.yml
@@ -14,7 +14,7 @@ on:
       - main
       - 'release/**'
   schedule:
-    - cron: "0 */2 * * *" # every 2hrs
+    - cron: "0 */4 * * *" # every 4hrs
 jobs:
   dgraph-upgrade-and-integration-tests:
     if: github.event.pull_request.draft == false
@@ -45,7 +45,7 @@ jobs:
           # move the binary
           cp dgraph/dgraph ~/go/bin/dgraph
           # run the tests
-          go test -v -timeout=60m -failfast -tags=upgrade,integration2 ./...
+          go test -v -timeout=120m -failfast -tags=upgrade,integration2 ./...
           # clean up docker containers after test execution
           go clean -testcache
           # sleep

--- a/dgraphtest/local_cluster.go
+++ b/dgraphtest/local_cluster.go
@@ -38,6 +38,7 @@ import (
 
 	"github.com/dgraph-io/dgo/v230"
 	"github.com/dgraph-io/dgo/v230/protos/api"
+	"github.com/dgraph-io/dgraph/x"
 )
 
 // cluster's network struct
@@ -485,7 +486,7 @@ func (c *LocalCluster) Upgrade(version string, strategy UpgradeStrategy) error {
 		if err != nil {
 			return err
 		}
-		if err := hc.LoginIntoNamespace(DefaultUser, DefaultPassword, 0); err != nil {
+		if err := hc.LoginIntoNamespace(DefaultUser, DefaultPassword, x.GalaxyNamespace); err != nil {
 			return errors.Wrapf(err, "error during login before upgrade")
 		}
 		if err := hc.Backup(c, true, DefaultBackupDir); err != nil {
@@ -514,7 +515,7 @@ func (c *LocalCluster) Upgrade(version string, strategy UpgradeStrategy) error {
 		if err != nil {
 			return errors.Wrapf(err, "error creating HTTP client after upgrade")
 		}
-		if err := hc.LoginIntoNamespace(DefaultUser, DefaultPassword, 0); err != nil {
+		if err := hc.LoginIntoNamespace(DefaultUser, DefaultPassword, x.GalaxyNamespace); err != nil {
 			return errors.Wrapf(err, "error during login after upgrade")
 		}
 		if err := hc.Restore(c, DefaultBackupDir, "", 0, 1, encPath); err != nil {

--- a/query/upgrade_test.go
+++ b/query/upgrade_test.go
@@ -63,7 +63,7 @@ func TestMain(m *testing.M) {
 
 		hc, err := c.HTTPClient()
 		x.Panic(err)
-		x.Panic(hc.LoginIntoNamespace(dgraphtest.DefaultUser, dgraphtest.DefaultPassword, 0))
+		x.Panic(hc.LoginIntoNamespace(dgraphtest.DefaultUser, dgraphtest.DefaultPassword, x.GalaxyNamespace))
 
 		mutate(c)
 		x.Panic(c.Upgrade(uc.After, uc.Strategy))


### PR DESCRIPTION
For some reason, when we use the worktree.Checkout, it seems to fail a lot in CI with errors
  test panicked: error while checking out git repo with hash [a77bbe8ae0d42697a38069a9749cfe71c2dafbe6]:
  open /home/ubuntu/actions-runner/_work/dgraph/repo/ee/updatemanifest: no such file or directory
Until we know why that is happening, I [Aman] have moved to use the git command line tool.

This PR also increases the timeout for the upgrade GitHub workflow to 2 hours and frequency of periodic runs to 4 hours.