### PR TITLE
fix(acl): revert the error changed in #8937

### DIFF
--- a/ee/acl/acl_test.go
+++ b/ee/acl/acl_test.go
@@ -2793,13 +2793,13 @@ func (asuite *AclTestSuite) TestDeleteGrootAndGuardiansUsingDelNQuadShouldFail()
 	// Try deleting groot user
 	_, err = gc.Mutate(mu)
 	require.Error(t, err, "Deleting groot user should have returned an error")
-	require.Contains(t, err.Error(), "properties of guardians group and groot user cannot be deleted")
+	require.Contains(t, err.Error(), "Properties of guardians group and groot user cannot be deleted")
 
 	mu = &api.Mutation{DelNquads: []byte(fmt.Sprintf("%s %s %s .", "<"+guardiansUid+">", "*", "*")), CommitNow: true}
 	// Try deleting guardians group
 	_, err = gc.Mutate(mu)
 	require.Error(t, err, "Deleting guardians group should have returned an error")
-	require.Contains(t, err.Error(), "properties of guardians group and groot user cannot be deleted")
+	require.Contains(t, err.Error(), "Properties of guardians group and groot user cannot be deleted")
 }
 
 func deleteGuardiansGroupAndGrootUserShouldFail(t *testing.T, hc *dgraphtest.HTTPClient) {

--- a/query/mutation.go
+++ b/query/mutation.go
@@ -301,7 +301,7 @@ func checkIfDeletingAclOperation(ctx context.Context, edges []*pb.DirectedEdge) 
 		}
 	}
 	if isDeleteAclOperation {
-		return errors.Errorf("Reserved properties of guardians group and groot user cannot be deleted.")
+		return errors.Errorf("Reserved Properties of guardians group and groot user cannot be deleted.")
 	}
 	return nil
 }

--- a/systest/bgindex/count_test.go
+++ b/systest/bgindex/count_test.go
@@ -123,7 +123,7 @@ func TestCountIndex(t *testing.T) {
 				CommitNow: true,
 				DelNquads: []byte(fmt.Sprintf(`<%v> <value> "%v" .`, uid, ec-1)),
 			}); err != nil && (errors.Is(err, dgo.ErrAborted) ||
-				strings.Contains(err.Error(), "properties of guardians group and groot user cannot be deleted")) {
+				strings.Contains(err.Error(), "Properties of guardians group and groot user cannot be deleted")) {
 				return
 			} else if err != nil {
 				t.Fatalf("error in deletion :: %v\n", err)


### PR DESCRIPTION
upgrade tests fail because of the change in the error. This PR undoes the change in the error made in the PR #8937.