### PR TITLE
chore(zero): improve error message while unmarshalling WAL

### DIFF
--- a/dgraph/cmd/zero/raft.go
+++ b/dgraph/cmd/zero/raft.go
@@ -629,7 +629,7 @@ func (n *node) checkForCIDInEntries() (bool, error) {
 			}
 			var proposal pb.ZeroProposal
 			if err = proposal.Unmarshal(entry.Data[8:]); err != nil {
-				return false, err
+				return false, errors.Wrapf(err, "error unmarshlling wal entry: [%x]", entry.Data[8:])
 			}
 			if len(proposal.Cid) > 0 {
 				return true, err


### PR DESCRIPTION
Added stack trace to the error message 
This was the error message before change
```2023/05/09 20:31:21 proto: Tablet: illegal tag 0 (wire type 0)

github.com/dgraph-io/dgraph/x.Check
	/home/ash/go/src/github.com/dgraph-io/dgraph-release/x/error.go:42
github.com/dgraph-io/dgraph/dgraph/cmd/zero.run
	/home/ash/go/src/github.com/dgraph-io/dgraph-release/dgraph/cmd/zero/run.go:338
github.com/dgraph-io/dgraph/dgraph/cmd/zero.init.0.func1
	/home/ash/go/src/github.com/dgraph-io/dgraph-release/dgraph/cmd/zero/run.go:83
github.com/spf13/cobra.(*Command).execute
	/home/ash/go/pkg/mod/github.com/spf13/cobra@v0.0.5/command.go:830
github.com/spf13/cobra.(*Command).ExecuteC
	/home/ash/go/pkg/mod/github.com/spf13/cobra@v0.0.5/command.go:914
github.com/spf13/cobra.(*Command).Execute
	/home/ash/go/pkg/mod/github.com/spf13/cobra@v0.0.5/command.go:864
github.com/dgraph-io/dgraph/dgraph/cmd.Execute
	/home/ash/go/src/github.com/dgraph-io/dgraph-release/dgraph/cmd/root.go:78
main.main
	/home/ash/go/src/github.com/dgraph-io/dgraph-release/dgraph/main.go:99
runtime.main
	/usr/local/go/src/runtime/proc.go:225
runtime.goexit
	/usr/local/go/src/runtime/asm_amd64.s:1371
```

This is the error message after change

```
2023/06/23 11:37:32 proto: ZeroProposal: wiretype end group for non-group
error unmarshlling wal entry: [645646546234234364565565434545234343566456456463452422daee13212313123123131313131312316c686f73743a37303830200130cf94d1a40612380a18302d6467726170682e6772617068716c2e705f7175657279121c08011218302d6467726170682e6772617068716c2e705f717565727912300a14302d6467726170682e6772617068716c2e786964121808011214302d6467726170682e6772617068716c2e78696412360a17302d6467726170682e6772617068716c2e736368656d61121b08011217302d6467726170682e6772617068716c2e736368656d6112280a10302d6467726170682e64726f702e6f70121408011210302d6467726170682e64726f702e6f7012220a0d302d6467726170682e7479706512110801120d302d6467726170682e7479706512120a05302d616765120908011205302d616765121c0a0a302d66756c6c4e616d65120e0801120a302d66756c6c4e616d6512160a07302d656d61696c120b08011207302d656d61696c180b20b1bfa6fbf6e9d6f30c1a1f0801121b0901000000000000001a0e6c6f63616c686f73743a35303830200120904e28b0ea013001422466346266353138302d303964302d346136632d383537612d3731653030623138626536664a1310ffffffffffffffffff0118b098efa5062001]
github.com/dgraph-io/dgraph/dgraph/cmd/zero.(*node).checkForCIDInEntries
	/home/shiva/workspace/dgraph-work/integration-tests/dgraph/dgraph/cmd/zero/raft.go:632
github.com/dgraph-io/dgraph/dgraph/cmd/zero.(*node).initAndStartNode
	/home/shiva/workspace/dgraph-work/integration-tests/dgraph/dgraph/cmd/zero/raft.go:665
github.com/dgraph-io/dgraph/dgraph/cmd/zero.run
	/home/shiva/workspace/dgraph-work/integration-tests/dgraph/dgraph/cmd/zero/run.go:337
github.com/dgraph-io/dgraph/dgraph/cmd/zero.init.0.func1
	/home/shiva/workspace/dgraph-work/integration-tests/dgraph/dgraph/cmd/zero/run.go:82
github.com/spf13/cobra.(*Command).execute
	/home/shiva/go/pkg/mod/github.com/spf13/cobra@v0.0.5/command.go:830
github.com/spf13/cobra.(*Command).ExecuteC
	/home/shiva/go/pkg/mod/github.com/spf13/cobra@v0.0.5/command.go:914
github.com/spf13/cobra.(*Command).Execute
	/home/shiva/go/pkg/mod/github.com/spf13/cobra@v0.0.5/command.go:864
github.com/dgraph-io/dgraph/dgraph/cmd.Execute
	/home/shiva/workspace/dgraph-work/integration-tests/dgraph/dgraph/cmd/root.go:77
main.main
	/home/shiva/workspace/dgraph-work/integration-tests/dgraph/dgraph/main.go:98
runtime.main
	/home/shiva/go/src/runtime/proc.go:250
runtime.goexit
	/home/shiva/go/src/runtime/asm_amd64.s:1594

github.com/dgraph-io/dgraph/x.Check
	/home/shiva/workspace/dgraph-work/integration-tests/dgraph/x/error.go:42
github.com/dgraph-io/dgraph/dgraph/cmd/zero.run
	/home/shiva/workspace/dgraph-work/integration-tests/dgraph/dgraph/cmd/zero/run.go:337
github.com/dgraph-io/dgraph/dgraph/cmd/zero.init.0.func1
	/home/shiva/workspace/dgraph-work/integration-tests/dgraph/dgraph/cmd/zero/run.go:82
github.com/spf13/cobra.(*Command).execute
	/home/shiva/go/pkg/mod/github.com/spf13/cobra@v0.0.5/command.go:830
github.com/spf13/cobra.(*Command).ExecuteC
	/home/shiva/go/pkg/mod/github.com/spf13/cobra@v0.0.5/command.go:914
github.com/spf13/cobra.(*Command).Execute
	/home/shiva/go/pkg/mod/github.com/spf13/cobra@v0.0.5/command.go:864
github.com/dgraph-io/dgraph/dgraph/cmd.Execute
	/home/shiva/workspace/dgraph-work/integration-tests/dgraph/dgraph/cmd/root.go:77
main.main
	/home/shiva/workspace/dgraph-work/integration-tests/dgraph/dgraph/main.go:98
runtime.main
	/home/shiva/go/src/runtime/proc.go:250
runtime.goexit
	/home/shiva/go/src/runtime/asm_amd64.s:1594
```