### PR TITLE
perf(query): Improve Intersection with UID pack

### DIFF
--- a/algo/uidlist.go
+++ b/algo/uidlist.go
@@ -112,9 +112,9 @@ func IntersectCompressedWithBin(dec *codec.Decoder, q []uint64, o *[]uint64) {
 				break
 			}
 			IntersectWithBin(blockUids, q, o)
-			last_uid := blockUids[len(blockUids)-1]
+			lastUid := blockUids[len(blockUids)-1]
 			qidx := sort.Search(len(q), func(idx int) bool {
-				return q[idx] >= last_uid
+				return q[idx] >= lastUid
 			})
 			if qidx >= len(q) {
 				return

--- a/algo/uidlist.go
+++ b/algo/uidlist.go
@@ -108,15 +108,15 @@ func IntersectCompressedWithBin(dec *codec.Decoder, q []uint64, o *[]uint64) {
 		last_q := q[len(q)-1]
 		uids := make([]uint64, 0)
 		for {
-			n := dec.Uids()
-			if len(n) == 0 {
+			block_uids := dec.Uids()
+			if len(block_uids) == 0 {
 				break
 			}
-			uids = append(uids, n...)
+			uids = append(uids, block_uids...)
 			if uids[len(uids)-1] > last_q {
 				break
 			}
-			uids = dec.Next()
+			dec.Next()
 		}
 		IntersectWithBin(uids, q, o)
 		return

--- a/algo/uidlist.go
+++ b/algo/uidlist.go
@@ -92,6 +92,7 @@ func IntersectCompressedWithLinJump(dec *codec.Decoder, v []uint64, o *[]uint64)
 // IntersectCompressedWithBin is based on the paper
 // "Fast Intersection Algorithms for Sorted Sequences"
 // https://link.springer.com/chapter/10.1007/978-3-642-12476-1_3
+// Call seek on dec before calling this function
 func IntersectCompressedWithBin(dec *codec.Decoder, q []uint64, o *[]uint64) {
 	ld := dec.ApproxLen()
 	lq := len(q)
@@ -106,12 +107,12 @@ func IntersectCompressedWithBin(dec *codec.Decoder, q []uint64, o *[]uint64) {
 	// Pick the shorter list and do binary search
 	if ld < lq {
 		for {
-			block_uids := dec.Uids()
-			if len(block_uids) == 0 {
+			blockUids := dec.Uids()
+			if len(blockUids) == 0 {
 				break
 			}
-			IntersectWithBin(block_uids, q, o)
-			last_uid := block_uids[len(block_uids)-1]
+			IntersectWithBin(blockUids, q, o)
+			last_uid := blockUids[len(blockUids)-1]
 			qidx := sort.Search(len(q), func(idx int) bool {
 				return q[idx] >= last_uid
 			})
@@ -124,7 +125,7 @@ func IntersectCompressedWithBin(dec *codec.Decoder, q []uint64, o *[]uint64) {
 		return
 	}
 
-	uids := dec.Seek(q[0], codec.SeekStart)
+	var uids []uint64
 	for _, u := range q {
 		if len(uids) == 0 || u > uids[len(uids)-1] {
 			uids = dec.Seek(u, codec.SeekStart)

--- a/algo/uidlist.go
+++ b/algo/uidlist.go
@@ -105,20 +105,22 @@ func IntersectCompressedWithBin(dec *codec.Decoder, q []uint64, o *[]uint64) {
 
 	// Pick the shorter list and do binary search
 	if ld < lq {
-		last_q := q[len(q)-1]
-		uids := make([]uint64, 0)
 		for {
 			block_uids := dec.Uids()
 			if len(block_uids) == 0 {
 				break
 			}
-			uids = append(uids, block_uids...)
-			if uids[len(uids)-1] > last_q {
-				break
+			IntersectWithBin(block_uids, q, o)
+			last_uid := block_uids[len(block_uids)-1]
+			qidx := sort.Search(len(q), func(idx int) bool {
+				return q[idx] >= last_uid
+			})
+			if qidx >= len(q) {
+				return
 			}
+			q = q[qidx:]
 			dec.Next()
 		}
-		IntersectWithBin(uids, q, o)
 		return
 	}
 

--- a/algo/uidlist_test.go
+++ b/algo/uidlist_test.go
@@ -391,8 +391,6 @@ func BenchmarkListIntersectCompressBin(b *testing.B) {
 			dst2 := &pb.List{}
 			compressedUids := codec.Encode(v1, 256)
 
-			fmt.Printf("len: %d, compressed: %d, bytes/int: %f\n",
-				len(v1), compressedUids.Size(), float64(compressedUids.Size())/float64(len(v1)))
 			b.Run(fmt.Sprintf("compressed:IntersectWith:ratio=%v:size=%d:overlap=%.2f:", r, sz, overlap),
 				func(b *testing.B) {
 					for k := 0; k < b.N; k++ {


### PR DESCRIPTION
This PR improves the performance of IntersectCompressedWithBin. LDBC09 Query went from 38 second -> 22 second. Benchmarks show up to 80% improvement in performance.