### PR TITLE
chore(build): name codename configurable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@
 #
 
 BUILD          ?= $(shell git rev-parse --short HEAD)
-BUILD_CODENAME  = dgraph
+BUILD_CODENAME ?= dgraph
 BUILD_DATE     ?= $(shell git log -1 --format=%ci)
 BUILD_BRANCH   ?= $(shell git rev-parse --abbrev-ref HEAD)
 BUILD_VERSION  ?= $(shell git describe --always --tags)


### PR DESCRIPTION
Description: Currently `codename` ldflag` is not mutable and set to `dgraph`.  We would like to make it configurable for cloud builds.
