### PR TITLE
test(upgrade): handle different versions of Dgraph for --telemetry flag

### DIFF
--- a/dgraphtest/config.go
+++ b/dgraphtest/config.go
@@ -33,7 +33,6 @@ func AllUpgradeCombos(v20 bool) []UpgradeCombo {
 	fixedVersionCombos := []UpgradeCombo{
 		// OPEN SOURCE RELEASES, 4fc9cfd => v23.1.0
 		// v23.1.0 has one error modified which was fixed in commit 4fc9cfd after v23.1.0
-		{"v21.03.0", "4fc9cfd", BackupRestore},
 		{"v21.03.0-92-g0c9f60156", "4fc9cfd", BackupRestore},
 		{"v21.03.0-98-g19f71a78a-slash", "4fc9cfd", BackupRestore},
 		{"v21.03.0-99-g4a03c144a-slash", "4fc9cfd", BackupRestore},
@@ -67,15 +66,24 @@ func AllUpgradeCombos(v20 bool) []UpgradeCombo {
 		{"0c9f60156", "4fc9cfd", InPlace}, // v21.03.0-92-g0c9f60156
 	}
 
-	if v20 {
-		fixedVersionCombos = append(fixedVersionCombos, []UpgradeCombo{
-			{"v20.11.3", localVersion, BackupRestore},
-		}...)
-	}
-
+	// In mainCombos list, we keep latest version to current HEAD as well as
+	// older versions of dgraph to ensure that a change does not cause failures.
 	mainCombos := []UpgradeCombo{
 		{"v23.0.1", localVersion, BackupRestore},
 		{"v23.0.1", localVersion, InPlace},
+		{"v21.03.0", "4fc9cfd", BackupRestore},
+	}
+
+	if v20 {
+		fixedVersionCombos = append(fixedVersionCombos, []UpgradeCombo{
+			{"v20.11.2-rc1-25-g4400610b2", "4fc9cfd", BackupRestore},
+			{"v20.11.2-rc1-23-gaf5030a5", "4fc9cfd", BackupRestore},
+			{"v20.11.0-11-gb36b4862", "4fc9cfd", BackupRestore},
+		}...)
+
+		mainCombos = append(mainCombos, []UpgradeCombo{
+			{"v20.11.2-rc1-16-g4d041a3a", localVersion, BackupRestore},
+		}...)
 	}
 
 	if os.Getenv("DGRAPH_UPGRADE_MAIN_ONLY") == "true" {

--- a/dgraphtest/dgraph.go
+++ b/dgraphtest/dgraph.go
@@ -132,14 +132,13 @@ func (z *zero) bindings(offset int) nat.PortMap {
 }
 
 func (z *zero) cmd(c *LocalCluster) []string {
-	zcmd := []string{"/gobin/dgraph", "zero", "--telemetry=reports=false;sentry=false;",
-		fmt.Sprintf("--my=%s:%v", z.aname(), zeroGrpcPort), "--bindall",
+	zcmd := []string{"/gobin/dgraph", "zero", fmt.Sprintf("--my=%s:%v", z.aname(), zeroGrpcPort), "--bindall",
 		fmt.Sprintf(`--replicas=%v`, c.conf.replicas), "--logtostderr", fmt.Sprintf("-v=%d", c.conf.verbosity)}
 
 	if c.lowerThanV21 {
-		zcmd = append(zcmd, fmt.Sprintf(`--idx=%v`, z.id+1))
+		zcmd = append(zcmd, fmt.Sprintf(`--idx=%v`, z.id+1), "--telemetry=false")
 	} else {
-		zcmd = append(zcmd, fmt.Sprintf(`--raft=idx=%v`, z.id+1),
+		zcmd = append(zcmd, fmt.Sprintf(`--raft=idx=%v`, z.id+1), "--telemetry=reports=false;sentry=false;",
 			fmt.Sprintf(`--limit=refill-interval=%v;uid-lease=%v`, c.conf.refillInterval, c.conf.uidLease))
 	}
 
@@ -232,14 +231,14 @@ func (a *alpha) bindings(offset int) nat.PortMap {
 }
 
 func (a *alpha) cmd(c *LocalCluster) []string {
-	acmd := []string{"/gobin/dgraph", "alpha", "--telemetry=reports=false;sentry=false;",
-		fmt.Sprintf("--my=%s:%v", a.aname(), alphaInterPort),
+	acmd := []string{"/gobin/dgraph", "alpha", fmt.Sprintf("--my=%s:%v", a.aname(), alphaInterPort),
 		"--bindall", "--logtostderr", fmt.Sprintf("-v=%d", c.conf.verbosity)}
 
 	if c.lowerThanV21 {
-		acmd = append(acmd, `--whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16`)
+		acmd = append(acmd, `--whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16`, "--telemetry=false")
 	} else {
-		acmd = append(acmd, `--security=whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16`)
+		acmd = append(acmd, `--security=whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16`,
+			"--telemetry=reports=false;sentry=false;")
 	}
 
 	if c.conf.acl {


### PR DESCRIPTION
The --telemetry superflag was introduced in v21 version. Before that version of Dgraph, we did not have super flags. This commit also modifies upgrade configuration to include some versions of Dgraph in the upgrade tests that are run with each PR.