### PR TITLE
DGRAPHCORE-355: Allow data deletion for non-internal predicates

### DIFF
--- a/edgraph/server.go
+++ b/edgraph/server.go
@@ -1587,7 +1587,7 @@ func authorizeRequest(ctx context.Context, qc *queryContext) error {
 
 func getHash(ns, startTs uint64) string {
 	h := sha256.New()
-	h.Write([]byte(fmt.Sprintf("%#x%#x%s", ns, startTs, x.WorkerConfig.HmacSecret)))
+	h.Write([]byte(fmt.Sprintf("%#x%#x%s", ns, startTs, string(x.WorkerConfig.HmacSecret))))
 	return hex.EncodeToString(h.Sum(nil))
 }
 

--- a/edgraph/server_test.go
+++ b/edgraph/server_test.go
@@ -18,6 +18,8 @@ package edgraph
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -204,4 +206,13 @@ func TestParseSchemaFromAlterOperation(t *testing.T) {
 		})
 	}
 
+}
+
+func TestGetHash(t *testing.T) {
+	h := sha256.New()
+	_, err := h.Write([]byte("0xa0x14123456789"))
+	require.NoError(t, err)
+
+	x.WorkerConfig.HmacSecret = []byte("123456789")
+	require.Equal(t, hex.EncodeToString(h.Sum(nil)), getHash(10, 20))
 }

--- a/query/mutation.go
+++ b/query/mutation.go
@@ -286,6 +286,9 @@ func checkIfDeletingAclOperation(ctx context.Context, edges []*pb.DirectedEdge) 
 
 	isDeleteAclOperation := false
 	for _, edge := range edges {
+		if !x.IsReservedPredicate(schema.Predicate) {
+			continue
+		}
 		// Disallow deleting of guardians group
 		if edge.Entity == guardianUid && edge.Op == pb.DirectedEdge_DEL {
 			isDeleteAclOperation = true
@@ -298,7 +301,7 @@ func checkIfDeletingAclOperation(ctx context.Context, edges []*pb.DirectedEdge) 
 		}
 	}
 	if isDeleteAclOperation {
-		return errors.Errorf("Properties of guardians group and groot user cannot be deleted.")
+		return errors.Errorf("Reserved properties of guardians group and groot user cannot be deleted.")
 	}
 	return nil
 }


### PR DESCRIPTION

Title format:

 - `Topic(Area): Feature`
 - `Topic` must be one of `build|ci|docs|feat|fix|perf|refactor|chore|test`
 - `Area` must be one of `acl|audit|backup|badger|cdc|dql|export|graphql|indexing|multi-tenancy|raft|restore|upgrade|zero`
 - * Add [BREAKING] if it is a breaking change

------------------
Body Format:

Description: Allow data deletion of guardian group and groot user for non-internal predicates
Fixes: <GitHub Issue>
Closes: https://dgraph.atlassian.net/browse/DGRAPHCORE-355
Docs: <docs PR>
