### PR TITLE
test(upgrade): add upgrade tests for systest/plugin

### DIFF
--- a/dgraphtest/config.go
+++ b/dgraphtest/config.go
@@ -228,7 +228,7 @@ func (cc ClusterConfig) WithNormalizeCompatibilityMode(mode string) ClusterConfi
 	return cc
 }
 
-// WithCustomPlugins enables generation of custom plugins in testutil/custom_plugins
+// Enables generation of the custom_plugins in testutil/custom_plugins
 func (cc ClusterConfig) WithCustomPlugins() ClusterConfig {
 	cc.customPlugins = true
 	return cc

--- a/dgraphtest/config.go
+++ b/dgraphtest/config.go
@@ -116,6 +116,7 @@ type ClusterConfig struct {
 	portOffset     int // exposed port offset for grpc/http port for both alpha/zero
 	bulkOutDir     string
 	featureFlags   []string
+	customPlugins  bool
 }
 
 // NewClusterConfig generates a default ClusterConfig
@@ -134,6 +135,7 @@ func NewClusterConfig() ClusterConfig {
 		refillInterval: 20 * time.Second,
 		uidLease:       50,
 		portOffset:     -1,
+		customPlugins:  false,
 	}
 }
 
@@ -223,5 +225,11 @@ func (cc ClusterConfig) WithBulkLoadOutDir(dir string) ClusterConfig {
 // WithNormalizeCompatibilityMode sets the normalize-compatibility-mode feature flag for alpha
 func (cc ClusterConfig) WithNormalizeCompatibilityMode(mode string) ClusterConfig {
 	cc.featureFlags = append(cc.featureFlags, fmt.Sprintf("normalize-compatibility-mode=%v", mode))
+	return cc
+}
+
+// WithCustomPlugins enables generation of custom plugins in testutil/custom_plugins
+func (cc ClusterConfig) WithCustomPlugins() ClusterConfig {
+	cc.customPlugins = true
 	return cc
 }

--- a/dgraphtest/dgraph.go
+++ b/dgraphtest/dgraph.go
@@ -60,6 +60,7 @@ const (
 	DefaultUser     = "groot"
 	DefaultPassword = "password"
 
+	goBinMountPath     = "/gobin"
 	localVersion       = "local"
 	waitDurBeforeRetry = time.Second
 	requestTimeout     = 120 * time.Second
@@ -278,6 +279,10 @@ func (a *alpha) cmd(c *LocalCluster) []string {
 		acmd = append(acmd, fmt.Sprintf("--feature-flags=%v", strings.Join(c.conf.featureFlags, ";")))
 	}
 
+	if c.conf.customPlugins {
+		acmd = append(acmd, fmt.Sprintf("--custom_tokenizers=%s", c.customTokenizers))
+	}
+
 	return acmd
 }
 
@@ -385,7 +390,7 @@ func mountBinary(c *LocalCluster) (mount.Mount, error) {
 	return mount.Mount{
 		Type:     mount.TypeBind,
 		Source:   c.tempBinDir,
-		Target:   "/gobin",
+		Target:   goBinMountPath,
 		ReadOnly: true,
 	}, nil
 }

--- a/dgraphtest/image.go
+++ b/dgraphtest/image.go
@@ -25,7 +25,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/dgraph-io/dgraph/testutil"
 	"github.com/pkg/errors"
 )
 
@@ -34,6 +33,12 @@ func (c *LocalCluster) dgraphImage() string {
 }
 
 func (c *LocalCluster) setupBinary() error {
+	if c.conf.customPlugins {
+		race := false // Explicit var declaration to avoid confusion on the next line
+		if err := c.GeneratePlugins(race); err != nil {
+			return err
+		}
+	}
 	if c.conf.version == localVersion {
 		fromDir := filepath.Join(os.Getenv("GOPATH"), "bin")
 		return copyBinary(fromDir, c.tempBinDir, c.conf.version)
@@ -52,10 +57,6 @@ func (c *LocalCluster) setupBinary() error {
 	}
 	if err := buildDgraphBinary(repoDir, binariesPath, c.conf.version); err != nil {
 		return err
-	}
-	if c.conf.customPlugins {
-		race := false // Explicit var declaration to avoid confusion on the next line
-		testutil.GeneratePlugins(race)
 	}
 	return copyBinary(binariesPath, c.tempBinDir, c.conf.version)
 }

--- a/dgraphtest/image.go
+++ b/dgraphtest/image.go
@@ -53,11 +53,10 @@ func (c *LocalCluster) setupBinary() error {
 	if err := buildDgraphBinary(repoDir, binariesPath, c.conf.version); err != nil {
 		return err
 	}
-
-	// explicit var declaration to avoid confusion on the next line
-	race := false
-	testutil.GeneratePlugins(race)
-
+	if c.conf.customPlugins {
+		race := false // Explicit var declaration to avoid confusion on the next line
+		testutil.GeneratePlugins(race)
+	}
 	return copyBinary(binariesPath, c.tempBinDir, c.conf.version)
 }
 

--- a/dgraphtest/image.go
+++ b/dgraphtest/image.go
@@ -25,6 +25,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/dgraph-io/dgraph/testutil"
 	"github.com/pkg/errors"
 )
 
@@ -52,6 +53,11 @@ func (c *LocalCluster) setupBinary() error {
 	if err := buildDgraphBinary(repoDir, binariesPath, c.conf.version); err != nil {
 		return err
 	}
+
+	// explicit var declaration to avoid confusion on the next line
+	race := false
+	testutil.GeneratePlugins(race)
+
 	return copyBinary(binariesPath, c.tempBinDir, c.conf.version)
 }
 

--- a/systest/plugin/integration_test.go
+++ b/systest/plugin/integration_test.go
@@ -33,6 +33,7 @@ import (
 type PluginTestSuite struct {
 	suite.Suite
 	dc dgraphtest.Cluster
+	pfiEntry PluginFuncInp
 }
 
 func (psuite *PluginTestSuite) SetupTest() {
@@ -54,8 +55,9 @@ func (psuite *PluginTestSuite) Upgrade() {
 }
 
 func TestPluginTestSuite(t *testing.T) {
+	var psuite PluginTestSuite
 	for _, e := range pfiArray {
-		psuite.pfiEntry := e
+		psuite.pfiEntry = e
 		suite.Run(t, new(PluginTestSuite))
 	}
 }

--- a/systest/plugin/integration_test.go
+++ b/systest/plugin/integration_test.go
@@ -31,8 +31,8 @@ import (
 
 type PluginTestSuite struct {
 	suite.Suite
-	dc dgraphtest.Cluster
-	pfiEntry PluginFuncInp
+	dc         dgraphtest.Cluster
+	dataSetNdx int
 }
 
 func (psuite *PluginTestSuite) SetupTest() {
@@ -54,9 +54,5 @@ func (psuite *PluginTestSuite) Upgrade() {
 }
 
 func TestPluginTestSuite(t *testing.T) {
-	var psuite PluginTestSuite
-	for _, e := range pfiArray {
-		psuite.pfiEntry = e
-		suite.Run(t, &psuite)
-	}
+	suite.Run(t, new(PluginTestSuite))
 }

--- a/systest/plugin/integration_test.go
+++ b/systest/plugin/integration_test.go
@@ -19,20 +19,17 @@
 package main
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/dgraph-io/dgraph/dgraphtest"
-	"github.com/dgraph-io/dgraph/x"
 )
 
 type PluginTestSuite struct {
 	suite.Suite
-	dc         dgraphtest.Cluster
-	dataSetNdx int
+	dc  dgraphtest.Cluster
 }
 
 func (psuite *PluginTestSuite) SetupTest() {
@@ -44,8 +41,6 @@ func (psuite *PluginTestSuite) TearDownTest() {
 	gcli, cleanup, err := psuite.dc.Client()
 	require.NoError(t, err)
 	defer cleanup()
-	require.NoError(t, gcli.LoginIntoNamespace(context.Background(),
-		dgraphtest.DefaultUser, dgraphtest.DefaultPassword, x.GalaxyNamespace))
 	require.NoError(t, gcli.DropAll())
 }
 

--- a/systest/plugin/integration_test.go
+++ b/systest/plugin/integration_test.go
@@ -1,0 +1,61 @@
+//go:build integration
+
+/*
+ * Copyright 2023 Dgraph Labs, Inc. and Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/dgraph-io/dgo/v230/protos/api"
+	"github.com/dgraph-io/dgraph/dgraphtest"
+	"github.com/dgraph-io/dgraph/x"
+)
+
+type PluginTestSuite struct {
+	suite.Suite
+	dc dgraphtest.Cluster
+}
+
+func (psuite *PluginTestSuite) SetupTest() {
+	psuite.dc = dgraphtest.NewComposeCluster()
+}
+
+func (psuite *PluginTestSuite) TearDownTest() {
+	t := psuite.T()
+	gcli, cleanup, err := psuite.dc.Client()
+	defer cleanup()
+	require.NoError(t, err)
+	require.NoError(t, gcli.LoginIntoNamespace(context.Background(),
+		dgraphtest.DefaultUser, dgraphtest.DefaultPassword, x.GalaxyNamespace))
+	require.NoError(t, gcli.Alter(context.Background(), &api.Operation{DropAll: true}))
+}
+
+func (psuite *PluginTestSuite) Upgrade() {
+	// Not implemented for integration tests
+}
+
+func TestPluginTestSuite(t *testing.T) {
+	for _, e := range pfiArray {
+		psuite.pfiEntry := e
+		suite.Run(t, new(PluginTestSuite))
+	}
+}

--- a/systest/plugin/integration_test.go
+++ b/systest/plugin/integration_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
-	"github.com/dgraph-io/dgo/v230/protos/api"
 	"github.com/dgraph-io/dgraph/dgraphtest"
 	"github.com/dgraph-io/dgraph/x"
 )
@@ -43,11 +42,11 @@ func (psuite *PluginTestSuite) SetupTest() {
 func (psuite *PluginTestSuite) TearDownTest() {
 	t := psuite.T()
 	gcli, cleanup, err := psuite.dc.Client()
-	defer cleanup()
 	require.NoError(t, err)
+	defer cleanup()
 	require.NoError(t, gcli.LoginIntoNamespace(context.Background(),
 		dgraphtest.DefaultUser, dgraphtest.DefaultPassword, x.GalaxyNamespace))
-	require.NoError(t, gcli.Alter(context.Background(), &api.Operation{DropAll: true}))
+	require.NoError(t, gcli.DropAll())
 }
 
 func (psuite *PluginTestSuite) Upgrade() {
@@ -58,6 +57,6 @@ func TestPluginTestSuite(t *testing.T) {
 	var psuite PluginTestSuite
 	for _, e := range pfiArray {
 		psuite.pfiEntry = e
-		suite.Run(t, new(PluginTestSuite))
+		suite.Run(t, &psuite)
 	}
 }

--- a/systest/plugin/plugin_test.go
+++ b/systest/plugin/plugin_test.go
@@ -349,10 +349,6 @@ func (psuite *PluginTestSuite) TestPlugins() {
 		}
 	}
 
-	initialSchema string
-	setJSON       string
-	cases         []testCase
-
 	arg := psuite.pfiEntry
 	pluginFn(arg.initialSchema, arg.setJSON, arg.cases)
 }

--- a/systest/plugin/plugin_test.go
+++ b/systest/plugin/plugin_test.go
@@ -1,4 +1,4 @@
-//go:build (!oss && integration) || upgrade
+//go:build integration || upgrade
 
 /*
  * Copyright 2017-2023 Dgraph Labs, Inc. and Contributors
@@ -30,11 +30,12 @@ import (
 	"github.com/dgraph-io/dgraph/x"
 )
 
-
+/*
 type testCase struct {
 	query      string
 	wantResult string
 }
+*/
 
 type PluginFuncInp struct {
 	initialSchema string
@@ -322,13 +323,11 @@ func (psuite *PluginTestSuite) TestPlugins() {
 		defer cancel()
 
 		gcli, cleanup, err := psuite.dc.Client()
-		defer cleanup()
 		require.NoError(t, err)
+		defer cleanup()
 		require.NoError(t, gcli.LoginIntoNamespace(context.Background(),
 			dgraphtest.DefaultUser, dgraphtest.DefaultPassword, x.GalaxyNamespace))
-		require.NoError(t, gcli.Alter(ctx, &api.Operation{
-			DropAll: true,
-		}))
+		require.NoError(t, gcli.DropAll())
 		require.NoError(t, gcli.Alter(ctx, &api.Operation{
 			Schema: initialSchema,
 		}))

--- a/systest/plugin/upgrade_test.go
+++ b/systest/plugin/upgrade_test.go
@@ -62,7 +62,7 @@ func (psuite *PluginTestSuite) Upgrade() {
 }
 
 func TestPluginTestSuite(t *testing.T) {
-	for _, uc := range dgraphtest.AllUpgradeCombos() {
+	for _, uc := range dgraphtest.AllUpgradeCombos(false) {
 		log.Printf("running: backup in [%v], restore in [%v]", uc.Before, uc.After)
 		var psuite PluginTestSuite
 		psuite.uc = uc

--- a/systest/plugin/upgrade_test.go
+++ b/systest/plugin/upgrade_test.go
@@ -76,7 +76,7 @@ func TestPluginTestSuite(t *testing.T) {
 		var psuite PluginTestSuite
 		psuite.uc = uc
 		for _, e := range pfiArray {
-			psuite.pfiEntry := e
+			psuite.pfiEntry = e
 			suite.Run(t, &psuite)
 		}
 	}

--- a/systest/plugin/upgrade_test.go
+++ b/systest/plugin/upgrade_test.go
@@ -1,0 +1,83 @@
+//go:build upgrade
+
+/*
+ * Copyright 2023 Dgraph Labs, Inc. and Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"log"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/dgraph-io/dgraph/dgraphtest"
+	"github.com/dgraph-io/dgraph/x"
+)
+
+type PluginTestSuite struct {
+	suite.Suite
+	dc dgraphtest.Cluster
+	lc *dgraphtest.LocalCluster
+	uc dgraphtest.UpgradeCombo
+	pfiEntry PluginFuncInp
+}
+
+func (psuite *PluginTestSuite) SetupTest() {
+	conf := dgraphtest.NewClusterConfig().WithNumAlphas(1).WithNumZeros(1).WithReplicas(1).
+		WithACL(20 * time.Second).WithEncryption().WithVersion(psuite.uc.Before)
+	c, err := dgraphtest.NewLocalCluster(conf)
+	x.Panic(err)
+	if err := c.Start(); err != nil {
+		c.Cleanup(true)
+		panic(err)
+	}
+
+	psuite.dc = c
+	psuite.lc = c
+}
+
+func (psuite *PluginTestSuite) TearDownTest() {
+	psuite.lc.Cleanup(psuite.T().Failed())
+}
+
+func (psuite *PluginTestSuite) Upgrade() {
+	t := psuite.T()
+
+	if err := psuite.lc.Upgrade(psuite.uc.After, psuite.uc.Strategy); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// For testing purpose
+var comboEntry = []dgraphtest.UpgradeCombo{
+			{"v21.03.0", "v23.0.0", dgraphtest.BackupRestore},
+}
+
+func TestPluginTestSuite(t *testing.T) {
+	//for _, uc := range dgraphtest.AllUpgradeCombos {
+	//}
+	for _, uc := range comboEntry {
+		log.Printf("running: backup in [%v], restore in [%v]", uc.Before, uc.After)
+		var psuite PluginTestSuite
+		psuite.uc = uc
+		for _, e := range pfiArray {
+			psuite.pfiEntry := e
+			suite.Run(t, &psuite)
+		}
+	}
+}

--- a/systest/plugin/upgrade_test.go
+++ b/systest/plugin/upgrade_test.go
@@ -19,6 +19,7 @@
 package main
 
 import (
+	"errors"
 	"log"
 	"testing"
 
@@ -39,8 +40,6 @@ type PluginTestSuite struct {
 func (psuite *PluginTestSuite) SetupSubTest() {
 	// The TestPlugins() invokes subtest function, hence using
 	// SetupSubTest() instead of SetupTest().
-	psuite.lc.Cleanup(psuite.T().Failed())
-
 	conf := dgraphtest.NewClusterConfig().WithNumAlphas(1).WithNumZeros(1).WithReplicas(1).
 		WithVersion(psuite.uc.Before).WithCustomPlugins()
 	c, err := dgraphtest.NewLocalCluster(conf)
@@ -69,7 +68,7 @@ func TestPluginTestSuite(t *testing.T) {
 		psuite.uc = uc
 		suite.Run(t, &psuite)
 		if t.Failed() {
-			t.Fatal("TestPluginTestSuite tests failed")
+			x.Panic(errors.New("TestPluginTestSuite tests failed"))
 		}
 	}
 }

--- a/systest/plugin/upgrade_test.go
+++ b/systest/plugin/upgrade_test.go
@@ -63,15 +63,8 @@ func (psuite *PluginTestSuite) Upgrade() {
 	}
 }
 
-// For testing purpose
-var comboEntry = []dgraphtest.UpgradeCombo{
-			{"v21.03.0", "v23.0.0", dgraphtest.BackupRestore},
-}
-
 func TestPluginTestSuite(t *testing.T) {
-	//for _, uc := range dgraphtest.AllUpgradeCombos {
-	//}
-	for _, uc := range comboEntry {
+	for _, uc := range dgraphtest.AllUpgradeCombos {
 		log.Printf("running: backup in [%v], restore in [%v]", uc.Before, uc.After)
 		var psuite PluginTestSuite
 		psuite.uc = uc

--- a/systest/plugin/upgrade_test.go
+++ b/systest/plugin/upgrade_test.go
@@ -21,8 +21,8 @@ package main
 import (
 	"log"
 	"testing"
-	"time"
 
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/dgraph-io/dgraph/dgraphtest"
@@ -31,21 +31,18 @@ import (
 
 type PluginTestSuite struct {
 	suite.Suite
-	dc         dgraphtest.Cluster
-	lc         *dgraphtest.LocalCluster
-	uc         dgraphtest.UpgradeCombo
-	dataSetNdx int
-}
-
-func (psuite *PluginTestSuite) SetupTest() {
+	dc  dgraphtest.Cluster
+	lc  *dgraphtest.LocalCluster
+	uc  dgraphtest.UpgradeCombo
 }
 
 func (psuite *PluginTestSuite) SetupSubTest() {
+	// The TestPlugins() invokes subtest function, hence using
+	// SetupSubTest() instead of SetupTest().
 	psuite.lc.Cleanup(psuite.T().Failed())
 
 	conf := dgraphtest.NewClusterConfig().WithNumAlphas(1).WithNumZeros(1).WithReplicas(1).
-		WithACL(20 * time.Second).WithEncryption().WithVersion(psuite.uc.Before).
-		WithCustomPlugins()
+		WithVersion(psuite.uc.Before).WithCustomPlugins()
 	c, err := dgraphtest.NewLocalCluster(conf)
 	x.Panic(err)
 	if err := c.Start(); err != nil {
@@ -62,11 +59,7 @@ func (psuite *PluginTestSuite) TearDownTest() {
 }
 
 func (psuite *PluginTestSuite) Upgrade() {
-	t := psuite.T()
-
-	if err := psuite.lc.Upgrade(psuite.uc.After, psuite.uc.Strategy); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(psuite.T(), psuite.lc.Upgrade(psuite.uc.After, psuite.uc.Strategy))
 }
 
 func TestPluginTestSuite(t *testing.T) {


### PR DESCRIPTION
This is an existing 'integration' test, now transformed to run for 'integration' and 'upgrade' using dgraphtest framework. Additionally, leveraging 'testify/suite' package's SetupTest() / SetupSubTest() / TeardownTest() / TeardownSubTest() functionality during the test runs. 'integration' tests are still run using t.go and the dgraphtest framework acts as a no-op for now. Going forward, there are plans to have dgraphtest framework take over the t.go. 'upgrade' used in the tests is Dgraph version upgrade from a source version to a target version using 'BackupRestore' and 'InPlace'.

**Plugin insights:** Hope this link will help here https://dgraph.io/docs/query-language/indexing-custom-tokenizers/#implementing-a-plugin

Closes: https://dgraph.atlassian.net/browse/DGRAPHCORE-304