### PR TITLE
feat(dql): add keyword "every" to DQL

### DIFF
--- a/dql/parser.go
+++ b/dql/parser.go
@@ -2609,7 +2609,7 @@ func parseLanguageList(it *lex.ItemIterator) ([]string, error) {
 
 func validKeyAtRoot(k string) bool {
 	switch k {
-	case "func", "orderasc", "orderdesc", "first", "offset", "after":
+	case "func", "orderasc", "orderdesc", "first", "offset", "after", "every":
 		return true
 	case "from", "to", "numpaths", "minweight", "maxweight":
 		// Specific to shortest path
@@ -2623,7 +2623,7 @@ func validKeyAtRoot(k string) bool {
 // Check for validity of key at non-root nodes.
 func validKey(k string) bool {
 	switch k {
-	case "orderasc", "orderdesc", "first", "offset", "after":
+	case "orderasc", "orderdesc", "first", "offset", "after", "every":
 		return true
 	}
 	return false

--- a/query/query.go
+++ b/query/query.go
@@ -2399,8 +2399,8 @@ func ProcessGraph(ctx context.Context, sg, parent *SubGraph, rch chan error) {
 }
 
 // applies "every" to lists inside uidMatrix
-// the first node is selected from each of the uid lists, then every sg.Params.Every node
-// nodes are selected after applying first, offset and after
+// every 'every-th' uid is selected from the uid lists,
+// padding uids are considered when skipping uids from next list
 func (sg *SubGraph) applyEvery(ctx context.Context) error {
 	sg.updateUidMatrix()
 
@@ -2413,7 +2413,8 @@ func (sg *SubGraph) applyEvery(ctx context.Context) error {
 		uidsLen := (len(uidList) - offset) / every
 		uids := make([]uint64, uidsLen)
 		for j := 0; j < uidsLen; j++ {
-			uids[j] = uidList[j*every+offset]
+			// take the last uid of every-sized batches starting at offset
+			uids[j] = uidList[(j+1)*every-1+offset]
 		}
 		sg.uidMatrix[i].Uids = uids
 

--- a/query/query.go
+++ b/query/query.go
@@ -2407,15 +2407,20 @@ func ProcessGraph(ctx context.Context, sg, parent *SubGraph, rch chan error) {
 func (sg *SubGraph) applyEvery(ctx context.Context) error {
 	sg.updateUidMatrix()
 
+	offset := 0
 	every := sg.Params.Every
 	for i := 0; i < len(sg.uidMatrix); i++ {
 		uidList := codec.GetUids(sg.uidMatrix[i])
 
 		r := sroar.NewBitmap()
-		for j := 0; j < len(uidList); j += every {
+		for j := offset; j < len(uidList); j += every {
 			r.Set(uidList[j])
 		}
 		sg.uidMatrix[i].Bitmap = r.ToBuffer()
+
+		// there might be some uids after the last uid picked from uidList
+		// consider these as skipped, so skip that number of uids fewer from next list
+		offset = (offset - len(uidList) % every) % every
 	}
 
 	sg.DestMap = codec.Merge(sg.uidMatrix)

--- a/query/query.go
+++ b/query/query.go
@@ -2272,6 +2272,14 @@ func ProcessGraph(ctx context.Context, sg, parent *SubGraph, rch chan error) {
 		}
 	}
 
+	// We apply Every _before_ pagination, so we can paginate the result of Every
+	if sg.Params.Every > 1 {
+		if err := sg.applyEvery(ctx); err != nil {
+			rch <- err
+			return
+		}
+	}
+
 	if len(sg.Params.Order) == 0 && len(sg.Params.FacetsOrder) == 0 {
 		// for `has` function when there is no filtering and ordering, we fetch
 		// correct paginated results so no need to apply pagination here.
@@ -2290,14 +2298,6 @@ func ProcessGraph(ctx context.Context, sg, parent *SubGraph, rch chan error) {
 				rch <- err
 				return
 			}
-		}
-	}
-
-	// We apply Every _after_ pagination, so it refers to the respective page
-	if sg.Params.Every > 1 {
-		if err := sg.applyEvery(ctx); err != nil {
-			rch <- err
-			return
 		}
 	}
 

--- a/query/query4_test.go
+++ b/query/query4_test.go
@@ -1082,6 +1082,36 @@ func TestHasFirstOffsetEvery(t *testing.T) {
 	}`, js)
 }
 
+func TestHasAfterEvery(t *testing.T) {
+	query := `{
+		q(func:has(name), after: 0x18, every:10) {
+			 name
+		 }
+	 }`
+	js := processQueryNoErr(t, query)
+	require.JSONEq(t, `{
+		"data": {
+			"q": [
+			  {
+				"name": "Daryl Dixon"
+			  },
+			  {
+				"name": "E"
+			  },
+			  {
+				"name": "Bob"
+			  },
+			  {
+				"name": "School A"
+			  },
+			  {
+				"name": "Alice"
+			  }
+			]
+		  }
+	}`, js)
+}
+
 func TestCascadeSubQuery2(t *testing.T) {
 	query := `
 	{

--- a/query/query4_test.go
+++ b/query/query4_test.go
@@ -1013,20 +1013,12 @@ func TestHasEvery(t *testing.T) {
 				"name": "Alice"
 			  },
 			  {
-				"uid": "0xdaf",
-				"name": "Andrew"
+				"uid": "0x1001",
+				"name": "Badger"
 			  },
 			  {
-				"uid": "0xdaf",
-				"name": ""
-			  },
-			  {
-				"uid": "0x2715",
-				"name": "SF Bay Area"
-			  },
-			  {
-				"uid": "0x2715",
-				"name": "Bob"
+				"uid": "0x2000",
+				"name": "Regex Master"
 			  }
 			]
 		  }
@@ -1035,7 +1027,7 @@ func TestHasEvery(t *testing.T) {
 
 func TestHasEveryWithFirst(t *testing.T) {
 	query := `{
-		q(func:has(name), every:10, first: 2) {
+		q(func:has(name), first: 20, every:10) {
 			 uid
 			 name
 		 }
@@ -1059,7 +1051,7 @@ func TestHasEveryWithFirst(t *testing.T) {
 
 func TestHasEveryWithFirstOffset(t *testing.T) {
 	query := `{
-		q(func:has(name), every:10, first:2, offset:2) {
+		q(func:has(name), first:20, offset:20, every:10) {
 			 uid
 			 name
 		 }
@@ -1073,12 +1065,8 @@ func TestHasEveryWithFirstOffset(t *testing.T) {
 				"name": "Alice"
 			  },
 			  {
-				"uid": "0xdaf",
-				"name": "Andrew"
-			  },
-			  {
-				"uid": "0xdaf",
-				"name": ""
+				"uid": "0x1001",
+				"name": "Badger"
 			  }
 			]
 		  }
@@ -1087,7 +1075,7 @@ func TestHasEveryWithFirstOffset(t *testing.T) {
 
 func TestHasEveryWithAfter(t *testing.T) {
 	query := `{
-		q(func:has(name), every:10, after:0x36) {
+		q(func:has(name), after:0x36, every:10) {
 			 uid
 			 name
 		 }
@@ -1101,20 +1089,12 @@ func TestHasEveryWithAfter(t *testing.T) {
 				"name": "Alice"
 			  },
 			  {
-				"uid": "0xdaf",
-				"name": "Andrew"
+				"uid": "0x1001",
+				"name": "Badger"
 			  },
 			  {
-				"uid": "0xdaf",
-				"name": ""
-			  },
-			  {
-				"uid": "0x2715",
-				"name": "SF Bay Area"
-			  },
-			  {
-				"uid": "0x2715",
-				"name": "Bob"
+				"uid": "0x2000",
+				"name": "Regex Master"
 			  }
 			]
 		  }
@@ -1123,7 +1103,7 @@ func TestHasEveryWithAfter(t *testing.T) {
 
 func TestHasEveryWithFirstAfter(t *testing.T) {
 	query := `{
-		q(func:has(name), every: 10, first:2, after: 0x36) {
+		q(func:has(name), first:20, after: 0x36, every: 10) {
 			 uid
 			 name
 		 }
@@ -1137,12 +1117,8 @@ func TestHasEveryWithFirstAfter(t *testing.T) {
 				"name": "Alice"
 			  },
 			  {
-				"uid": "0xdaf",
-				"name": "Andrew"
-			  },
-			  {
-				"uid": "0xdaf",
-				"name": ""
+				"uid": "0x1001",
+				"name": "Badger"
 			  }
 			]
 		  }

--- a/query/query4_test.go
+++ b/query/query4_test.go
@@ -770,7 +770,7 @@ func TestHasOrderAscOffset(t *testing.T) {
 
 func TestHasFirst(t *testing.T) {
 	query := `{
-		q(func:has(name),first:5) {
+		q(func:has(name), first:5) {
 			 name
 		 }
 	 }`
@@ -887,7 +887,7 @@ func TestRegExpVariableReplacement(t *testing.T) {
 
 func TestHasFirstOffset(t *testing.T) {
 	query := `{
-		q(func:has(name),first:5, offset: 5) {
+		q(func:has(name), first:5, offset: 5) {
 			 name
 		 }
 	 }`
@@ -953,6 +953,7 @@ func TestHasFilterOrderOffset(t *testing.T) {
 		  }
 	}`, js)
 }
+
 func TestCascadeSubQuery1(t *testing.T) {
 	query := `
 	{
@@ -985,6 +986,99 @@ func TestCascadeSubQuery1(t *testing.T) {
 				}
 			]
 		}
+	}`, js)
+}
+
+func TestHasEvery(t *testing.T) {
+	query := `{
+		q(func:has(name), every:10) {
+			 name
+		 }
+	 }`
+	js := processQueryNoErr(t, query)
+	require.JSONEq(t, `{
+		"data": {
+			"q": [
+			  {
+				"name": "Michonne"
+			  },
+			  {
+				"name": "Daryl Dixon"
+			  },
+			  {
+				"name": "E"
+			  },
+			  {
+				"name": "Bob"
+			  },
+			  {
+				"name": "School A"
+			  },
+			  {
+				"name": "Alice"
+			  }
+			]
+		  }
+	}`, js)
+}
+
+func TestHasFirstEvery(t *testing.T) {
+	query := `{
+		q(func:has(name), first: 10, every:2) {
+			 name
+		 }
+	 }`
+	js := processQueryNoErr(t, query)
+	require.JSONEq(t, `{
+		"data": {
+			"q": [
+			  {
+				"name": "Michonne"
+			  },
+			  {
+				"name": "Margaret"
+			  },
+			  {
+				"name": "Garfield"
+			  },
+			  {
+				"name": "Nemo"
+			  },
+			  {
+				"name": "Rick Grimes"
+			  }
+			]
+		  }
+	}`, js)
+}
+
+func TestHasFirstOffsetEvery(t *testing.T) {
+	query := `{
+		q(func:has(name), first: 10, offset:1, every:2) {
+			 name
+		 }
+	 }`
+	js := processQueryNoErr(t, query)
+	require.JSONEq(t, `{
+		"data": {
+			"q": [
+			  {
+				"name": "King Lear"
+			  },
+			  {
+				"name": "Leonard"
+			  },
+			  {
+				"name": "Bear"
+			  },
+			  {
+				"name": "name"
+			  },
+			  {
+				"name": "Glenn Rhee"
+			  }
+			]
+		  }
 	}`, js)
 }
 

--- a/query/query4_test.go
+++ b/query/query4_test.go
@@ -1139,6 +1139,10 @@ func TestHasEveryWithFirstAfter(t *testing.T) {
 			  {
 				"uid": "0xdaf",
 				"name": "Andrew"
+			  },
+			  {
+				"uid": "0xdaf",
+				"name": ""
 			  }
 			]
 		  }

--- a/query/query4_test.go
+++ b/query/query4_test.go
@@ -770,7 +770,7 @@ func TestHasOrderAscOffset(t *testing.T) {
 
 func TestHasFirst(t *testing.T) {
 	query := `{
-		q(func:has(name), first:5) {
+		q(func:has(name),first:5) {
 			 name
 		 }
 	 }`
@@ -887,7 +887,7 @@ func TestRegExpVariableReplacement(t *testing.T) {
 
 func TestHasFirstOffset(t *testing.T) {
 	query := `{
-		q(func:has(name), first:5, offset: 5) {
+		q(func:has(name),first:5, offset: 5) {
 			 name
 		 }
 	 }`
@@ -992,6 +992,7 @@ func TestCascadeSubQuery1(t *testing.T) {
 func TestHasEvery(t *testing.T) {
 	query := `{
 		q(func:has(name), every:10) {
+			 uid
 			 name
 		 }
 	 }`
@@ -1000,31 +1001,42 @@ func TestHasEvery(t *testing.T) {
 		"data": {
 			"q": [
 			  {
-				"name": "Michonne"
+				"uid": "0x18",
+				"name": "Glenn Rhee"
 			  },
 			  {
-				"name": "Daryl Dixon"
+				"uid": "0x36",
+				"name": "D"
 			  },
 			  {
-				"name": "E"
-			  },
-			  {
-				"name": "Bob"
-			  },
-			  {
-				"name": "School A"
-			  },
-			  {
+				"uid": "0x3e8",
 				"name": "Alice"
+			  },
+			  {
+				"uid": "0xdaf",
+				"name": "Andrew"
+			  },
+			  {
+				"uid": "0xdaf",
+				"name": ""
+			  },
+			  {
+				"uid": "0x2715",
+				"name": "SF Bay Area"
+			  },
+			  {
+				"uid": "0x2715",
+				"name": "Bob"
 			  }
 			]
 		  }
 	}`, js)
 }
 
-func TestHasFirstEvery(t *testing.T) {
+func TestHasEveryWithFirst(t *testing.T) {
 	query := `{
 		q(func:has(name), every:10, first: 2) {
+			 uid
 			 name
 		 }
 	 }`
@@ -1033,19 +1045,22 @@ func TestHasFirstEvery(t *testing.T) {
 		"data": {
 			"q": [
 			  {
-				"name": "Michonne"
+				"uid": "0x18",
+				"name": "Glenn Rhee"
 			  },
 			  {
-				"name": "Daryl Dixon"
+				"uid": "0x36",
+				"name": "D"
 			  }
 			]
 		  }
 	}`, js)
 }
 
-func TestHasFirstOffsetEvery(t *testing.T) {
+func TestHasEveryWithFirstOffset(t *testing.T) {
 	query := `{
-		q(func:has(name), every:10, first: 2, offset:2) {
+		q(func:has(name), every:10, first:2, offset:2) {
+			 uid
 			 name
 		 }
 	 }`
@@ -1054,40 +1069,76 @@ func TestHasFirstOffsetEvery(t *testing.T) {
 		"data": {
 			"q": [
 			  {
-				"name": "E"
-			  },
-			  {
-				"name": "Bob"
-			  }
-			]
-		  }
-	}`, js)
-}
-
-func TestHasAfterEvery(t *testing.T) {
-	query := `{
-		q(func:has(name), after: 0x18, every:10) {
-			 name
-		 }
-	 }`
-	js := processQueryNoErr(t, query)
-	require.JSONEq(t, `{
-		"data": {
-			"q": [
-			  {
-				"name": "Daryl Dixon"
-			  },
-			  {
-				"name": "E"
-			  },
-			  {
-				"name": "Bob"
-			  },
-			  {
-				"name": "School A"
-			  },
-			  {
+				"uid": "0x3e8",
 				"name": "Alice"
+			  },
+			  {
+				"uid": "0xdaf",
+				"name": "Andrew"
+			  },
+			  {
+				"uid": "0xdaf",
+				"name": ""
+			  }
+			]
+		  }
+	}`, js)
+}
+
+func TestHasEveryWithAfter(t *testing.T) {
+	query := `{
+		q(func:has(name), every:10, after:0x36) {
+			 uid
+			 name
+		 }
+	 }`
+	js := processQueryNoErr(t, query)
+	require.JSONEq(t, `{
+		"data": {
+			"q": [
+			  {
+				"uid": "0x3e8",
+				"name": "Alice"
+			  },
+			  {
+				"uid": "0xdaf",
+				"name": "Andrew"
+			  },
+			  {
+				"uid": "0xdaf",
+				"name": ""
+			  },
+			  {
+				"uid": "0x2715",
+				"name": "SF Bay Area"
+			  },
+			  {
+				"uid": "0x2715",
+				"name": "Bob"
+			  }
+			]
+		  }
+	}`, js)
+}
+
+func TestHasEveryWithFirstAfter(t *testing.T) {
+	query := `{
+		q(func:has(name), every: 10, first:2, after: 0x36) {
+			 uid
+			 name
+		 }
+	 }`
+	js := processQueryNoErr(t, query)
+	require.JSONEq(t, `{
+		"data": {
+			"q": [
+			  {
+				"uid": "0x3e8",
+				"name": "Alice"
+			  },
+			  {
+				"uid": "0xdaf",
+				"name": "Andrew"
 			  }
 			]
 		  }

--- a/query/query4_test.go
+++ b/query/query4_test.go
@@ -1024,7 +1024,7 @@ func TestHasEvery(t *testing.T) {
 
 func TestHasFirstEvery(t *testing.T) {
 	query := `{
-		q(func:has(name), first: 10, every:2) {
+		q(func:has(name), every:10, first: 2) {
 			 name
 		 }
 	 }`
@@ -1036,16 +1036,7 @@ func TestHasFirstEvery(t *testing.T) {
 				"name": "Michonne"
 			  },
 			  {
-				"name": "Margaret"
-			  },
-			  {
-				"name": "Garfield"
-			  },
-			  {
-				"name": "Nemo"
-			  },
-			  {
-				"name": "Rick Grimes"
+				"name": "Daryl Dixon"
 			  }
 			]
 		  }
@@ -1054,7 +1045,7 @@ func TestHasFirstEvery(t *testing.T) {
 
 func TestHasFirstOffsetEvery(t *testing.T) {
 	query := `{
-		q(func:has(name), first: 10, offset:1, every:2) {
+		q(func:has(name), every:10, first: 2, offset:2) {
 			 name
 		 }
 	 }`
@@ -1063,19 +1054,10 @@ func TestHasFirstOffsetEvery(t *testing.T) {
 		"data": {
 			"q": [
 			  {
-				"name": "King Lear"
+				"name": "E"
 			  },
 			  {
-				"name": "Leonard"
-			  },
-			  {
-				"name": "Bear"
-			  },
-			  {
-				"name": "name"
-			  },
-			  {
-				"name": "Glenn Rhee"
+				"name": "Bob"
 			  }
 			]
 		  }


### PR DESCRIPTION
This adds the keyword `every` to DQL, which picks equidistant nodes. This provides a deterministic sample of the result that is proportional in size. It can be combined with `first`, `offset`, and `after`. Pagination is applied **before** `every`.

This supersedes #8107

Docs PR: None