### PR TITLE
test: print more logs if the upgrade tests fail

### DIFF
--- a/.github/workflows/ci-dgraph-upgrade-tests.yml
+++ b/.github/workflows/ci-dgraph-upgrade-tests.yml
@@ -21,6 +21,8 @@ jobs:
     runs-on: [self-hosted, x64]
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - name: Get Go Version
         run: |
           #!/bin/bash

--- a/dgraphtest/paths.go
+++ b/dgraphtest/paths.go
@@ -26,6 +26,7 @@ import (
 )
 
 var (
+	baseRepoDir   string // baseRepoDir points to the dgraph repo from where tests are running
 	repoDir       string // repoDir to store cloned repository of dgraph
 	binDir        string // binDir to store multiple binary versions
 	encKeyPath    string
@@ -44,13 +45,15 @@ func init() {
 	// setup paths
 	_, thisFilePath, _, _ := runtime.Caller(0)
 	basePath := strings.ReplaceAll(thisFilePath, "/paths.go", "")
-	binDir = filepath.Join(basePath, "binaries")
-	encKeyPath = filepath.Join(basePath, "data", "enc-key")
-	aclSecretPath = filepath.Join(basePath, "data", "hmac-secret")
+	baseRepoDir = strings.ReplaceAll(basePath, "/dgraphtest", "")
 
 	var err error
 	repoDir, err = os.MkdirTemp("", "dgraph-repo")
 	if err != nil {
 		panic(err)
 	}
+
+	binDir = filepath.Join(basePath, "binaries")
+	encKeyPath = filepath.Join(basePath, "data", "enc-key")
+	aclSecretPath = filepath.Join(basePath, "data", "hmac-secret")
 }

--- a/systest/multi-tenancy/upgrade_test.go
+++ b/systest/multi-tenancy/upgrade_test.go
@@ -41,7 +41,10 @@ func (msuite *MultitenancyTestSuite) SetupTest() {
 		WithACL(20 * time.Second).WithEncryption().WithVersion(msuite.uc.Before)
 	c, err := dgraphtest.NewLocalCluster(conf)
 	x.Panic(err)
-	x.Panic(c.Start())
+	if err := c.Start(); err != nil {
+		c.Cleanup(true)
+		panic(err)
+	}
 
 	msuite.dc = c
 	msuite.lc = c


### PR DESCRIPTION
Description: Sometimes tests fail and container logs are empty. Now, we also print the output of inspecting the docker containers. We additionally also use existing dgraph repo on disk to clone a copy instead of downloading the whole repo again from GitHub for building binaries.
Closes: DGRAPHCORE-285 DGRAPHCORE-280
