### PR TITLE
fix(upgrade): look for version string in logs bottom up

### DIFF
--- a/dgraphtest/image.go
+++ b/dgraphtest/image.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 
 	"github.com/pkg/errors"
 )
@@ -137,7 +138,7 @@ func getHash(ref string) (string, error) {
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return "", errors.Wrapf(err, "error while running rev-parse on [%v]\noutput:%v", ref, string(out))
 	} else {
-		return string(out), nil
+		return strings.TrimSpace(string(out)), nil
 	}
 }
 

--- a/dgraphtest/local_cluster.go
+++ b/dgraphtest/local_cluster.go
@@ -781,6 +781,9 @@ func (c *LocalCluster) checkDgraphVersion(containerID string) error {
 	if err != nil {
 		return errors.Wrapf(err, "error during checkDgraphVersion for container [%v]", containerID)
 	}
+
+	// During in-place upgrade, container remains same but logs have version string twice - once for old version, once for new.
+	// Want new version string. Look bottom-up using LastIndex to get latest version's string.
 	index := strings.LastIndex(contLogs, "Commit SHA-1     : ")
 	running := strings.Fields(contLogs[index : index+70])[3] // 70 is arbitrary
 	chash, err := getHash(c.GetVersion())

--- a/dgraphtest/local_cluster.go
+++ b/dgraphtest/local_cluster.go
@@ -781,7 +781,7 @@ func (c *LocalCluster) checkDgraphVersion(containerID string) error {
 	if err != nil {
 		return errors.Wrapf(err, "error during checkDgraphVersion for container [%v]", containerID)
 	}
-	index := strings.Index(contLogs, "Commit SHA-1     : ")
+	index := strings.LastIndex(contLogs, "Commit SHA-1     : ")
 	running := strings.Fields(contLogs[index : index+70])[3] // 70 is arbitrary
 	chash, err := getHash(c.GetVersion())
 	if err != nil {
@@ -792,7 +792,7 @@ func (c *LocalCluster) checkDgraphVersion(containerID string) error {
 		return errors.Wrapf(err, "error while getting hash for %v", running)
 	}
 	if chash != rhash {
-		return errors.Errorf("found different dgraph version than expected [%v]", c.GetVersion())
+		return errors.Errorf("found different dgraph version [%v] than expected [%v]", rhash, chash)
 	}
 	return nil
 }

--- a/dgraphtest/local_cluster.go
+++ b/dgraphtest/local_cluster.go
@@ -782,8 +782,9 @@ func (c *LocalCluster) checkDgraphVersion(containerID string) error {
 		return errors.Wrapf(err, "error during checkDgraphVersion for container [%v]", containerID)
 	}
 
-	// During in-place upgrade, container remains same but logs have version string twice - once for old version, once for new.
-	// Want new version string. Look bottom-up using LastIndex to get latest version's string.
+	// During in-place upgrade, container remains same but logs have version string twice
+	// once for old version, once for new. Want new version string. Look bottom-up using
+	// LastIndex to get latest version's string.
 	index := strings.LastIndex(contLogs, "Commit SHA-1     : ")
 	running := strings.Fields(contLogs[index : index+70])[3] // 70 is arbitrary
 	chash, err := getHash(c.GetVersion())


### PR DESCRIPTION
For in place upgrade, the container remains the same and the logs have the version string twice, one for the old container and one for the new container. We want the version string in the logs for the new container. Hence, we look for the string in the logs bottom up by using strings.LastIndex instead of strings.Index.