### PR TITLE
fix(sec): upgrade certifi to 2022.12.07

### DIFF
--- a/contrib/config/marketplace/aws/tests/requirements.txt
+++ b/contrib/config/marketplace/aws/tests/requirements.txt
@@ -4,7 +4,7 @@ awscli==1.18.40
 backports.shutil-get-terminal-size==1.0.0
 boto3==1.12.40
 botocore==1.15.40
-certifi==2022.12.7
+certifi==2022.12.07
 cfn-lint==0.29.5
 chardet==3.0.4
 colorama==0.4.3

--- a/contrib/embargo/requirements.txt
+++ b/contrib/embargo/requirements.txt
@@ -1,5 +1,5 @@
 args==0.1.0
-certifi==2022.12.7
+certifi==2022.12.07
 chardet==3.0.4
 click==7.1.2
 clint==0.5.1


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in certifi 2022.12.7
- [CVE-2022-23491](https://www.oscs1024.com/hd/CVE-2022-23491)


### What did I do？
Upgrade certifi from 2022.12.7 to 2022.12.07 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How can we automate the detection of these types of issues?
By using the [GitHub Actions](https://github.com/murphysecurity/actions) configurations provided by murphysec, we can conduct automatic code security checks in our CI pipeline.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS