### PR TITLE
fix(snapshot): Enable snapshot streaming after bulkload

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,12 +46,3 @@ systest/bulk_live/live/**/*.rdf
 systest/bulk_live/live/**/*.txt
 x/log_test/*.enc
 *.buf
-
-# Dgraph Files
-# p/w/zw
-*.sst
-*.vlog
-*.logs
-MANIFEST
-KEYREGISTRY
-DISCARD

--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ systest/bulk_live/live/**/*.txt
 x/log_test/*.enc
 *.buf
 
+# Dgraph Files
 # p/w/zw
 *.sst
 *.vlog

--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,11 @@ systest/bulk_live/live/**/*.rdf
 systest/bulk_live/live/**/*.txt
 x/log_test/*.enc
 *.buf
+
+# p/w/zw
+*.sst
+*.vlog
+*.logs
+MANIFEST
+KEYREGISTRY
+DISCARD

--- a/dgraphtest/cluster.go
+++ b/dgraphtest/cluster.go
@@ -24,6 +24,7 @@ import (
 	"io"
 	"net/http"
 	"os/exec"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -64,6 +65,7 @@ type HTTPClient struct {
 	graphqlURL string
 	licenseURL string
 	stateURL   string
+	assignURL  string
 }
 
 // GraphQLParams are used for making graphql requests to dgraph
@@ -584,6 +586,12 @@ func (hc *HTTPClient) GetZeroState() (*LicenseResponse, error) {
 	}
 
 	return &stateResponse, nil
+}
+
+func (hc *HTTPClient) AssignState(what string, nums int) (*http.Response, error) {
+	url := hc.assignURL + "?what=" + what + "&num=" + strconv.Itoa(nums)
+	response, err := http.Get(url)
+	return response, err
 }
 
 // SetupSchema sets up DQL schema

--- a/dgraphtest/cluster.go
+++ b/dgraphtest/cluster.go
@@ -641,14 +641,14 @@ func (hc *HTTPClient) AssignState(what string, nums int) error {
 	for i := 0; i < 5; i++ {
 		response, err := http.Get(url)
 		if err != nil {
-			log.Printf("[WARN] unable to assing state. err: %s", err)
+			log.Printf("[WARN] unable to assign state. err: %s", err)
 			time.Sleep(waitDurBeforeRetry)
 			continue
 		}
 		if err = readResponseBody(response); err == nil {
 			return nil
 		}
-		log.Printf("[WARN] unable to assing state. err: %s", err)
+		log.Printf("[WARN] unable to assign state. err: %s", err)
 		time.Sleep(waitDurBeforeRetry)
 	}
 	return err

--- a/dgraphtest/cluster.go
+++ b/dgraphtest/cluster.go
@@ -105,7 +105,6 @@ type AssignIdResponse struct {
 	ReadOnly string `json:"readOnly"`
 }
 
-
 func (hc *HTTPClient) Login(user, password string, ns uint64) error {
 	login := `mutation login($userId: String, $password: String, $namespace: Int, $refreshToken: String) {
 		login(userId: $userId, password: $password, namespace: $namespace, refreshToken: $refreshToken) {

--- a/dgraphtest/cluster.go
+++ b/dgraphtest/cluster.go
@@ -604,7 +604,6 @@ func (hc *HTTPClient) GetZeroState() (*LicenseResponse, error) {
 	return &stateResponse, nil
 }
 
-
 func parseAssignError(body []byte) (AssignError, error) {
 	var resp AssignError
 	err := json.Unmarshal(body, &resp)
@@ -639,7 +638,7 @@ func (hc *HTTPClient) AssignState(what string, nums int) error {
 	log.Printf("[INFO] moving state: %s to %d", what, nums)
 	url := hc.assignURL + "?what=" + what + "&num=" + strconv.Itoa(nums)
 	var err error
-	for i:=0; i<5; i++ {
+	for i := 0; i < 5; i++ {
 		response, err := http.Get(url)
 		if err != nil {
 			log.Printf("[WARN] unable to assing state. err: %s", err)

--- a/dgraphtest/cluster.go
+++ b/dgraphtest/cluster.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log"
 	"net/http"
 	"os/exec"
 	"strconv"
@@ -589,6 +590,7 @@ func (hc *HTTPClient) GetZeroState() (*LicenseResponse, error) {
 }
 
 func (hc *HTTPClient) AssignState(what string, nums int) (*http.Response, error) {
+	log.Printf("[INFO] moving state: %s to %d", what, nums)
 	url := hc.assignURL + "?what=" + what + "&num=" + strconv.Itoa(nums)
 	response, err := http.Get(url)
 	return response, err

--- a/dgraphtest/config.go
+++ b/dgraphtest/config.go
@@ -92,9 +92,10 @@ type ClusterConfig struct {
 	refillInterval time.Duration
 	uidLease       int
 	// exposed port offset for grpc/http port for both alpha/zero
-	portOffset int
-	bulkOutDir string
-	lambdaURL  string
+	portOffset      int
+	bulkOutDir      string
+	lambdaURL       string
+	pDirReplication string // 0, 1, all
 }
 
 func NewClusterConfig() ClusterConfig {
@@ -179,6 +180,13 @@ func (cc ClusterConfig) WithExposedPortOffset(offset uint64) ClusterConfig {
 // that the same p directory is used while setting up alphas.
 func (cc ClusterConfig) WithBulkLoadOutDir(dir string) ClusterConfig {
 	cc.bulkOutDir = dir
+	return cc
+}
+
+// WithBulkLoadpDirIn sets the p dir for the alphas. This controls
+// if we want to use same p directory while setting up alphas.
+func (cc ClusterConfig) WithBulkLoadpDirIn(pDir string) ClusterConfig {
+	cc.pDirReplication = pDir
 	return cc
 }
 

--- a/dgraphtest/dgraph.go
+++ b/dgraphtest/dgraph.go
@@ -281,16 +281,19 @@ func (a *alpha) mounts(c *LocalCluster) ([]mount.Mount, error) {
 	}
 
 	if c.conf.bulkOutDir != "" {
-		pDir := filepath.Join(c.conf.bulkOutDir, strconv.Itoa(a.id/c.conf.replicas), "p")
-		if err := os.MkdirAll(pDir, os.ModePerm); err != nil {
-			return nil, errors.Wrap(err, "erorr creating bulk dir")
+		if c.conf.numAlphas == 1 || (c.conf.numAlphas > 1 && a.id == 0) {
+			pDir := filepath.Join(c.conf.bulkOutDir, strconv.Itoa(a.id/c.conf.replicas), "p")
+			if err := os.MkdirAll(pDir, os.ModePerm); err != nil {
+				return nil, errors.Wrap(err, "erorr creating bulk dir")
+			}
+			mounts = append(mounts, mount.Mount{
+				Type:     mount.TypeBind,
+				Source:   pDir,
+				Target:   DefaultAlphaPDir,
+				ReadOnly: false,
+			})
 		}
-		mounts = append(mounts, mount.Mount{
-			Type:     mount.TypeBind,
-			Source:   pDir,
-			Target:   DefaultAlphaPDir,
-			ReadOnly: false,
-		})
+
 	}
 
 	for dir, vol := range c.conf.volumes {

--- a/dgraphtest/dgraph.go
+++ b/dgraphtest/dgraph.go
@@ -281,8 +281,17 @@ func (a *alpha) mounts(c *LocalCluster) ([]mount.Mount, error) {
 	}
 
 	if c.conf.bulkOutDir != "" {
-		if c.conf.numAlphas == 1 || (c.conf.numAlphas > 1 && a.id == 0) {
-			pDir := filepath.Join(c.conf.bulkOutDir, strconv.Itoa(a.id/c.conf.replicas), "p")
+		var pDir string
+		switch c.conf.pDirReplication {
+		case "0":
+			if a.id == 0 {
+				pDir = filepath.Join(c.conf.bulkOutDir, strconv.Itoa(a.id), "p")
+			}
+		default:
+			pDir = filepath.Join(c.conf.bulkOutDir, strconv.Itoa(a.id/c.conf.replicas), "p")
+		}
+
+		if pDir != "" {
 			if err := os.MkdirAll(pDir, os.ModePerm); err != nil {
 				return nil, errors.Wrap(err, "erorr creating bulk dir")
 			}
@@ -293,7 +302,6 @@ func (a *alpha) mounts(c *LocalCluster) ([]mount.Mount, error) {
 				ReadOnly: false,
 			})
 		}
-
 	}
 
 	for dir, vol := range c.conf.volumes {

--- a/dgraphtest/dgraph.go
+++ b/dgraphtest/dgraph.go
@@ -92,11 +92,27 @@ type dnode interface {
 	zeroURL(*LocalCluster) (string, error)
 }
 
+type nodeType interface {
+	getId() int
+	cname() string
+	aname() string
+	cid() string
+	workingDir() string
+	healthURL(*LocalCluster) (string, error)
+	assignURL(*LocalCluster) (string, error)
+	alphaURL(*LocalCluster) (string, error)
+	zeroURL(*LocalCluster) (string, error)
+}
+
 type zero struct {
 	id            int    // 0, 1, 2
 	containerID   string // container ID in docker world
 	containerName string // something like test-1234_zero2
 	aliasName     string // something like alpha0, zero1
+}
+
+func (z *zero) getId() int {
+	return z.id
 }
 
 func (z *zero) cname() string {
@@ -191,6 +207,10 @@ type alpha struct {
 	containerID   string
 	containerName string
 	aliasName     string
+}
+
+func (a *alpha) getId() int {
+	return a.id
 }
 
 func (a *alpha) cname() string {

--- a/dgraphtest/load.go
+++ b/dgraphtest/load.go
@@ -493,3 +493,28 @@ func (c *LocalCluster) BulkLoad(opts BulkOpts) error {
 		return nil
 	}
 }
+
+func (c *LocalCluster) CopyBulkLoadDirsToAlphaMounts() error {
+	var src, target string
+	for _, alpha := range c.alphas {
+		if alpha.id == 0 {
+			// No need to copy
+			src = filepath.Join(c.conf.bulkOutDir, strconv.Itoa(alpha.id), "p")
+			continue
+		}
+		target = filepath.Join(filepath.Dir(c.conf.bulkOutDir), "copy", strconv.Itoa(alpha.id))
+		if err := copyFolder(src, target); err != nil {
+			return err
+		}
+		log.Printf("[INFO] copied bulk load dir from [%v] to [%v]", src, target)
+	}
+	return nil
+}
+
+func copyFolder(src, target string) error {
+	cmd := exec.Command("cp", "-r", src, target)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return errors.Wrapf(err, "error copying folder: %v", string(out))
+	}
+	return nil
+}

--- a/dgraphtest/local_cluster.go
+++ b/dgraphtest/local_cluster.go
@@ -276,7 +276,11 @@ func (c *LocalCluster) StartAlpha(id int) error {
 	if id >= c.conf.numAlphas {
 		return fmt.Errorf("invalid id of alpha: %v", id)
 	}
-	return c.startContainer(c.alphas[id])
+	err := c.startContainer(c.alphas[id])
+	if err != nil {
+		return err
+	}
+	return c.HealthCheckAlpha(id)
 }
 
 func (c *LocalCluster) startContainer(dc dnode) error {

--- a/dgraphtest/local_cluster.go
+++ b/dgraphtest/local_cluster.go
@@ -363,7 +363,7 @@ func (c *LocalCluster) LeaderCheck(zeroOnly bool) error {
 		return err
 	}
 
-	for i := 0; i < 10; i++ {
+	for i := 0; i < 20; i++ {
 		req, err := http.NewRequest(http.MethodGet, client.stateURL, nil)
 		if err != nil {
 			return errors.Wrap(err, "error building req for state endpoint")
@@ -376,7 +376,11 @@ func (c *LocalCluster) LeaderCheck(zeroOnly bool) error {
 		}
 
 		var result map[string]interface{}
-		json.Unmarshal(body, &result)
+		err = json.Unmarshal(body, &result)
+		if err != nil {
+			log.Printf("[WARNING] error unmarshalling state endpoint [%v], err: [%v]", client.stateURL, err)
+			continue
+		}
 		zeros := result["zeros"].(map[string]interface{})
 
 		var leaderCount int

--- a/dgraphtest/local_cluster.go
+++ b/dgraphtest/local_cluster.go
@@ -280,8 +280,7 @@ func (c *LocalCluster) StartAlpha(id int) error {
 	if id >= c.conf.numAlphas {
 		return fmt.Errorf("invalid id of alpha: %v", id)
 	}
-	err := c.startContainer(c.alphas[id])
-	if err != nil {
+	if err := c.startContainer(c.alphas[id]); err != nil {
 		return err
 	}
 	return c.HealthCheck([]int{id}, nil)

--- a/systest/integration2/bulk_loader_snapshot_test.go
+++ b/systest/integration2/bulk_loader_snapshot_test.go
@@ -83,7 +83,7 @@ func queryAlphaWith(t *testing.T, query, expectedResp string, client *dgraphtest
 
 func TestBulkLoaderSnapshot(t *testing.T) {
 	conf := dgraphtest.NewClusterConfig().WithNumAlphas(3).WithNumZeros(1).WithReplicas(3).
-		WithBulkLoadOutDir(t.TempDir()).WithACL(time.Hour).WithVerbosity(2)
+		WithBulkLoadpDirIn("0").WithBulkLoadOutDir(t.TempDir()).WithACL(time.Hour).WithVerbosity(2)
 	c, err := dgraphtest.NewLocalCluster(conf)
 	require.NoError(t, err)
 	defer func() { c.Cleanup(t.Failed()) }()

--- a/systest/integration2/bulk_loader_snapshot_test.go
+++ b/systest/integration2/bulk_loader_snapshot_test.go
@@ -19,7 +19,6 @@ package main
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -92,9 +91,9 @@ func TestBulkLoaderSnapshot(t *testing.T) {
 
 	baseDir := t.TempDir()
 	dqlSchemaFile := filepath.Join(baseDir, "person.schema")
-	require.NoError(t, ioutil.WriteFile(dqlSchemaFile, []byte(personSchema), os.ModePerm))
+	require.NoError(t, os.WriteFile(dqlSchemaFile, []byte(personSchema), os.ModePerm))
 	dataFile := filepath.Join(baseDir, "person.rdf")
-	require.NoError(t, ioutil.WriteFile(dataFile, []byte(rdfData), os.ModePerm))
+	require.NoError(t, os.WriteFile(dataFile, []byte(rdfData), os.ModePerm))
 
 	opts := dgraphtest.BulkOpts{
 		DataFiles:   []string{dataFile},

--- a/systest/integration2/bulk_loader_snapshot_test.go
+++ b/systest/integration2/bulk_loader_snapshot_test.go
@@ -80,7 +80,8 @@ func queryAlphaWith(t *testing.T, query string, client *dgraphtest.GrpcClient) *
 }
 
 func TestBulkLoaderSnapshot(t *testing.T) {
-	conf := dgraphtest.NewClusterConfig().WithNumAlphas(3).WithNumZeros(1).WithReplicas(3).WithBulkLoadOutDir(t.TempDir()).WithACL(time.Hour)
+	conf := dgraphtest.NewClusterConfig().WithNumAlphas(3).WithNumZeros(1).WithReplicas(3).
+		WithBulkLoadOutDir(t.TempDir()).WithACL(time.Hour).WithVerbosity(2)
 	c, err := dgraphtest.NewLocalCluster(conf)
 	require.NoError(t, err)
 	defer func() { c.Cleanup(t.Failed()) }()
@@ -122,9 +123,6 @@ func TestBulkLoaderSnapshot(t *testing.T) {
 		`{"q1": [{"name": "Dave"},{"name": "Alice"},{"name": "Charlie"},{"name": "Bob"}]}`,
 		string(resp.GetJson()),
 	)
-
-	// Wait for snapshot to be taken by Alpha 0
-	time.Sleep(5 * time.Second)
 
 	// start Alpha 1
 	require.NoError(t, c.StartAlpha(1))

--- a/systest/integration2/bulk_loader_snapshot_test.go
+++ b/systest/integration2/bulk_loader_snapshot_test.go
@@ -24,10 +24,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/dgraph-io/dgraph/dgraphtest"
 	"github.com/dgraph-io/dgraph/testutil"
 	"github.com/dgraph-io/dgraph/x"
-	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -91,7 +92,7 @@ func TestBulkLoaderSnapshot(t *testing.T) {
 
 	// start zero
 	require.NoError(t, c.StartZero(0))
-	require.NoError(t, c.HealthCheck(true))
+	require.NoError(t, c.HealthCheck(nil, []int{0}))
 
 	baseDir := t.TempDir()
 	dqlSchemaFile := filepath.Join(baseDir, "person.schema")

--- a/systest/integration2/bulk_loader_snapshot_test.go
+++ b/systest/integration2/bulk_loader_snapshot_test.go
@@ -1,0 +1,121 @@
+//go:build integration2
+
+/*
+ * Copyright 2023 Dgraph Labs, Inc. and Contributors *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"context"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/dgraph-io/dgraph/dgraphtest"
+	"github.com/dgraph-io/dgraph/testutil"
+	"github.com/dgraph-io/dgraph/x"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	personSchema = `
+		type Person {
+    	    name
+    	}
+	
+		name: string @index(fulltext) .
+		age : int @index(int) .
+		friend: [uid] .
+	`
+
+	rdfData = `
+	_:a <name> "Alice" .
+	_:a <age> "10" .
+	_:a <dgraph.type> "Person" .
+		
+	_:b <name> "Bob" .
+	_:b <age> "10" .
+	_:b <dgraph.type> "Person" .
+
+	_:c <name> "Charlie" .
+	_:c <age> "10" .
+	_:c <dgraph.type> "Person" .
+
+	_:d <name> "Dave" .
+	_:d <age> "10" .
+	_:d <dgraph.type> "Person" .
+
+	_:a <friend> _:c .
+	_:a <friend> _:b .
+	_:c <friend> _:d .
+	_:c <friend> _:d .
+	`
+
+	requestTimeout = 120 * time.Second
+)
+
+func TestBulkLoaderSnapshot(t *testing.T) {
+	conf := dgraphtest.NewClusterConfig().WithNumAlphas(1).WithNumZeros(1).
+		WithACL(time.Hour).WithReplicas(1).WithBulkLoadOutDir(t.TempDir())
+	c, err := dgraphtest.NewLocalCluster(conf)
+	require.NoError(t, err)
+	defer func() { c.Cleanup(t.Failed()) }()
+
+	// start zero
+	require.NoError(t, c.StartZero(0))
+	require.NoError(t, c.HealthCheck(true))
+
+	baseDir := t.TempDir()
+	dqlSchemaFile := filepath.Join(baseDir, "person.schema")
+	require.NoError(t, ioutil.WriteFile(dqlSchemaFile, []byte(personSchema), os.ModePerm))
+	dataFile := filepath.Join(baseDir, "person.rdf")
+	require.NoError(t, ioutil.WriteFile(dataFile, []byte(rdfData), os.ModePerm))
+
+	opts := dgraphtest.BulkOpts{
+		DataFiles:   []string{dataFile},
+		SchemaFiles: []string{dqlSchemaFile},
+	}
+	require.NoError(t, c.BulkLoad(opts))
+
+	// start Alphas
+	require.NoError(t, c.Start())
+
+	// get gRPC client
+	gc, cleanup, err := c.Client()
+	require.NoError(t, err)
+	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(context.Background(), requestTimeout)
+	defer cancel()
+	require.NoError(t, gc.LoginIntoNamespace(ctx, dgraphtest.DefaultUser,
+		dgraphtest.DefaultPassword, x.GalaxyNamespace))
+
+	// run some queries and ensure everything looks good
+	query := `{
+		q1(func: type(Person)){
+			name
+		}
+	}`
+	resp, err := gc.Query(query)
+	require.NoError(t, err, "Error while querying data")
+	testutil.CompareJSON(
+		t,
+		`{"q1": [{"name": "Dave"},{"name": "Alice"},{"name": "Charlie"},{"name": "Bob"}]}`,
+		string(resp.GetJson()),
+	)
+
+}

--- a/systest/integration2/bulk_loader_snapshot_test.go
+++ b/systest/integration2/bulk_loader_snapshot_test.go
@@ -103,7 +103,6 @@ func TestBulkLoaderSnapshot(t *testing.T) {
 
 	// start Alpha 0
 	require.NoError(t, c.StartAlpha(0))
-	require.NoError(t, c.HealthCheckAlpha(0))
 
 	// get gRPC client
 	gc, cleanup, err := c.ClientForAlpha(0)
@@ -125,7 +124,6 @@ func TestBulkLoaderSnapshot(t *testing.T) {
 
 	// start Alpha 1
 	require.NoError(t, c.StartAlpha(1))
-	require.NoError(t, c.HealthCheckAlpha(1))
 
 	// get gRPC client
 	gc, cleanup, err = c.ClientForAlpha(1)

--- a/systest/integration2/bulk_loader_snapshot_test.go
+++ b/systest/integration2/bulk_loader_snapshot_test.go
@@ -103,9 +103,7 @@ func TestBulkLoaderSnapshot(t *testing.T) {
 
 	// start Alpha 0
 	require.NoError(t, c.StartAlpha(0))
-	// require.NoError(t, c.Start())
 	require.NoError(t, c.HealthCheckAlpha(0))
-	// require.NoError(t, c.HealthCheck(false))
 
 	// get gRPC client
 	gc, cleanup, err := c.ClientForAlpha(0)

--- a/systest/integration2/bulk_loader_test.go
+++ b/systest/integration2/bulk_loader_test.go
@@ -18,7 +18,6 @@
 package main
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -72,7 +71,7 @@ const (
 )
 
 func TestBulkLoaderNoDqlSchema(t *testing.T) {
-	conf := dgraphtest.NewClusterConfig().WithNumAlphas(3).WithNumZeros(1).
+	conf := dgraphtest.NewClusterConfig().WithNumAlphas(2).WithNumZeros(1).
 		WithACL(time.Hour).WithReplicas(1).WithBulkLoadOutDir(t.TempDir())
 	c, err := dgraphtest.NewLocalCluster(conf)
 	require.NoError(t, err)
@@ -84,9 +83,9 @@ func TestBulkLoaderNoDqlSchema(t *testing.T) {
 
 	baseDir := t.TempDir()
 	gqlSchemaFile := filepath.Join(baseDir, "gql.schema")
-	require.NoError(t, ioutil.WriteFile(gqlSchemaFile, []byte(gqlSchema), os.ModePerm))
+	require.NoError(t, os.WriteFile(gqlSchemaFile, []byte(gqlSchema), os.ModePerm))
 	dataFile := filepath.Join(baseDir, "data.json")
-	require.NoError(t, ioutil.WriteFile(dataFile, []byte(jsonData), os.ModePerm))
+	require.NoError(t, os.WriteFile(dataFile, []byte(jsonData), os.ModePerm))
 
 	opts := dgraphtest.BulkOpts{
 		DataFiles:      []string{dataFile},

--- a/systest/integration2/bulk_loader_test.go
+++ b/systest/integration2/bulk_loader_test.go
@@ -138,8 +138,6 @@ func TestBulkLoaderNoDqlSchema(t *testing.T) {
 	  }`, string(data))
 }
 
-
-
 func TestBulkLoaderDataLoss(t *testing.T) {
 	dir := t.TempDir()
 	conf := dgraphtest.NewClusterConfig().WithNumAlphas(1).WithNumZeros(1).WithReplicas(1).
@@ -157,8 +155,7 @@ func TestBulkLoaderDataLoss(t *testing.T) {
 
 	require.NoError(t, error)
 	require.NoError(t, hc.AssignState("timestamps", 2500))
-		
-	
+
 	baseDir := t.TempDir()
 	dqlSchemaFile := filepath.Join(baseDir, "person.schema")
 	require.NoError(t, os.WriteFile(dqlSchemaFile, []byte(personSchema), os.ModePerm))
@@ -205,7 +202,7 @@ func TestBulkLoaderDataLoss(t *testing.T) {
 	hc, error = c2.HTTPZeroClient()
 
 	require.NoError(t, error)
-	require.NoError(t,  hc.AssignState("timestamps", 2500))
+	require.NoError(t, hc.AssignState("timestamps", 2500))
 
 	expectedResp := `{
 		"q1": [{"name": "Dave"},{"name": "Alice"},{"name": "Charlie"},{"name": "Bob"}]

--- a/systest/integration2/bulk_loader_test.go
+++ b/systest/integration2/bulk_loader_test.go
@@ -19,11 +19,6 @@ package main
 
 import (
 	"context"
-	"encoding/json"
-	"fmt"
-	"io"
-	"log"
-	"net/http"
 	"os"
 	"path/filepath"
 	"testing"
@@ -143,50 +138,7 @@ func TestBulkLoaderNoDqlSchema(t *testing.T) {
 	  }`, string(data))
 }
 
-type AssignError struct {
-	Errors []Entry `json:"errors"`
-}
 
-type Entry struct {
-	Message    string                 `json:"message"`
-	Extensions map[string]interface{} `json:"extensions"`
-}
-
-type AssignIdResponse struct {
-	StartId  string `json:"startId"`
-	EndId    string `json:"endId"`
-	ReadOnly string `json:"readOnly"`
-}
-
-func parseAssignError(body []byte) (AssignError, error) {
-	var resp AssignError
-	err := json.Unmarshal(body, &resp)
-	return resp, err
-}
-
-func parseAssignIdResponse(body []byte) (AssignIdResponse, error) {
-	var resp AssignIdResponse
-	err := json.Unmarshal(body, &resp)
-	return resp, err
-}
-
-func readResponseBody(t *testing.T, do *http.Response) error {
-	defer func() { _ = do.Body.Close() }()
-	body, err := io.ReadAll(do.Body)
-	if err != nil {
-		return err
-	}
-
-	if resp, err := parseAssignError(body); err == nil && len(resp.Errors) > 0 {
-		return fmt.Errorf("failed to assign state. error: %s", resp.Errors[0].Message)
-	}
-
-	if resp, err := parseAssignIdResponse(body); err == nil && resp.StartId != "" {
-		log.Printf("[INFO] success in assign state. StartId: %s EndId: %s", resp.StartId, resp.EndId)
-	}
-
-	return nil
-}
 
 func TestBulkLoaderDataLoss(t *testing.T) {
 	dir := t.TempDir()
@@ -204,10 +156,9 @@ func TestBulkLoaderDataLoss(t *testing.T) {
 	hc, error := c.HTTPZeroClient()
 
 	require.NoError(t, error)
-	resp, err := hc.AssignState("timestamps", 2500)
-	require.NoError(t, err)
-	require.NoError(t, readResponseBody(t, resp))
-
+	require.NoError(t, hc.AssignState("timestamps", 2500))
+		
+	
 	baseDir := t.TempDir()
 	dqlSchemaFile := filepath.Join(baseDir, "person.schema")
 	require.NoError(t, os.WriteFile(dqlSchemaFile, []byte(personSchema), os.ModePerm))
@@ -254,8 +205,7 @@ func TestBulkLoaderDataLoss(t *testing.T) {
 	hc, error = c2.HTTPZeroClient()
 
 	require.NoError(t, error)
-	_, err = hc.AssignState("timestamps", 2500)
-	require.NoError(t, err)
+	require.NoError(t,  hc.AssignState("timestamps", 2500))
 
 	expectedResp := `{
 		"q1": [{"name": "Dave"},{"name": "Alice"},{"name": "Charlie"},{"name": "Bob"}]

--- a/systest/integration2/bulk_loader_test.go
+++ b/systest/integration2/bulk_loader_test.go
@@ -24,9 +24,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/dgraph-io/dgraph/dgraphtest"
 	"github.com/dgraph-io/dgraph/x"
-	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -80,7 +81,7 @@ func TestBulkLoaderNoDqlSchema(t *testing.T) {
 
 	// start zero
 	require.NoError(t, c.StartZero(0))
-	require.NoError(t, c.HealthCheck(true))
+	require.NoError(t, c.HealthCheck(nil, []int{0}))
 
 	baseDir := t.TempDir()
 	gqlSchemaFile := filepath.Join(baseDir, "gql.schema")
@@ -147,7 +148,7 @@ func TestBulkLoaderDataLoss(t *testing.T) {
 
 	// start zero
 	require.NoError(t, c.StartZero(0))
-	require.NoError(t, c.HealthCheck(true))
+	require.NoError(t, c.HealthCheck(nil, []int{0}))
 	require.NoError(t, c.LeaderCheck(true))
 
 	hc, error := c.HTTPZeroClient()

--- a/systest/integration2/bulk_loader_test.go
+++ b/systest/integration2/bulk_loader_test.go
@@ -72,7 +72,7 @@ const (
 )
 
 func TestBulkLoaderNoDqlSchema(t *testing.T) {
-	conf := dgraphtest.NewClusterConfig().WithNumAlphas(2).WithNumZeros(1).
+	conf := dgraphtest.NewClusterConfig().WithNumAlphas(3).WithNumZeros(1).
 		WithACL(time.Hour).WithReplicas(1).WithBulkLoadOutDir(t.TempDir())
 	c, err := dgraphtest.NewLocalCluster(conf)
 	require.NoError(t, err)

--- a/worker/draft.go
+++ b/worker/draft.go
@@ -1853,7 +1853,7 @@ func (n *node) InitAndStartNode() {
 			// Also trigger a snapshot so that this node can take a snapshot if required
 			// Need a delay otherwise it interfers with starting of Raft loop
 			time.AfterFunc(1*time.Second, func() {
-				n.takeSnapshot()
+				_ = n.takeSnapshot()
 			})
 		}
 	}

--- a/worker/draft.go
+++ b/worker/draft.go
@@ -1657,7 +1657,7 @@ func (n *node) calculateSnapshot(startIdx, lastIdx, minPendingStart uint64) (*pb
 
 	// For bulk loaded p dir, maxCommitTs is zero. We move this to the
 	// ts of the pstore so that snapshot can proceed.
-	if maxCommitTs == 0 && pstore != nil {
+	if maxCommitTs == 0 {
 		maxCommitTs = pstore.MaxVersion()
 	}
 

--- a/worker/draft.go
+++ b/worker/draft.go
@@ -1645,6 +1645,12 @@ func (n *node) calculateSnapshot(startIdx, lastIdx, minPendingStart uint64) (*pb
 	maxCommitTs := snap.ReadTs
 	var snapshotIdx uint64
 
+	// For bulk loaded p dir, maxCommitTs is zero. We move this to the
+	// ts of the pstore so that snapshot can proceed.
+	if maxCommitTs == 0 {
+		maxCommitTs = pstore.MaxVersion()
+	}
+
 	// Trying to retrieve all entries at once might cause out-of-memory issues in
 	// cases where the raft log is too big to fit into memory. Instead of retrieving
 	// all entries at once, retrieve it in batches of 64MB.

--- a/worker/draft.go
+++ b/worker/draft.go
@@ -1657,7 +1657,7 @@ func (n *node) calculateSnapshot(startIdx, lastIdx, minPendingStart uint64) (*pb
 
 	// For bulk loaded p dir, maxCommitTs is zero. We move this to the
 	// ts of the pstore so that snapshot can proceed.
-	if maxCommitTs == 0 {
+	if maxCommitTs == 0 && pstore != nil {
 		maxCommitTs = pstore.MaxVersion()
 	}
 

--- a/worker/draft.go
+++ b/worker/draft.go
@@ -1050,7 +1050,7 @@ func (n *node) updateRaftProgress() error {
 
 func (n *node) checkpointAndClose(done chan struct{}) {
 	slowTicker := time.NewTicker(time.Minute)
-	lastSnapshotTs := time.Now()
+	lastSnapshotTime := time.Now()
 	var err error
 	defer slowTicker.Stop()
 
@@ -1059,7 +1059,7 @@ func (n *node) checkpointAndClose(done chan struct{}) {
 		case <-slowTicker.C:
 			// Do these operations asynchronously away from the main Run loop to allow heartbeats to
 			// be sent on time. Otherwise, followers would just keep running elections.
-			lastSnapshotTs, err = n.takeSnapshot(lastSnapshotTs)
+			lastSnapshotTime, err = n.takeSnapshot(lastSnapshotTime)
 			if err != nil {
 				continue
 			}

--- a/worker/draft.go
+++ b/worker/draft.go
@@ -1058,70 +1058,79 @@ func (n *node) checkpointAndClose(done chan struct{}) {
 
 	snapshotFrequency := x.WorkerConfig.Raft.GetDuration("snapshot-after-duration")
 
+	takeSnapshot := func() error {
+		glog.V(2).Info("Trying to take a snapshot")
+		n.elog.Printf("Size of applyCh: %d", len(n.applyCh))
+		if err := n.updateRaftProgress(); err != nil {
+			glog.Errorf("While updating Raft progress: %v", err)
+		}
+
+		if n.AmLeader() {
+			// If leader doesn't have a snapshot, we should create one immediately. This is very
+			// useful when you bring up the cluster from bulk loader. If you remove an alpha and
+			// add a new alpha, the new follower won't get a snapshot if the leader doesn't have
+			// one.
+			snap, err := n.Store.Snapshot()
+			if err != nil {
+				glog.Errorf("While retrieving snapshot from Store: %v\n", err)
+				return err
+			}
+
+			// If we don't have a snapshot, or if there are too many log files in Raft,
+			// calculate a new snapshot.
+			calculate := raft.IsEmptySnap(snap) || n.Store.NumLogFiles() > 4
+
+			// Only take snapshot if both snapshotFrequency and
+			// snapshotAfterEntries requirements are met. If set to 0,
+			// we consider duration condition to be disabled.
+			if snapshotFrequency == 0 || time.Since(lastSnapshotTime) > snapshotFrequency {
+				if chk, err := n.Store.Checkpoint(); err == nil {
+					if first, err := n.Store.FirstIndex(); err == nil {
+						// Save some cycles by only calculating snapshot if the checkpoint
+						// has gone quite a bit further than the first index.
+						calculate = calculate || chk >= first+snapshotAfterEntries
+						glog.V(3).Infof("Evaluating snapshot first:%d chk:%d (chk-first:%d) "+
+							"snapshotAfterEntries:%d snap:%v", first, chk, chk-first,
+							snapshotAfterEntries, calculate)
+					}
+				}
+			}
+
+			// We keep track of the applied index in the p directory. Even if we don't take
+			// snapshot for a while and let the Raft logs grow and restart, we would not have to
+			// run all the log entries, because we can tell Raft.Config to set Applied to that
+			// index.
+			// This applied index tracking also covers the case when we have a big index
+			// rebuild. The rebuild would be tracked just like others and would not need to be
+			// replayed after a restart, because the Applied config would let us skip right
+			// through it.
+			// We use disk based storage for Raft. So, we're not too concerned about
+			// snapshotting.  We just need to do enough, so that we don't have a huge backlog of
+			// entries to process on a restart.
+			if calculate {
+				// We can set discardN argument to zero, because we already know that calculate
+				// would be true if either we absolutely needed to calculate the snapshot,
+				// or our checkpoint already crossed the SnapshotAfter threshold.
+				if err := n.proposeSnapshot(); err != nil {
+					glog.Errorf("While calculating and proposing snapshot: %v", err)
+				} else {
+					lastSnapshotTime = time.Now()
+				}
+			}
+			go n.abortOldTransactions()
+		}
+		return nil
+	}
+
+	_ = takeSnapshot()
+
 	for {
 		select {
 		case <-slowTicker.C:
 			// Do these operations asynchronously away from the main Run loop to allow heartbeats to
 			// be sent on time. Otherwise, followers would just keep running elections.
-
-			n.elog.Printf("Size of applyCh: %d", len(n.applyCh))
-			if err := n.updateRaftProgress(); err != nil {
-				glog.Errorf("While updating Raft progress: %v", err)
-			}
-
-			if n.AmLeader() {
-				// If leader doesn't have a snapshot, we should create one immediately. This is very
-				// useful when you bring up the cluster from bulk loader. If you remove an alpha and
-				// add a new alpha, the new follower won't get a snapshot if the leader doesn't have
-				// one.
-				snap, err := n.Store.Snapshot()
-				if err != nil {
-					glog.Errorf("While retrieving snapshot from Store: %v\n", err)
-					continue
-				}
-
-				// If we don't have a snapshot, or if there are too many log files in Raft,
-				// calculate a new snapshot.
-				calculate := raft.IsEmptySnap(snap) || n.Store.NumLogFiles() > 4
-
-				// Only take snapshot if both snapshotFrequency and
-				// snapshotAfterEntries requirements are met. If set to 0,
-				// we consider duration condition to be disabled.
-				if snapshotFrequency == 0 || time.Since(lastSnapshotTime) > snapshotFrequency {
-					if chk, err := n.Store.Checkpoint(); err == nil {
-						if first, err := n.Store.FirstIndex(); err == nil {
-							// Save some cycles by only calculating snapshot if the checkpoint
-							// has gone quite a bit further than the first index.
-							calculate = calculate || chk >= first+snapshotAfterEntries
-							glog.V(3).Infof("Evaluating snapshot first:%d chk:%d (chk-first:%d) "+
-								"snapshotAfterEntries:%d snap:%v", first, chk, chk-first,
-								snapshotAfterEntries, calculate)
-						}
-					}
-				}
-
-				// We keep track of the applied index in the p directory. Even if we don't take
-				// snapshot for a while and let the Raft logs grow and restart, we would not have to
-				// run all the log entries, because we can tell Raft.Config to set Applied to that
-				// index.
-				// This applied index tracking also covers the case when we have a big index
-				// rebuild. The rebuild would be tracked just like others and would not need to be
-				// replayed after a restart, because the Applied config would let us skip right
-				// through it.
-				// We use disk based storage for Raft. So, we're not too concerned about
-				// snapshotting.  We just need to do enough, so that we don't have a huge backlog of
-				// entries to process on a restart.
-				if calculate {
-					// We can set discardN argument to zero, because we already know that calculate
-					// would be true if either we absolutely needed to calculate the snapshot,
-					// or our checkpoint already crossed the SnapshotAfter threshold.
-					if err := n.proposeSnapshot(); err != nil {
-						glog.Errorf("While calculating and proposing snapshot: %v", err)
-					} else {
-						lastSnapshotTime = time.Now()
-					}
-				}
-				go n.abortOldTransactions()
+			if takeSnapshot() != nil {
+				continue
 			}
 
 		case <-n.closer.HasBeenClosed():
@@ -1267,6 +1276,7 @@ func (n *node) Run() {
 				x.AssertTrue(rc.GetGroup() == n.gid)
 				if rc.Id != n.Id {
 					// Set node to unhealthy state here while it applies the snapshot.
+					glog.V(2).Infof("Leader is sending snapshot: %+v\n", snap)
 					x.UpdateHealthStatus(false)
 
 					// We are getting a new snapshot from leader. We need to wait for the applyCh to

--- a/worker/snapshot_test.go
+++ b/worker/snapshot_test.go
@@ -104,6 +104,7 @@ func TestSnapshot(t *testing.T) {
 	// uploading new schema while alpha2 is not running so we can
 	// test whether the stopped alpha gets new schema in snapshot
 	testutil.UpdateGQLSchema(t, testutil.SockAddrHttp, testSchema)
+	t.Logf("Waiting for snapshot.\n")
 	_ = waitForSnapshot(t, snapshotTs)
 
 	t.Logf("Starting alpha2.\n")

--- a/worker/worker_test.go
+++ b/worker/worker_test.go
@@ -22,14 +22,12 @@ import (
 	"context"
 	"fmt"
 	"math"
-	"os"
 	"strings"
 	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/dgraph-io/badger/v4"
 	"github.com/dgraph-io/dgo/v230"
 	"github.com/dgraph-io/dgo/v230/protos/api"
 	"github.com/dgraph-io/dgraph/posting"
@@ -356,36 +354,4 @@ func TestProcessTaskIndex(t *testing.T) {
 		}`,
 		string(resp.Json),
 	)
-}
-
-func TestMain(m *testing.M) {
-	posting.Config.CommitFraction = 0.10
-	gr = new(groupi)
-	gr.gid = 1
-	gr.tablets = make(map[string]*pb.Tablet)
-	addTablets := func(attrs []string, gid uint32, namespace uint64) {
-		for _, attr := range attrs {
-			gr.tablets[x.NamespaceAttr(namespace, attr)] = &pb.Tablet{GroupId: gid}
-		}
-	}
-
-	addTablets([]string{"name", "name2", "age", "http://www.w3.org/2000/01/rdf-schema#range", "",
-		"friend", "dgraph.type", "dgraph.graphql.xid", "dgraph.graphql.schema"},
-		1, x.GalaxyNamespace)
-	addTablets([]string{"friend_not_served"}, 2, x.GalaxyNamespace)
-	addTablets([]string{"name"}, 1, 0x2)
-
-	dir, err := os.MkdirTemp("", "storetest_")
-	x.Check(err)
-	defer os.RemoveAll(dir)
-
-	opt := badger.DefaultOptions(dir)
-	ps, err := badger.OpenManaged(opt)
-	x.Check(err)
-	pstore = ps
-	// Not using posting list cache
-	posting.Init(ps, 0)
-	Init(ps)
-
-	m.Run()
 }


### PR DESCRIPTION
**Description:** Enable snapshot streaming after bulkload

**Summary:** Previously, the bulkloaded `p` directory couldn't stream to a new alpha due to a commitTs of zero. In this PR, the commitTs is sourced from the `p` directory, allowing the alpha to create a snapshot and subsequently stream it to another alpha.

**Tests:**
- **TestBulkLoaderSnapshotPDirinAlpha0**: Load a `p` directory using bulkload. Then, initiate one alpha using the bulkloaded `p` directory and start a second alpha without any `p` directory. Query both alphas to ensure the snapshot has been successfully generated and that the data is accessible from both instances.
- **TestBulkLoaderSnapshotPDirinAll**: Load a `p` directory using bulkload. Then, copy bulkloaded `p` directory in all alphas and start the cluster. Query all alphas to ensure that the data is accessible from all instances.
- **TestBulkLoaderDataLoss**: Move the `zero` timestamp and load a `p` directory using bulkload. Then use this `p` directory on a fresh cluster (both zero and alpha are new). Validate that the query doesn't work without moving the timestamp of the new zero.

**Closes:** https://dgraph.atlassian.net/browse/DGRAPHCORE-214

**Docs:** NA
