### PR TITLE
perf(query): Read just the latest value for scalar types

### DIFF
--- a/posting/list.go
+++ b/posting/list.go
@@ -1428,7 +1428,8 @@ func (l *List) findStaticValue(readTs uint64) *pb.PostingList {
 	// This means that maxTs > readTs. Go through the map to find the closest value to readTs
 	mutation = nil
 	ts_found := uint64(0)
-	for ts, mutation_i := range l.mutationMap {
+	for _, mutation_i := range l.mutationMap {
+		ts := mutation_i.CommitTs
 		if ts <= readTs && ts > ts_found {
 			ts_found = ts
 			mutation = mutation_i

--- a/worker/task.go
+++ b/worker/task.go
@@ -420,6 +420,14 @@ func (qs *queryState) handleValuePostings(ctx context.Context, args funcArgs) er
 	outputs := make([]*pb.Result, numGo)
 	listType := schema.State().IsList(q.Attr)
 
+	// These are certain special cases where we can get away with reading only the latest value
+	// Lang doesn't work because we would be storing various different languages at various
+	// time. So when we go to read the latest value, we might get a different language.
+	// Similarly with DoCount and ExpandAll and Facets. List types are also not supported
+	// because list is stored by time, and we combine all the list items at various timestamps.
+	hasLang := schema.State().HasLang(q.Attr)
+	getMultiplePosting := q.DoCount || q.ExpandAll || listType || hasLang || q.FacetParam != nil
+
 	calculate := func(start, end int) error {
 		x.AssertTrue(start%width == 0)
 		out := &pb.Result{}
@@ -434,49 +442,75 @@ func (qs *queryState) handleValuePostings(ctx context.Context, args funcArgs) er
 			key := x.DataKey(q.Attr, q.UidList.Uids[i])
 
 			// Get or create the posting list for an entity, attribute combination.
-			pl, err := qs.cache.Get(key)
-			if err != nil {
-				return err
-			}
 
-			// If count is being requested, there is no need to populate value and facets matrix.
-			if q.DoCount {
-				count, err := countForValuePostings(args, pl, facetsTree, listType)
-				if err != nil && err != posting.ErrNoValue {
-					return err
-				}
-				out.Counts = append(out.Counts, uint32(count))
-				// Add an empty UID list to make later processing consistent.
-				out.UidMatrix = append(out.UidMatrix, &pb.List{})
-				continue
-			}
+			var vals []types.Val
+			fcs := &pb.FacetsList{FacetsList: make([]*pb.Facets, 0)} // TODO Figure out how it is stored
 
-			vals, fcs, err := retrieveValuesAndFacets(args, pl, facetsTree, listType)
-			switch {
-			case err == posting.ErrNoValue || (err == nil && len(vals) == 0):
-				// This branch is taken when the value does not exist in the pl or
-				// the number of values retrieved is zero (there could still be facets).
-				// We add empty lists to the UidMatrix, FaceMatrix, ValueMatrix and
-				// LangMatrix so that all these data structure have predictable layouts.
-				out.UidMatrix = append(out.UidMatrix, &pb.List{})
-				out.FacetMatrix = append(out.FacetMatrix, &pb.FacetsList{})
-				out.ValueMatrix = append(out.ValueMatrix,
-					&pb.ValueList{Values: []*pb.TaskValue{}})
-				if q.ExpandAll {
-					// To keep the cardinality same as that of ValueMatrix.
-					out.LangMatrix = append(out.LangMatrix, &pb.LangList{})
-				}
-				continue
-			case err != nil:
-				return err
-			}
-
-			if q.ExpandAll {
-				langTags, err := pl.GetLangTags(args.q.ReadTs)
+			if !getMultiplePosting {
+				pl, err := qs.cache.GetSinglePosting(key)
 				if err != nil {
 					return err
 				}
-				out.LangMatrix = append(out.LangMatrix, &pb.LangList{Lang: langTags})
+				if pl == nil || len(pl.Postings) == 0 {
+					out.UidMatrix = append(out.UidMatrix, &pb.List{})
+					out.FacetMatrix = append(out.FacetMatrix, &pb.FacetsList{})
+					out.ValueMatrix = append(out.ValueMatrix,
+						&pb.ValueList{Values: []*pb.TaskValue{}})
+					continue
+				}
+				vals = make([]types.Val, len(pl.Postings))
+				for i, p := range pl.Postings {
+					vals[i] = types.Val{
+						Tid:   types.TypeID(p.ValType),
+						Value: p.Value,
+					}
+				}
+			} else {
+				pl, err := qs.cache.Get(key)
+				if err != nil {
+					return err
+				}
+
+				// If count is being requested, there is no need to populate value and facets matrix.
+				if q.DoCount {
+					count, err := countForValuePostings(args, pl, facetsTree, listType)
+					if err != nil && err != posting.ErrNoValue {
+						return err
+					}
+					out.Counts = append(out.Counts, uint32(count))
+					// Add an empty UID list to make later processing consistent.
+					out.UidMatrix = append(out.UidMatrix, &pb.List{})
+					continue
+				}
+
+				vals, fcs, err = retrieveValuesAndFacets(args, pl, facetsTree, listType)
+
+				switch {
+				case err == posting.ErrNoValue || (err == nil && len(vals) == 0):
+					// This branch is taken when the value does not exist in the pl or
+					// the number of values retrieved is zero (there could still be facets).
+					// We add empty lists to the UidMatrix, FaceMatrix, ValueMatrix and
+					// LangMatrix so that all these data structure have predictable layouts.
+					out.UidMatrix = append(out.UidMatrix, &pb.List{})
+					out.FacetMatrix = append(out.FacetMatrix, &pb.FacetsList{})
+					out.ValueMatrix = append(out.ValueMatrix,
+						&pb.ValueList{Values: []*pb.TaskValue{}})
+					if q.ExpandAll {
+						// To keep the cardinality same as that of ValueMatrix.
+						out.LangMatrix = append(out.LangMatrix, &pb.LangList{})
+					}
+					continue
+				case err != nil:
+					return err
+				}
+
+				if q.ExpandAll {
+					langTags, err := pl.GetLangTags(args.q.ReadTs)
+					if err != nil {
+						return err
+					}
+					out.LangMatrix = append(out.LangMatrix, &pb.LangList{Lang: langTags})
+				}
 			}
 
 			uidList := new(pb.List)


### PR DESCRIPTION
Description: Right now, when we read some data, we read the entire posting list. With this we populate List structure in memory, which has two layers. These two layers are then merge sorted. All of this takes a lot of time. In this diff, we are updating the query processor to just read the latest value in case of scalar types. 

LDBC test for IC09.
Before: 39 seconds
After: 30 seconds
