### PR TITLE
chore(ci): fix test coverage workflow

### DIFF
--- a/.github/workflows/ci-dgraph-code-coverage.yml
+++ b/.github/workflows/ci-dgraph-code-coverage.yml
@@ -34,14 +34,76 @@ on:
   schedule:
     - cron: "0 0,6,12,18 * * *"
 jobs:
-  dgraph-code-coverage:
-    if: github.event.pull_request.draft == false
+  dgraph-code-coverage-pr:
+    if: github.event_name == 'pull_request_target' && github.event.pull_request.draft == false
     runs-on: [self-hosted, x64]
     # runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3 # checkout merge commit
         with:
           ref: "refs/pull/${{ github.event.number }}/merge"
+      - name: Get Go Version
+        run: |
+          #!/bin/bash
+          GOVERSION=$({ [ -f .go-version ] && cat .go-version; })
+          echo "GOVERSION=$GOVERSION" >> $GITHUB_ENV
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ env.GOVERSION }}
+      - name: Set up Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+      - name: Install protobuf-compiler
+        run: sudo apt-get install -y protobuf-compiler
+      - name: Check protobuf
+        run: |
+          cd ./protos
+          go mod tidy
+          make regenerate
+          git diff --exit-code -- .
+      - name: Make Linux Build and Docker Image with coverage enabled
+        run: make coverage-docker-image
+      - name: Build Test Binary
+        run: |
+          #!/bin/bash
+          # build the test binary
+          cd t; go build .
+      - name: Clean Up Environment
+        run: |
+          #!/bin/bash
+          # clean cache
+          go clean -testcache
+          # clean up docker containers before test execution
+          cd t; ./t -r
+      - name: Run Unit Tests
+        run: |
+          #!/bin/bash
+          # go env settings
+          export GOPATH=~/go
+          # move the binary
+          cp dgraph/dgraph ~/go/bin/dgraph
+          # run the tests
+          cd t; ./t --coverage=true --suite=unit,ldbc
+          # clean up docker containers after test execution
+          ./t -r
+          # sleep
+          sleep 5
+      - name: Install Goveralls
+        run: go install github.com/mattn/goveralls@latest
+      - name: Send Coverage Results
+        run: cd t && goveralls -repotoken ${{ secrets.COVERALLSIO_TOKEN }} -coverprofile=coverage.out
+
+  dgraph-code-coverage:
+    # i.e. on schedule, push to main / release branches
+    if: github.event_name != 'pull_request_target'
+    runs-on: [self-hosted, x64]
+    # runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: Get Go Version
         run: |
           #!/bin/bash

--- a/.github/workflows/ci-dgraph-code-coverage.yml
+++ b/.github/workflows/ci-dgraph-code-coverage.yml
@@ -101,9 +101,7 @@ jobs:
     runs-on: [self-hosted, x64]
     # runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
+      - uses: actions/checkout@v3 # defaults to SHA of event that triggered workflow
       - name: Get Go Version
         run: |
           #!/bin/bash


### PR DESCRIPTION
## Problem

On merges to main, coverage cannot be sent because workflow is attempting to checkout a merge commit, which is not applicable on a push to main (or a scheduled run).

## Solution

Add conditional logic to workflow.  Unfortunately AFAIK it is not possible to add the conditional logic to the specific step in the job, so we have to split this into two jobs, and select which one based on the type of event.  This creates some duplication but seems unavoidable.