### PR TITLE
chore: update cron job frequency to reset github notifications

### DIFF
--- a/.github/workflows/ci-aqua-security-trivy-tests.yml
+++ b/.github/workflows/ci-aqua-security-trivy-tests.yml
@@ -32,7 +32,7 @@ on:
       - main
       - 'release/**'
   schedule:
-    - cron: "0 * * * *"
+    - cron: "1 * * * *"
 jobs:
   build:
     name: trivy-tests

--- a/.github/workflows/ci-dgraph-fuzz.yml
+++ b/.github/workflows/ci-dgraph-fuzz.yml
@@ -14,7 +14,7 @@ on:
       - main
       - 'release/**'
   schedule:
-    - cron: "0 */8 * * *" # every 8hrs
+    - cron: "1 */8 * * *" # every 8hrs
 jobs:
   fuzz-test:
     runs-on: ubuntu-20.04

--- a/.github/workflows/ci-dgraph-integration2-tests.yml
+++ b/.github/workflows/ci-dgraph-integration2-tests.yml
@@ -14,7 +14,7 @@ on:
       - main
       - 'release/**'
   schedule:
-    - cron: "0 */4 * * *" # every 4hrs
+    - cron: "1 */4 * * *" # every 4hrs
 jobs:
   dgraph-integration2-tests:
     if: github.event.pull_request.draft == false

--- a/.github/workflows/ci-dgraph-ldbc-tests.yml
+++ b/.github/workflows/ci-dgraph-ldbc-tests.yml
@@ -32,7 +32,7 @@ on:
       - main
       - 'release/**'
   schedule:
-    - cron: "0 0 * * *" # 1-run per day
+    - cron: "1 0 * * *" # 1-run per day
 jobs:
   dgraph-ldbc-tests:
     if: github.event.pull_request.draft == false

--- a/.github/workflows/ci-dgraph-load-tests.yml
+++ b/.github/workflows/ci-dgraph-load-tests.yml
@@ -32,7 +32,7 @@ on:
       - main
       - 'release/**'
   schedule:
-    - cron: "0 0,6,12,18 * * *"
+    - cron: "1 0,6,12,18 * * *"
 jobs:
   dgraph-load-tests:
     if: github.event.pull_request.draft == false

--- a/.github/workflows/ci-dgraph-oss-build.yml
+++ b/.github/workflows/ci-dgraph-oss-build.yml
@@ -32,7 +32,7 @@ on:
       - main
       - 'release/**'
   schedule:
-    - cron: "0 0,6,12,18 * * *"
+    - cron: "1 0,6,12,18 * * *"
 jobs:
   dgraph-oss-build:
     if: github.event.pull_request.draft == false

--- a/.github/workflows/ci-dgraph-tests-arm64.yml
+++ b/.github/workflows/ci-dgraph-tests-arm64.yml
@@ -32,7 +32,7 @@ on:
       - main
       - 'release/**'
   schedule:
-    - cron: "0 0,6,12,18 * * *"
+    - cron: "1 0,6,12,18 * * *"
 jobs:
   dgraph-tests:
     if: github.event.pull_request.draft == false

--- a/.github/workflows/ci-dgraph-tests.yml
+++ b/.github/workflows/ci-dgraph-tests.yml
@@ -32,7 +32,7 @@ on:
       - main
       - 'release/**'
   schedule:
-    - cron: "0 0,6,12,18 * * *"
+    - cron: "1 0,6,12,18 * * *"
 jobs:
   dgraph-tests:
     if: github.event.pull_request.draft == false

--- a/.github/workflows/ci-dgraph-upgrade-fixed-versions-tests.yml
+++ b/.github/workflows/ci-dgraph-upgrade-fixed-versions-tests.yml
@@ -1,7 +1,7 @@
 name: ci-dgraph-upgrade-fixed-versions-tests
 on:
   schedule:
-    - cron: "0 */12 * * *" # every 12hrs
+    - cron: "1 */12 * * *" # every 12hrs
 jobs:
   dgraph-upgrade-fixed-versions-tests:
     runs-on: [self-hosted, x64]

--- a/.github/workflows/ci-dgraph-upgrade-tests.yml
+++ b/.github/workflows/ci-dgraph-upgrade-tests.yml
@@ -14,7 +14,7 @@ on:
       - main
       - 'release/**'
   schedule:
-    - cron: "0 */4 * * *" # every 4hrs
+    - cron: "1 */4 * * *" # every 4hrs
 jobs:
   dgraph-upgrade-tests:
     if: github.event.pull_request.draft == false

--- a/.github/workflows/ci-golang-lint.yml
+++ b/.github/workflows/ci-golang-lint.yml
@@ -32,7 +32,7 @@ on:
       - main
       - 'release/**'
   schedule:
-    - cron: "0 */2 * * *" # every 2hrs
+    - cron: "1 */2 * * *" # every 2hrs
 jobs:
   golang-lint:
     if: github.event.pull_request.draft == false


### PR DESCRIPTION
In our [scheduled runs](https://github.com/dgraph-io/dgraph/actions?query=event%3Aschedule) we see a number of "ghost" jobs.  E.g. [1](https://github.com/dgraph-io/dgraph/actions/runs/5881148541).  This is probably due to the following sequence of events:
- github actions sends a notification to developer who created / modified cron job frequency
- if this person is no longer able to receive this notification (i.e. no longer receiving emails) the action raise this ghost job with an error about unverified email

This is a bug with github actions.  After contacting github support they suggested changing the cron job frequency in order to reset who receives the notifications.  This may solve the issue.