### PR TITLE
fix(acl): allow data deletion for non-reserved predicates

### DIFF
--- a/ee/acl/acl_test.go
+++ b/ee/acl/acl_test.go
@@ -2793,13 +2793,13 @@ func (asuite *AclTestSuite) TestDeleteGrootAndGuardiansUsingDelNQuadShouldFail()
 	// Try deleting groot user
 	_, err = gc.Mutate(mu)
 	require.Error(t, err, "Deleting groot user should have returned an error")
-	require.Contains(t, err.Error(), "Properties of guardians group and groot user cannot be deleted")
+	require.Contains(t, err.Error(), "properties of guardians group and groot user cannot be deleted")
 
 	mu = &api.Mutation{DelNquads: []byte(fmt.Sprintf("%s %s %s .", "<"+guardiansUid+">", "*", "*")), CommitNow: true}
 	// Try deleting guardians group
 	_, err = gc.Mutate(mu)
 	require.Error(t, err, "Deleting guardians group should have returned an error")
-	require.Contains(t, err.Error(), "Properties of guardians group and groot user cannot be deleted")
+	require.Contains(t, err.Error(), "properties of guardians group and groot user cannot be deleted")
 }
 
 func deleteGuardiansGroupAndGrootUserShouldFail(t *testing.T, hc *dgraphtest.HTTPClient) {

--- a/query/common_test.go
+++ b/query/common_test.go
@@ -352,7 +352,7 @@ func populateCluster() {
 	// In the query package, we test using hard coded UIDs so that we know what results
 	// to expect. We need to move the max assigned UID in zero to higher value than
 	// all the UIDs we are using during the tests.
-	x.Panic(dc.AssignUids(client, 65536))
+	x.Panic(dc.AssignUids(client.Dgraph, 65536))
 
 	setSchema(testSchema)
 	err := addTriplesToCluster(`

--- a/query/integration_test.go
+++ b/query/integration_test.go
@@ -19,10 +19,10 @@
 package query
 
 import (
+	"context"
 	"testing"
 
 	"github.com/dgraph-io/dgraph/dgraphtest"
-	"github.com/dgraph-io/dgraph/testutil"
 	"github.com/dgraph-io/dgraph/x"
 )
 
@@ -30,8 +30,12 @@ func TestMain(m *testing.M) {
 	dc = dgraphtest.NewComposeCluster()
 
 	var err error
-	client, err = testutil.DgraphClientWithGroot(testutil.SockAddr)
+	var cleanup func()
+	client, cleanup, err = dc.Client()
 	x.Panic(err)
+	defer cleanup()
+	x.Panic(client.LoginIntoNamespace(context.Background(), dgraphtest.DefaultUser,
+		dgraphtest.DefaultPassword, x.GalaxyNamespace))
 
 	populateCluster()
 	m.Run()

--- a/query/mutation.go
+++ b/query/mutation.go
@@ -286,6 +286,9 @@ func checkIfDeletingAclOperation(ctx context.Context, edges []*pb.DirectedEdge) 
 
 	isDeleteAclOperation := false
 	for _, edge := range edges {
+		if !x.IsReservedPredicate(edge.Attr) {
+			continue
+		}
 		// Disallow deleting of guardians group
 		if edge.Entity == guardianUid && edge.Op == pb.DirectedEdge_DEL {
 			isDeleteAclOperation = true
@@ -298,7 +301,7 @@ func checkIfDeletingAclOperation(ctx context.Context, edges []*pb.DirectedEdge) 
 		}
 	}
 	if isDeleteAclOperation {
-		return errors.Errorf("Properties of guardians group and groot user cannot be deleted.")
+		return errors.Errorf("Reserved properties of guardians group and groot user cannot be deleted.")
 	}
 	return nil
 }

--- a/query/query0_test.go
+++ b/query/query0_test.go
@@ -27,7 +27,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/dgraph-io/dgo/v230"
 	"github.com/dgraph-io/dgraph/dgraphtest"
 	"github.com/dgraph-io/dgraph/dql"
 )
@@ -3576,5 +3575,5 @@ func TestInvalidRegex(t *testing.T) {
 	}
 }
 
-var client *dgo.Dgraph
+var client *dgraphtest.GrpcClient
 var dc dgraphtest.Cluster

--- a/query/upgrade_test.go
+++ b/query/upgrade_test.go
@@ -37,7 +37,7 @@ func TestMain(m *testing.M) {
 		x.Panic(dg.LoginIntoNamespace(context.Background(), dgraphtest.DefaultUser,
 			dgraphtest.DefaultPassword, x.GalaxyNamespace))
 
-		client = dg.Dgraph
+		client = dg
 		dc = c
 		populateCluster()
 	}
@@ -49,7 +49,7 @@ func TestMain(m *testing.M) {
 		x.Panic(dg.LoginIntoNamespace(context.Background(), dgraphtest.DefaultUser,
 			dgraphtest.DefaultPassword, x.GalaxyNamespace))
 
-		client = dg.Dgraph
+		client = dg
 		dc = c
 		return m.Run()
 	}

--- a/systest/bgindex/count_test.go
+++ b/systest/bgindex/count_test.go
@@ -123,7 +123,7 @@ func TestCountIndex(t *testing.T) {
 				CommitNow: true,
 				DelNquads: []byte(fmt.Sprintf(`<%v> <value> "%v" .`, uid, ec-1)),
 			}); err != nil && (errors.Is(err, dgo.ErrAborted) ||
-				strings.Contains(err.Error(), "Properties of guardians group and groot user cannot be deleted")) {
+				strings.Contains(err.Error(), "properties of guardians group and groot user cannot be deleted")) {
 				return
 			} else if err != nil {
 				t.Fatalf("error in deletion :: %v\n", err)


### PR DESCRIPTION
Description: when data (non-reserved predicates) is added on UIDs that belong to groot user or guardian group, it is allowed. But when the same data is deleted, that is not allowed. This PR allows deletion of non-reserved predicates on special UIDs.
Closes: https://dgraph.atlassian.net/browse/DGRAPHCORE-355
Docs: NA
