### PR TITLE
fix(upgrade): check commit SHA to find running dgraph version

### DIFF
--- a/dgraphtest/config.go
+++ b/dgraphtest/config.go
@@ -67,8 +67,8 @@ func AllUpgradeCombos() []UpgradeCombo {
 	}
 
 	mainCombos := []UpgradeCombo{
-		{"v23.0.1", "local", BackupRestore},
-		{"v23.0.1", "local", InPlace},
+		{"v23.0.1", localVersion, BackupRestore},
+		{"v23.0.1", localVersion, InPlace},
 	}
 
 	if os.Getenv("DGRAPH_UPGRADE_MAIN_ONLY") == "true" {

--- a/dgraphtest/local_cluster.go
+++ b/dgraphtest/local_cluster.go
@@ -781,7 +781,7 @@ func (c *LocalCluster) checkDgraphVersion(containerID string) error {
 	if err != nil {
 		return errors.Wrapf(err, "error during checkDgraphVersion for container [%v]", containerID)
 	}
-	index := strings.Index(contLogs, "Dgraph version   : ")
+	index := strings.Index(contLogs, "Commit SHA-1     : ")
 	running := strings.Fields(contLogs[index : index+70])[3] // 70 is arbitrary
 	chash, err := getHash(c.GetVersion())
 	if err != nil {
@@ -789,7 +789,7 @@ func (c *LocalCluster) checkDgraphVersion(containerID string) error {
 	}
 	rhash, err := getHash(running)
 	if err != nil {
-		return errors.Wrapf(err, "error while getting hash for %v", c.GetVersion())
+		return errors.Wrapf(err, "error while getting hash for %v", running)
 	}
 	if chash != rhash {
 		return errors.Errorf("found different dgraph version than expected [%v]", c.GetVersion())


### PR DESCRIPTION
for certain binaries such as v22.0.0, dgraph version that gets printed is "local". We now instead use the commit sha to find the right running version of Dgraph for ensuring that we are running the version that we expect to run.