### PR TITLE
ci(upgrade): break down upgrade tests CI workflow

### DIFF
--- a/.github/workflows/ci-dgraph-integration2-tests.yml
+++ b/.github/workflows/ci-dgraph-integration2-tests.yml
@@ -1,4 +1,4 @@
-name: ci-dgraph-upgrade-tests
+name: ci-dgraph-integration2-tests
 on:
   push:
     branches:
@@ -16,9 +16,9 @@ on:
   schedule:
     - cron: "0 */4 * * *" # every 4hrs
 jobs:
-  dgraph-upgrade-tests:
+  dgraph-integration2-tests:
     if: github.event.pull_request.draft == false
-    runs-on: [self-hosted, x64]
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
         with:
@@ -39,16 +39,15 @@ jobs:
           #!/bin/bash
           # clean cache
           go clean -testcache
-      - name: Run Upgrade and Integration Tests
+      - name: Run Integration2 Tests
         run: |
           #!/bin/bash
           # go env settings
           export GOPATH=~/go
-          export DGRAPH_UPGRADE_MAIN_ONLY=true
           # move the binary
           cp dgraph/dgraph ~/go/bin/dgraph
           # run the tests
-          go test -v -timeout=120m -failfast -tags=upgrade ./...
+          go test -v -timeout=30m -failfast -tags=integration2 ./...
           # clean up docker containers after test execution
           go clean -testcache
           # sleep

--- a/.github/workflows/ci-dgraph-upgrade-fixed-versions-tests.yml
+++ b/.github/workflows/ci-dgraph-upgrade-fixed-versions-tests.yml
@@ -1,23 +1,9 @@
-name: ci-dgraph-upgrade-tests
+name: ci-dgraph-upgrade-fixed-versions-tests
 on:
-  push:
-    branches:
-      - main
-      - 'release/**'
-  pull_request:
-    types:
-      - opened
-      - reopened
-      - synchronize
-      - ready_for_review
-    branches:
-      - main
-      - 'release/**'
   schedule:
-    - cron: "0 */4 * * *" # every 4hrs
+    - cron: "0 */12 * * *" # every 12hrs
 jobs:
-  dgraph-upgrade-tests:
-    if: github.event.pull_request.draft == false
+  dgraph-upgrade-fixed-versions-tests:
     runs-on: [self-hosted, x64]
     steps:
       - uses: actions/checkout@v3
@@ -44,11 +30,10 @@ jobs:
           #!/bin/bash
           # go env settings
           export GOPATH=~/go
-          export DGRAPH_UPGRADE_MAIN_ONLY=true
           # move the binary
           cp dgraph/dgraph ~/go/bin/dgraph
           # run the tests
-          go test -v -timeout=120m -failfast -tags=upgrade ./...
+          go test -v -timeout=4h -failfast -tags=upgrade ./...
           # clean up docker containers after test execution
           go clean -testcache
           # sleep

--- a/dgraphtest/config.go
+++ b/dgraphtest/config.go
@@ -19,6 +19,7 @@ package dgraphtest
 import (
 	"fmt"
 	"math/rand"
+	"os"
 	"time"
 )
 
@@ -28,45 +29,53 @@ type UpgradeCombo struct {
 	Strategy UpgradeStrategy
 }
 
-var AllUpgradeCombos = []UpgradeCombo{
-	// OPEN SOURCE RELEASES
-	// a77bbe8ae0d42697a38069a9749cfe71c2dafbe6
-	{"v21.03.0", "v23.0.0", BackupRestore},
-	// 0c9f60156b34a675d76695a912e07b45590644ff
-	{"v21.03.0-92-g0c9f60156", "v23.0.0", BackupRestore},
-	// 19f71a78a93112f57fea3e5e33f070b60b39b652
-	{"v21.03.0-98-g19f71a78a-slash", "v23.0.0", BackupRestore},
-	// 4a03c144afc10438016f9a73d90b6d0f78ef2e16
-	{"v21.03.0-99-g4a03c144a-slash", "v23.0.0", BackupRestore},
-	// ea1cb5f35650c54419483d6129460b4b25cbb418
-	{"v21.03.1", "v23.0.0", BackupRestore},
-	// b17395d33801bf36235de378d8560f61f4457d2b
-	{"v21.03.2", "v23.0.0", BackupRestore},
-	// c36206a5c7062efef797f62bd797625a2d0d2a27
-	{"v22.0.0", "v23.0.0", BackupRestore},
-	// 7fb5291a984af45d4639d370c290939152c79612
-	{"v22.0.1", "v23.0.0", BackupRestore},
-	// 7b18a6bec95731201d94142ec86a4fde035fb7e0
-	{"v22.0.2", "v23.0.0", BackupRestore},
-	//  CLOUD VERSIONS
-	// v21.03.0-48-ge3d3e6290
-	{"e3d3e6290", "v23.0.0", BackupRestore},
-	// v21.03.0-63-g8b9e92314
-	{"8b9e92314", "v23.0.0", BackupRestore},
-	// v21.03.0-66-gdfa5daec1
-	{"dfa5daec1", "v23.0.0", BackupRestore},
-	// v21.03.0-69-g88e4aa07c
-	{"88e4aa07c", "v23.0.0", BackupRestore},
-	// v21.03.0-73-gd9df244fb
-	{"d9df244fb", "v23.0.0", BackupRestore},
-	// v21.03.0-76-ged09b8cc1
-	{"ed09b8cc1", "v23.0.0", BackupRestore},
-	// v21.03.0-78-ge4ad0b113
-	{"e4ad0b113", "v23.0.0", BackupRestore},
-	// v21.03.0-82-g83c9cbedc
-	{"83c9cbedc", "v23.0.0", BackupRestore},
-	// v21.03.0-84-gc5862ae2a
-	{"c5862ae2a", "v23.0.0", BackupRestore},
+func AllUpgradeCombos() []UpgradeCombo {
+	fixedVersionCombos := []UpgradeCombo{
+		// OPEN SOURCE RELEASES
+		{"v21.03.0", "v23.0.0", BackupRestore},
+		{"v21.03.0-92-g0c9f60156", "v23.0.0", BackupRestore},
+		{"v21.03.0-98-g19f71a78a-slash", "v23.0.0", BackupRestore},
+		{"v21.03.0-99-g4a03c144a-slash", "v23.0.0", BackupRestore},
+		{"v21.03.1", "v23.0.0", BackupRestore},
+		{"v21.03.2", "v23.0.0", BackupRestore},
+		{"v22.0.0", "v23.0.0", BackupRestore},
+		{"v22.0.1", "v23.0.0", BackupRestore},
+		{"v22.0.2", "v23.0.0", BackupRestore},
+
+		//  CLOUD VERSIONS
+		{"e3d3e6290", "v23.0.0", BackupRestore}, // v21.03.0-48-ge3d3e6290
+		{"8b9e92314", "v23.0.0", BackupRestore}, // v21.03.0-63-g8b9e92314
+		{"dfa5daec1", "v23.0.0", BackupRestore}, // v21.03.0-66-gdfa5daec1
+		{"88e4aa07c", "v23.0.0", BackupRestore}, // v21.03.0-69-g88e4aa07c
+		{"d9df244fb", "v23.0.0", BackupRestore}, // v21.03.0-73-gd9df244fb
+		{"ed09b8cc1", "v23.0.0", BackupRestore}, // v21.03.0-76-ged09b8cc1
+		{"e4ad0b113", "v23.0.0", BackupRestore}, // v21.03.0-78-ge4ad0b113
+		{"83c9cbedc", "v23.0.0", BackupRestore}, // v21.03.0-82-g83c9cbedc
+		{"c5862ae2a", "v23.0.0", BackupRestore}, // v21.03.0-84-gc5862ae2a
+
+		// In place upgrade for cloud versions
+		{"e3d3e6290", "v23.0.0", InPlace}, // v21.03.0-48-ge3d3e6290
+		{"8b9e92314", "v23.0.0", InPlace}, // v21.03.0-63-g8b9e92314
+		{"dfa5daec1", "v23.0.0", InPlace}, // v21.03.0-66-gdfa5daec1
+		{"88e4aa07c", "v23.0.0", InPlace}, // v21.03.0-69-g88e4aa07c
+		{"d9df244fb", "v23.0.0", InPlace}, // v21.03.0-73-gd9df244fb
+		{"ed09b8cc1", "v23.0.0", InPlace}, // v21.03.0-76-ged09b8cc1
+		{"e4ad0b113", "v23.0.0", InPlace}, // v21.03.0-78-ge4ad0b113
+		{"83c9cbedc", "v23.0.0", InPlace}, // v21.03.0-82-g83c9cbedc
+		{"c5862ae2a", "v23.0.0", InPlace}, // v21.03.0-84-gc5862ae2a
+		{"0c9f60156", "v23.0.0", InPlace}, // v21.03.0-92-g0c9f60156
+	}
+
+	mainCombos := []UpgradeCombo{
+		{"v23.0.0", "local", BackupRestore},
+		{"v23.0.0", "local", InPlace},
+	}
+
+	if os.Getenv("DGRAPH_UPGRADE_MAIN_ONLY") == "true" {
+		return mainCombos
+	} else {
+		return fixedVersionCombos
+	}
 }
 
 type ClusterConfig struct {

--- a/dgraphtest/local_cluster.go
+++ b/dgraphtest/local_cluster.go
@@ -65,14 +65,14 @@ type UpgradeStrategy int
 const (
 	BackupRestore UpgradeStrategy = iota
 	ExportImport
-	StopStart
+	InPlace
 )
 
 func (u UpgradeStrategy) String() string {
 	switch u {
 	case BackupRestore:
 		return "backup-restore"
-	case StopStart:
+	case InPlace:
 		return "stop-start"
 	case ExportImport:
 		return "export-import"
@@ -573,7 +573,7 @@ func (c *LocalCluster) Upgrade(version string, strategy UpgradeStrategy) error {
 		}
 		return nil
 
-	case StopStart:
+	case InPlace:
 		if err := c.Stop(); err != nil {
 			return err
 		}

--- a/ee/acl/upgrade_test.go
+++ b/ee/acl/upgrade_test.go
@@ -55,7 +55,7 @@ func (asuite *AclTestSuite) Upgrade() {
 }
 
 func TestACLSuite(t *testing.T) {
-	for _, uc := range dgraphtest.AllUpgradeCombos {
+	for _, uc := range dgraphtest.AllUpgradeCombos() {
 		log.Printf("running upgrade tests for confg: %+v", uc)
 		aclSuite := AclTestSuite{uc: uc}
 		suite.Run(t, &aclSuite)

--- a/query/upgrade_test.go
+++ b/query/upgrade_test.go
@@ -75,7 +75,7 @@ func TestMain(m *testing.M) {
 		}
 	}
 
-	for _, uc := range dgraphtest.AllUpgradeCombos {
+	for _, uc := range dgraphtest.AllUpgradeCombos() {
 		log.Printf("running upgrade tests for confg: %+v", uc)
 		runTest(uc)
 	}

--- a/systest/multi-tenancy/upgrade_test.go
+++ b/systest/multi-tenancy/upgrade_test.go
@@ -64,7 +64,7 @@ func (msuite *MultitenancyTestSuite) Upgrade() {
 }
 
 func TestMultitenancySuite(t *testing.T) {
-	for _, uc := range dgraphtest.AllUpgradeCombos {
+	for _, uc := range dgraphtest.AllUpgradeCombos() {
 		log.Printf("running upgrade tests for confg: %+v", uc)
 		var msuite MultitenancyTestSuite
 		msuite.uc = uc


### PR DESCRIPTION
This PR breaks down the earlier upgrade CI workflow into 3 different workflows:
 1. upgrade tests from last release to main
 2. upgrade tests from older releases to last release
 3. integration2 tests workflow

We have added an env variable DGRAPH_UPGRADE_MAIN_ONLY so that we can identify what tests to run. This PR also updates the upgrade tests config to run tests with InPlace upgrade strategy as well.

Closes: DGRAPHCORE-273
Docs: NA
