### PR TITLE
doc(restore): add docs for mutations in between incremental restores

### DIFF
--- a/dgraphtest/local_cluster.go
+++ b/dgraphtest/local_cluster.go
@@ -73,7 +73,7 @@ func (u UpgradeStrategy) String() string {
 	case BackupRestore:
 		return "backup-restore"
 	case InPlace:
-		return "stop-start"
+		return "in-place"
 	case ExportImport:
 		return "export-import"
 	default:

--- a/systest/integration2/incremental_restore_test.go
+++ b/systest/integration2/incremental_restore_test.go
@@ -87,5 +87,12 @@ func TestIncrementalRestore(t *testing.T) {
 			sort.Ints(data.Q[0].Money)
 			require.Equal(t, uids[j-1:i], data.Q[0].Money)
 		}
+
+		// Even when we do an in between mutations, it makes no difference.
+		// Incremental restore overwrites any data written in between.
+		if i == 10 {
+			_, err := gc.Mutate(&api.Mutation{SetNquads: []byte(`<10> <money> "4" .`), CommitNow: true})
+			require.NoError(t, err)
+		}
 	}
 }

--- a/worker/online_restore.go
+++ b/worker/online_restore.go
@@ -371,6 +371,10 @@ func handleRestoreProposal(ctx context.Context, req *pb.RestoreRequest, pidx uin
 		if err := pstore.DropPrefix(dropAttrs...); err != nil {
 			return errors.Wrap(err, "failed to reduce incremental restore map")
 		}
+		// If there are any writes done after last incremental restore on badger DB,
+		// the restore or incremental restore will lose that data. This happens because
+		// the timestamp of the in between mutations etc will be lower than the timestamp
+		// of this incremental restore that we may be doing now (if it is one).
 		if err := sw.PrepareIncremental(); err != nil {
 			return errors.Wrapf(err, "while preparing DB")
 		}


### PR DESCRIPTION
If we do mutations in between incremental restores, those will get lost. The next incremental restore will overwrite any data that is written in between two incremental restores. It is not very useful to try to block the next incremental restore after in between mutations because it is really hard to detect that a change was made.

For example, let's say we detect the mutations done in between two incremental restores by looking at the data in memtable. But then, if we restart Dgraph, or drop any other attribute (predicate), that may end up doing compaction and would persist all the data from memtable to sstables. This would make it impossible to figure out that a change was made.

It wouldn't be very useful to store this information (that a mutation was done) in an in memory flag either. It would get destroyed if the alpha restarts. Any other methodology seems too complex to me. I think I'd rather keep the semantics of the incremental restore to say that it will overwrite any in between mutations that are done if any.

Closes: DGRAPHCORE-276
Docs: WIP