### PR TITLE
fix(export): Support for any s3 endpoint

### DIFF
--- a/x/minioclient.go
+++ b/x/minioclient.go
@@ -10,7 +10,6 @@ import (
 	"github.com/golang/glog"
 	minio "github.com/minio/minio-go/v6"
 	"github.com/minio/minio-go/v6/pkg/credentials"
-	"github.com/minio/minio-go/v6/pkg/s3utils"
 	"github.com/pkg/errors"
 )
 

--- a/x/minioclient.go
+++ b/x/minioclient.go
@@ -90,9 +90,6 @@ func NewMinioClient(uri *url.URL, creds *MinioCredentials) (*MinioClient, error)
 		if !strings.Contains(uri.Host, ".") {
 			uri.Host = defaultEndpointS3
 		}
-		if !s3utils.IsAmazonEndpoint(*uri) {
-			return nil, errors.Errorf("Invalid S3 endpoint %q", uri.Host)
-		}
 	default: // minio
 		if uri.Host == "" {
 			return nil, errors.Errorf("Minio handler requires a host")


### PR DESCRIPTION
Description: Many blob storage providers support the S3 API, e.g.: Cloudflare R2, Backblaze B2. This fix allows to use any S3 endpoint.
Fixes: #8940
