### PR TITLE
fix(bulk): enable running bulk loader with only gql schema

### DIFF
--- a/dgraph/cmd/bulk/loader.go
+++ b/dgraph/cmd/bulk/loader.go
@@ -42,6 +42,7 @@ import (
 	"github.com/dgraph-io/dgraph/chunker"
 	"github.com/dgraph-io/dgraph/ee/enc"
 	"github.com/dgraph-io/dgraph/filestore"
+	gqlSchema "github.com/dgraph-io/dgraph/graphql/schema"
 	"github.com/dgraph-io/dgraph/protos/pb"
 	"github.com/dgraph-io/dgraph/schema"
 	"github.com/dgraph-io/dgraph/x"
@@ -186,7 +187,7 @@ func (ld *loader) leaseNamespaces() {
 		ns, err := client.AssignIds(ctx, &pb.Num{Val: maxNs, Type: pb.Num_NS_ID})
 		cancel()
 		if err == nil {
-			fmt.Printf("Assigned namespaces till %d", ns.GetEndId())
+			fmt.Printf("Assigned namespaces till %d\n", ns.GetEndId())
 			return
 		}
 		fmt.Printf("Error communicating with dgraph zero, retrying: %v", err)
@@ -195,6 +196,10 @@ func (ld *loader) leaseNamespaces() {
 }
 
 func readSchema(opt *options) *schema.ParsedSchema {
+	if opt.SchemaFile == "" {
+		return genDQLSchema(opt)
+	}
+
 	f, err := filestore.Open(opt.SchemaFile)
 	x.Check(err)
 	defer func() {
@@ -220,6 +225,32 @@ func readSchema(opt *options) *schema.ParsedSchema {
 	result, err := schema.ParseWithNamespace(string(buf), opt.Namespace)
 	x.Check(err)
 	return result
+}
+
+func genDQLSchema(opt *options) *schema.ParsedSchema {
+	gqlSchBytes := readGqlSchema(opt)
+	nsToSchemas := parseGqlSchema(string(gqlSchBytes))
+
+	var finalSch schema.ParsedSchema
+	for ns, gqlSch := range nsToSchemas {
+		if opt.Namespace != math.MaxUint64 {
+			ns = opt.Namespace
+		}
+
+		h, err := gqlSchema.NewHandler(gqlSch, false)
+		x.Check(err)
+
+		_, err = gqlSchema.FromString(h.GQLSchema(), ns)
+		x.Check(err)
+
+		ps, err := schema.ParseWithNamespace(h.DGSchema(), ns)
+		x.Check(err)
+
+		finalSch.Preds = append(finalSch.Preds, ps.Preds...)
+		finalSch.Types = append(finalSch.Types, ps.Types...)
+	}
+
+	return &finalSch
 }
 
 func (ld *loader) mapStage() {
@@ -332,12 +363,8 @@ func parseGqlSchema(s string) map[uint64]string {
 	return schemaMap
 }
 
-func (ld *loader) processGqlSchema(loadType chunker.InputFormat) {
-	if ld.opt.GqlSchemaFile == "" {
-		return
-	}
-
-	f, err := filestore.Open(ld.opt.GqlSchemaFile)
+func readGqlSchema(opt *options) []byte {
+	f, err := filestore.Open(opt.GqlSchemaFile)
 	x.Check(err)
 	defer func() {
 		if err := f.Close(); err != nil {
@@ -345,19 +372,26 @@ func (ld *loader) processGqlSchema(loadType chunker.InputFormat) {
 		}
 	}()
 
-	key := ld.opt.EncryptionKey
-	if !ld.opt.Encrypted {
+	key := opt.EncryptionKey
+	if !opt.Encrypted {
 		key = nil
 	}
 	r, err := enc.GetReader(key, f)
 	x.Check(err)
-	if filepath.Ext(ld.opt.GqlSchemaFile) == ".gz" {
+	if filepath.Ext(opt.GqlSchemaFile) == ".gz" {
 		r, err = gzip.NewReader(r)
 		x.Check(err)
 	}
 
 	buf, err := io.ReadAll(r)
 	x.Check(err)
+	return buf
+}
+
+func (ld *loader) processGqlSchema(loadType chunker.InputFormat) {
+	if ld.opt.GqlSchemaFile == "" {
+		return
+	}
 
 	rdfSchema := `_:gqlschema <dgraph.type> "dgraph.graphql" <%#x> .
 	_:gqlschema <dgraph.graphql.xid> "dgraph.graphql.schema" <%#x> .
@@ -388,6 +422,7 @@ func (ld *loader) processGqlSchema(loadType chunker.InputFormat) {
 		ld.readerChunkCh <- gqlBuf
 	}
 
+	buf := readGqlSchema(ld.opt)
 	schemas := parseGqlSchema(string(buf))
 	if ld.opt.Namespace == math.MaxUint64 {
 		// Preserve the namespace.

--- a/dgraph/cmd/bulk/run.go
+++ b/dgraph/cmd/bulk/run.go
@@ -215,12 +215,16 @@ func run() {
 	fmt.Printf("Encrypted input: %v; Encrypted output: %v\n", opt.Encrypted, opt.EncryptedOut)
 
 	if opt.SchemaFile == "" {
-		fmt.Fprint(os.Stderr, "Schema file must be specified.\n")
-		os.Exit(1)
-	}
-	if !filestore.Exists(opt.SchemaFile) {
-		fmt.Fprintf(os.Stderr, "Schema path(%v) does not exist.\n", opt.SchemaFile)
-		os.Exit(1)
+		// if only graphql schema is provided, we can generate DQL schema from it.
+		if opt.GqlSchemaFile == "" {
+			fmt.Fprint(os.Stderr, "Schema file must be specified.\n")
+			os.Exit(1)
+		}
+	} else {
+		if !filestore.Exists(opt.SchemaFile) {
+			fmt.Fprintf(os.Stderr, "Schema path(%v) does not exist.\n", opt.SchemaFile)
+			os.Exit(1)
+		}
 	}
 	if opt.DataFiles == "" {
 		fmt.Fprint(os.Stderr, "RDF or JSON file(s) location must be specified.\n")

--- a/dgraphtest/cluster.go
+++ b/dgraphtest/cluster.go
@@ -238,7 +238,7 @@ func (hc *HTTPClient) RunGraphqlQuery(params GraphQLParams, admin bool) ([]byte,
 
 	respBody, err := hc.doPost(reqBody, admin)
 	if err != nil {
-		return nil, errors.Wrap(err, "error while running admin query")
+		return nil, errors.Wrap(err, "error while running graphql query")
 	}
 
 	var gqlResp GraphQLResponse
@@ -246,7 +246,7 @@ func (hc *HTTPClient) RunGraphqlQuery(params GraphQLParams, admin bool) ([]byte,
 		return nil, errors.Wrap(err, "error unmarshalling GQL response")
 	}
 	if len(gqlResp.Errors) > 0 {
-		return nil, errors.Wrapf(gqlResp.Errors, "error while running admin query, resp: %v", string(gqlResp.Data))
+		return nil, errors.Wrapf(gqlResp.Errors, "error while running graphql query, resp: %v", string(gqlResp.Data))
 	}
 	return gqlResp.Data, nil
 }

--- a/dgraphtest/config.go
+++ b/dgraphtest/config.go
@@ -84,6 +84,7 @@ type ClusterConfig struct {
 	uidLease       int
 	// exposed port offset for grpc/http port for both alpha/zero
 	portOffset int
+	bulkOutDir string
 }
 
 func NewClusterConfig() ClusterConfig {
@@ -161,5 +162,12 @@ func (cc ClusterConfig) WithUidLease(uidLease int) ClusterConfig {
 // to fixed ports (port (5080, 6080, 8080 and 9080) + offset + id (0, 1, 2 ...)) on the host.
 func (cc ClusterConfig) WithExposedPortOffset(offset uint64) ClusterConfig {
 	cc.portOffset = int(offset)
+	return cc
+}
+
+// WithBulkLoadOutDir sets the out dir for the bulk loader. This ensures
+// that the same p directory is used while setting up alphas.
+func (cc ClusterConfig) WithBulkLoadOutDir(dir string) ClusterConfig {
+	cc.bulkOutDir = dir
 	return cc
 }

--- a/dgraphtest/local_cluster.go
+++ b/dgraphtest/local_cluster.go
@@ -262,7 +262,7 @@ func (c *LocalCluster) Start() error {
 			return err
 		}
 	}
-	return c.HealthCheck()
+	return c.HealthCheck(false)
 }
 
 func (c *LocalCluster) StartZero(id int) error {
@@ -343,7 +343,7 @@ func (c *LocalCluster) killContainer(dc dnode) error {
 	return nil
 }
 
-func (c *LocalCluster) HealthCheck() error {
+func (c *LocalCluster) HealthCheck(zeroOnly bool) error {
 	log.Printf("[INFO] checking health of containers")
 	for i := 0; i < c.conf.numZeros; i++ {
 		url, err := c.zeros[i].healthURL(c)
@@ -355,6 +355,10 @@ func (c *LocalCluster) HealthCheck() error {
 		}
 		log.Printf("[INFO] container [zero-%v] passed health check", i)
 	}
+	if zeroOnly {
+		return nil
+	}
+
 	for i := 0; i < c.conf.numAlphas; i++ {
 		url, err := c.alphas[i].healthURL(c)
 		if err != nil {

--- a/systest/integration2/bulk_loader_test.go
+++ b/systest/integration2/bulk_loader_test.go
@@ -1,0 +1,138 @@
+//go:build integration2
+
+/*
+ * Copyright 2023 Dgraph Labs, Inc. and Contributors *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/dgraph-io/dgraph/dgraphtest"
+	"github.com/dgraph-io/dgraph/x"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	gqlSchema = `[
+		{
+		  "namespace": 0,
+		  "schema": "type Message {id: ID!\ncontent: String!\nauthor: String\nuniqueId: Int64! @id\n}"
+		},
+		{
+		  "namespace": 1,
+		  "schema": "type Template {id: ID!\ncontent: String!\nuniqueId: Int64! @id\n}"
+		}
+	  ]`
+	jsonData = `
+	[
+		{"Message.content": "XBNTBGBHGQ", "Message.author": "PXYNHBWGGD",
+			"Message.uniqueId": 7, "dgraph.type": "Message", "namespace": 0},
+		{"Message.content": "ILEOMLXRYX", "Message.author": "BBBZKURCJH",
+			"Message.uniqueId": 5, "dgraph.type": "Message", "namespace": 0},
+		{"Message.content": "RFAXPWUCUN", "Message.author": "CMZEOCORNL",
+			"Message.uniqueId": 0, "dgraph.type": "Message", "namespace": 0},
+		{"Message.content": "ZKCRMYNBLT", "Message.author": "TYLORHNKJA",
+			"Message.uniqueId": 9, "dgraph.type": "Message", "namespace": 0},
+		{"Message.content": "HMODLPKCHE", "Message.author": "ZNTIZEYBMV",
+			"Message.uniqueId": 4, "dgraph.type": "Message", "namespace": 0},
+		{"Message.content": "FBIOEOJBZF", "Message.author": "EQXLNWFYBN",
+			"Message.uniqueId": 6, "dgraph.type": "Message", "namespace": 0},
+		{"Message.content": "DVTCTXCVYI", "Message.author": "USYMVFJYXA",
+			"Message.uniqueId": 3, "dgraph.type": "Message", "namespace": 0},
+		{"Message.content": "SOWTAXHTCT", "Message.author": "SAILDEMEJV",
+			"Message.uniqueId": 8, "dgraph.type": "Message", "namespace": 0},
+		{"Message.content": "MLMQWMJQQW", "Message.author": "ANBSOCYLXB",
+			"Message.uniqueId": 1, "dgraph.type": "Message", "namespace": 0},
+		{"Message.content": "CVFSBBIDCL", "Message.author": "JONAEYCCTQ",
+			"Message.uniqueId": 2, "dgraph.type": "Message", "namespace": 0},
+		{"Template.content": "t1", "Template.uniqueId": 1, "dgraph.type": "Template", "namespace": 1},
+		{"Template.content": "t2", "Template.uniqueId": 2, "dgraph.type": "Template", "namespace": 1},
+		{"Template.content": "t3", "Template.uniqueId": 3, "dgraph.type": "Template", "namespace": 1},
+		{"dgraph.xid": "groot", "dgraph.password": "password", "dgraph.type": "dgraph.type.User",
+			"dgraph.user.group": {"dgraph.xid": "guardians", "dgraph.type": "dgraph.type.Group",
+			"namespace": 1}, "namespace": 1}
+	]`
+)
+
+func TestBulkLoaderNoDqlSchema(t *testing.T) {
+	conf := dgraphtest.NewClusterConfig().WithNumAlphas(2).WithNumZeros(1).
+		WithACL(time.Hour).WithReplicas(1).WithBulkLoadOutDir(t.TempDir())
+	c, err := dgraphtest.NewLocalCluster(conf)
+	require.NoError(t, err)
+	defer func() { c.Cleanup(t.Failed()) }()
+
+	// start zero
+	require.NoError(t, c.StartZero(0))
+	require.NoError(t, c.HealthCheck(true))
+
+	baseDir := t.TempDir()
+	gqlSchemaFile := filepath.Join(baseDir, "gql.schema")
+	require.NoError(t, ioutil.WriteFile(gqlSchemaFile, []byte(gqlSchema), os.ModePerm))
+	dataFile := filepath.Join(baseDir, "data.json")
+	require.NoError(t, ioutil.WriteFile(dataFile, []byte(jsonData), os.ModePerm))
+
+	opts := dgraphtest.BulkOpts{
+		DataFiles:      []string{dataFile},
+		GQLSchemaFiles: []string{gqlSchemaFile},
+	}
+	require.NoError(t, c.BulkLoad(opts))
+
+	// start Alphas
+	require.NoError(t, c.Start())
+
+	// run some queries and ensure everything looks good
+	hc, err := c.HTTPClient()
+	require.NoError(t, err)
+	require.NoError(t, hc.LoginIntoNamespace(dgraphtest.DefaultUser,
+		dgraphtest.DefaultPassword, x.GalaxyNamespace))
+
+	params := dgraphtest.GraphQLParams{
+		Query: `query {
+			getMessage(uniqueId: 3) {
+				content
+				author
+			}
+		}`,
+	}
+	data, err := hc.RunGraphqlQuery(params, false)
+	require.NoError(t, err)
+	dgraphtest.CompareJSON(`{
+		"getMessage": {
+		  "content": "DVTCTXCVYI",
+		  "author": "USYMVFJYXA"
+		}
+	  }`, string(data))
+
+	require.NoError(t, hc.LoginIntoNamespace(dgraphtest.DefaultUser, dgraphtest.DefaultPassword, 1))
+	params = dgraphtest.GraphQLParams{
+		Query: `query {
+			getTemplate(uniqueId: 2) {
+				content
+			}
+		}`,
+	}
+	data, err = hc.RunGraphqlQuery(params, false)
+	require.NoError(t, err)
+	dgraphtest.CompareJSON(`{
+		"getTemplate": {
+		  "content": "t2"
+		}
+	  }`, string(data))
+}

--- a/systest/integration2/incremental_restore_test.go
+++ b/systest/integration2/incremental_restore_test.go
@@ -36,14 +36,14 @@ func TestIncrementalRestore(t *testing.T) {
 	conf := dgraphtest.NewClusterConfig().WithNumAlphas(6).WithNumZeros(3).WithReplicas(3).WithACL(time.Hour)
 	c, err := dgraphtest.NewLocalCluster(conf)
 	require.NoError(t, err)
-	defer c.Cleanup(t.Failed())
+	defer func() { c.Cleanup(t.Failed()) }()
 	require.NoError(t, c.Start())
 
 	gc, cleanup, err := c.Client()
 	require.NoError(t, err)
 	defer cleanup()
 	require.NoError(t, gc.LoginIntoNamespace(context.Background(),
-		dgraphtest.DefaultUser, dgraphtest.DefaultPassword, 0))
+		dgraphtest.DefaultUser, dgraphtest.DefaultPassword, x.GalaxyNamespace))
 
 	hc, err := c.HTTPClient()
 	require.NoError(t, err)


### PR DESCRIPTION
If only gql schema is provided, and DQL schema is missing bulk loader used to fail. This PR adds the ability to auto generate the DQL schema from the gql schema and use it in the bulk loader.

This PR also adds support for running bulk loader in the dgraphtest package. Additionally, this PR also changes the dgraphtest package to always copy the dgraph binary into a temp folder even when the version of the dgraph used is set to "local".

Closes: DGRAPHCORE-324
Docs PR: NA