### PR TITLE
[feat] Add build Codename to Telemetry data

### DIFF
--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -48,6 +48,7 @@ type Telemetry struct {
 	NumGraphQLPM   uint64   `json:",omitempty"`
 	NumGraphQL     uint64   `json:",omitempty"`
 	EEFeaturesList []string `json:",omitempty"`
+	Codename       string   `json:",omitempty"`
 }
 
 const url = "https://ping.dgraph.io/3.0/projects/5b809dfac9e77c0001783ad0/events"
@@ -65,6 +66,7 @@ func NewZero(ms *pb.MembershipState) *Telemetry {
 		Version:   x.Version(),
 		OS:        runtime.GOOS,
 		Arch:      runtime.GOARCH,
+		Codename:  x.Codename(),
 	}
 	for _, g := range ms.GetGroups() {
 		t.NumAlphas += len(g.GetMembers())
@@ -86,6 +88,7 @@ func NewAlpha(ms *pb.MembershipState) *Telemetry {
 		OS:             runtime.GOOS,
 		Arch:           runtime.GOARCH,
 		EEFeaturesList: worker.GetEEFeaturesList(),
+		Codename:       x.Codename(),
 	}
 }
 

--- a/x/init.go
+++ b/x/init.go
@@ -90,6 +90,12 @@ func Version() string {
 	return dgraphVersion
 }
 
+// Codename returns a string containing the dgraphCodename.
+func Codename() string {
+	return dgraphCodename
+}
+
+
 // pattern for  dev version = min. 7 hex digits of commit-hash.
 var versionRe *regexp.Regexp = regexp.MustCompile(`-g[[:xdigit:]]{7,}`)
 

--- a/x/init.go
+++ b/x/init.go
@@ -95,7 +95,6 @@ func Codename() string {
 	return dgraphCodename
 }
 
-
 // pattern for  dev version = min. 7 hex digits of commit-hash.
 var versionRe *regexp.Regexp = regexp.MustCompile(`-g[[:xdigit:]]{7,}`)
 


### PR DESCRIPTION
In order to distinguish Telemetry data coming from cloud instances, add build `Codename` to Telemetry data. This is the same approach we are using for distinguishing Sentry data.
