### PR TITLE
chore(upgrade): run upgrade tests for v23.0.1

### DIFF
--- a/dgraphtest/cluster.go
+++ b/dgraphtest/cluster.go
@@ -649,10 +649,6 @@ func IsHigherVersion(higher, lower string) (bool, error) {
 		return true, nil
 	}
 
-	if err := ensureDgraphClone(); err != nil {
-		return false, err
-	}
-
 	// An older commit is usually the ancestor of a newer commit which is a descendant commit
 	cmd := exec.Command("git", "merge-base", "--is-ancestor", lower, higher)
 	cmd.Dir = repoDir

--- a/dgraphtest/config.go
+++ b/dgraphtest/config.go
@@ -32,43 +32,43 @@ type UpgradeCombo struct {
 func AllUpgradeCombos() []UpgradeCombo {
 	fixedVersionCombos := []UpgradeCombo{
 		// OPEN SOURCE RELEASES
-		{"v21.03.0", "v23.0.0", BackupRestore},
-		{"v21.03.0-92-g0c9f60156", "v23.0.0", BackupRestore},
-		{"v21.03.0-98-g19f71a78a-slash", "v23.0.0", BackupRestore},
-		{"v21.03.0-99-g4a03c144a-slash", "v23.0.0", BackupRestore},
-		{"v21.03.1", "v23.0.0", BackupRestore},
-		{"v21.03.2", "v23.0.0", BackupRestore},
-		{"v22.0.0", "v23.0.0", BackupRestore},
-		{"v22.0.1", "v23.0.0", BackupRestore},
-		{"v22.0.2", "v23.0.0", BackupRestore},
+		{"v21.03.0", "v23.0.1", BackupRestore},
+		{"v21.03.0-92-g0c9f60156", "v23.0.1", BackupRestore},
+		{"v21.03.0-98-g19f71a78a-slash", "v23.0.1", BackupRestore},
+		{"v21.03.0-99-g4a03c144a-slash", "v23.0.1", BackupRestore},
+		{"v21.03.1", "v23.0.1", BackupRestore},
+		{"v21.03.2", "v23.0.1", BackupRestore},
+		{"v22.0.0", "v23.0.1", BackupRestore},
+		{"v22.0.1", "v23.0.1", BackupRestore},
+		{"v22.0.2", "v23.0.1", BackupRestore},
 
 		//  CLOUD VERSIONS
-		{"e3d3e6290", "v23.0.0", BackupRestore}, // v21.03.0-48-ge3d3e6290
-		{"8b9e92314", "v23.0.0", BackupRestore}, // v21.03.0-63-g8b9e92314
-		{"dfa5daec1", "v23.0.0", BackupRestore}, // v21.03.0-66-gdfa5daec1
-		{"88e4aa07c", "v23.0.0", BackupRestore}, // v21.03.0-69-g88e4aa07c
-		{"d9df244fb", "v23.0.0", BackupRestore}, // v21.03.0-73-gd9df244fb
-		{"ed09b8cc1", "v23.0.0", BackupRestore}, // v21.03.0-76-ged09b8cc1
-		{"e4ad0b113", "v23.0.0", BackupRestore}, // v21.03.0-78-ge4ad0b113
-		{"83c9cbedc", "v23.0.0", BackupRestore}, // v21.03.0-82-g83c9cbedc
-		{"c5862ae2a", "v23.0.0", BackupRestore}, // v21.03.0-84-gc5862ae2a
+		{"e3d3e6290", "v23.0.1", BackupRestore}, // v21.03.0-48-ge3d3e6290
+		{"8b9e92314", "v23.0.1", BackupRestore}, // v21.03.0-63-g8b9e92314
+		{"dfa5daec1", "v23.0.1", BackupRestore}, // v21.03.0-66-gdfa5daec1
+		{"88e4aa07c", "v23.0.1", BackupRestore}, // v21.03.0-69-g88e4aa07c
+		{"d9df244fb", "v23.0.1", BackupRestore}, // v21.03.0-73-gd9df244fb
+		{"ed09b8cc1", "v23.0.1", BackupRestore}, // v21.03.0-76-ged09b8cc1
+		{"e4ad0b113", "v23.0.1", BackupRestore}, // v21.03.0-78-ge4ad0b113
+		{"83c9cbedc", "v23.0.1", BackupRestore}, // v21.03.0-82-g83c9cbedc
+		{"c5862ae2a", "v23.0.1", BackupRestore}, // v21.03.0-84-gc5862ae2a
 
 		// In place upgrade for cloud versions
-		{"e3d3e6290", "v23.0.0", InPlace}, // v21.03.0-48-ge3d3e6290
-		{"8b9e92314", "v23.0.0", InPlace}, // v21.03.0-63-g8b9e92314
-		{"dfa5daec1", "v23.0.0", InPlace}, // v21.03.0-66-gdfa5daec1
-		{"88e4aa07c", "v23.0.0", InPlace}, // v21.03.0-69-g88e4aa07c
-		{"d9df244fb", "v23.0.0", InPlace}, // v21.03.0-73-gd9df244fb
-		{"ed09b8cc1", "v23.0.0", InPlace}, // v21.03.0-76-ged09b8cc1
-		{"e4ad0b113", "v23.0.0", InPlace}, // v21.03.0-78-ge4ad0b113
-		{"83c9cbedc", "v23.0.0", InPlace}, // v21.03.0-82-g83c9cbedc
-		{"c5862ae2a", "v23.0.0", InPlace}, // v21.03.0-84-gc5862ae2a
-		{"0c9f60156", "v23.0.0", InPlace}, // v21.03.0-92-g0c9f60156
+		{"e3d3e6290", "v23.0.1", InPlace}, // v21.03.0-48-ge3d3e6290
+		{"8b9e92314", "v23.0.1", InPlace}, // v21.03.0-63-g8b9e92314
+		{"dfa5daec1", "v23.0.1", InPlace}, // v21.03.0-66-gdfa5daec1
+		{"88e4aa07c", "v23.0.1", InPlace}, // v21.03.0-69-g88e4aa07c
+		{"d9df244fb", "v23.0.1", InPlace}, // v21.03.0-73-gd9df244fb
+		{"ed09b8cc1", "v23.0.1", InPlace}, // v21.03.0-76-ged09b8cc1
+		{"e4ad0b113", "v23.0.1", InPlace}, // v21.03.0-78-ge4ad0b113
+		{"83c9cbedc", "v23.0.1", InPlace}, // v21.03.0-82-g83c9cbedc
+		{"c5862ae2a", "v23.0.1", InPlace}, // v21.03.0-84-gc5862ae2a
+		{"0c9f60156", "v23.0.1", InPlace}, // v21.03.0-92-g0c9f60156
 	}
 
 	mainCombos := []UpgradeCombo{
-		{"v23.0.0", "local", BackupRestore},
-		{"v23.0.0", "local", InPlace},
+		{"v23.0.1", "local", BackupRestore},
+		{"v23.0.1", "local", InPlace},
 	}
 
 	if os.Getenv("DGRAPH_UPGRADE_MAIN_ONLY") == "true" {

--- a/dgraphtest/image.go
+++ b/dgraphtest/image.go
@@ -45,9 +45,6 @@ func (c *LocalCluster) setupBinary() error {
 		return copyBinary(binDir, c.tempBinDir, c.conf.version)
 	}
 
-	if err := ensureDgraphClone(); err != nil {
-		return err
-	}
 	if err := runGitCheckout(c.conf.version); err != nil {
 		return err
 	}
@@ -132,6 +129,16 @@ func runGitCheckout(gitRef string) error {
 		return errors.Wrapf(err, "error checking out gitRef [%v]\noutput:%v", gitRef, string(out))
 	}
 	return nil
+}
+
+func getHash(ref string) (string, error) {
+	cmd := exec.Command("git", "rev-parse", ref)
+	cmd.Dir = repoDir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", errors.Wrapf(err, "error while running rev-parse on [%v]\noutput:%v", ref, string(out))
+	} else {
+		return string(out), nil
+	}
 }
 
 func buildDgraphBinary(dir, binaryDir, version string) error {

--- a/dgraphtest/local_cluster.go
+++ b/dgraphtest/local_cluster.go
@@ -781,7 +781,17 @@ func (c *LocalCluster) checkDgraphVersion(containerID string) error {
 	if err != nil {
 		return errors.Wrapf(err, "error during checkDgraphVersion for container [%v]", containerID)
 	}
-	if !strings.Contains(contLogs, fmt.Sprintf("Dgraph version   : %v", c.GetVersion())) {
+	index := strings.Index(contLogs, "Dgraph version   : ")
+	running := strings.Fields(contLogs[index : index+70])[3] // 70 is arbitrary
+	chash, err := getHash(c.GetVersion())
+	if err != nil {
+		return errors.Wrapf(err, "error while getting hash for %v", c.GetVersion())
+	}
+	rhash, err := getHash(running)
+	if err != nil {
+		return errors.Wrapf(err, "error while getting hash for %v", c.GetVersion())
+	}
+	if chash != rhash {
 		return errors.Errorf("found different dgraph version than expected [%v]", c.GetVersion())
 	}
 	return nil

--- a/dgraphtest/paths.go
+++ b/dgraphtest/paths.go
@@ -52,6 +52,9 @@ func init() {
 	if err != nil {
 		panic(err)
 	}
+	if err := ensureDgraphClone(); err != nil {
+		panic(err)
+	}
 
 	binDir = filepath.Join(basePath, "binaries")
 	encKeyPath = filepath.Join(basePath, "data", "enc-key")


### PR DESCRIPTION
This PR also fixes a bug in the code that compares the running Dgraph version vs the expected version. It is possible that the version is specified in e.g. long git hash format whereas we use the short git hash format of Dgraph version in the logs.