### PR TITLE
sec(acl): convert x.Sensitive to string type for authn hash

### DIFF
--- a/edgraph/server.go
+++ b/edgraph/server.go
@@ -1587,7 +1587,7 @@ func authorizeRequest(ctx context.Context, qc *queryContext) error {
 
 func getHash(ns, startTs uint64) string {
 	h := sha256.New()
-	h.Write([]byte(fmt.Sprintf("%#x%#x%s", ns, startTs, x.WorkerConfig.HmacSecret)))
+	h.Write([]byte(fmt.Sprintf("%#x%#x%s", ns, startTs, string(x.WorkerConfig.HmacSecret))))
 	return hex.EncodeToString(h.Sum(nil))
 }
 

--- a/edgraph/server_test.go
+++ b/edgraph/server_test.go
@@ -18,6 +18,8 @@ package edgraph
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -204,4 +206,13 @@ func TestParseSchemaFromAlterOperation(t *testing.T) {
 		})
 	}
 
+}
+
+func TestGetHash(t *testing.T) {
+	h := sha256.New()
+	_, err := h.Write([]byte("0xa0x14123456789"))
+	require.NoError(t, err)
+
+	x.WorkerConfig.HmacSecret = []byte("123456789")
+	require.Equal(t, hex.EncodeToString(h.Sum(nil)), getHash(10, 20))
 }


### PR DESCRIPTION
we use a combination of namespace, start timestamp and ACL hmac secret key to make the transaction context more robust. Unfortunately, because the ACL secret is of type x.Sensitive, we ended up using "*****" as the key for computing hash. This commit fixes this issue. This is NOT a breaking change.