### PR TITLE
perf(query): Update CompressedBin IntersectionAlgo

### DIFF
--- a/algo/uidlist.go
+++ b/algo/uidlist.go
@@ -112,14 +112,11 @@ func IntersectCompressedWithBin(dec *codec.Decoder, q []uint64, o *[]uint64) {
 			if len(blockUids) == 0 {
 				break
 			}
-			if ld*linVsBinRatio < len(q) {
-				q = q[IntersectWithBin(blockUids, q, o):]
-			} else {
-				// For small enough difference between two arrays, we should just
-				// do lin intersect
-				_, off := IntersectWithLin(blockUids, q, o)
-				q = q[off:]
+			_, off := IntersectWithJump(blockUids, q, o)
+			if off == 0 {
+				off = 1 // if v[k] isn't in u, move forward
 			}
+			q = q[off:]
 			if len(q) == 0 {
 				return
 			}

--- a/algo/uidlist.go
+++ b/algo/uidlist.go
@@ -60,7 +60,7 @@ func IntersectCompressedWith(pack *pb.UidPack, afterUID uint64, v, o *pb.List) {
 
 	// Select appropriate function based on heuristics.
 	ratio := float64(m) / float64(n)
-	if ratio < 100 {
+	if ratio < 10 {
 		IntersectCompressedWithLinJump(&dec, v.Uids, &dst)
 	} else {
 		IntersectCompressedWithBin(&dec, v.Uids, &dst)

--- a/algo/uidlist.go
+++ b/algo/uidlist.go
@@ -113,9 +113,6 @@ func IntersectCompressedWithBin(dec *codec.Decoder, q []uint64, o *[]uint64) {
 				break
 			}
 			_, off := IntersectWithJump(blockUids, q, o)
-			if off == 0 {
-				off = 1 // if v[k] isn't in u, move forward
-			}
 			q = q[off:]
 			if len(q) == 0 {
 				return

--- a/algo/uidlist.go
+++ b/algo/uidlist.go
@@ -128,9 +128,8 @@ func IntersectCompressedWithBin(dec *codec.Decoder, q []uint64, o *[]uint64) {
 	}
 
 	uids := dec.Uids()
-	qidx := -1
+	qidx := 0
 	for {
-		qidx += 1
 		if qidx >= len(q) {
 			return
 		}
@@ -139,7 +138,7 @@ func IntersectCompressedWithBin(dec *codec.Decoder, q []uint64, o *[]uint64) {
 			if lq*10 < ld {
 				uids = dec.LinearSeek(u)
 			} else {
-				uids = dec.SeekToBlock(u, codec.SeekStart)
+				uids = dec.SeekToBlock(u, codec.SeekCurrent)
 			}
 			if len(uids) == 0 {
 				return

--- a/algo/uidlist.go
+++ b/algo/uidlist.go
@@ -113,23 +113,16 @@ func IntersectCompressedWithBin(dec *codec.Decoder, q []uint64, o *[]uint64) {
 			}
 			if ld*10 < len(q) {
 				q = q[IntersectWithBin(blockUids, q, o):]
-				dec.Next()
 			} else {
 				// For small enough difference between two arrays, we should just
 				// do lin intersect
 				_, off := IntersectWithLin(blockUids, q, o)
-				if off == 0 {
-					off = 1
-				}
-				if off == len(q) {
-					return
-				}
 				q = q[off:]
-				if len(q) == 0 {
-					return
-				}
-				dec.Seek(q[0], codec.SeekStart)
 			}
+			if len(q) == 0 {
+				return
+			}
+			dec.Next()
 		}
 		return
 	}

--- a/algo/uidlist_test.go
+++ b/algo/uidlist_test.go
@@ -502,6 +502,43 @@ func sortUint64(nums []uint64) {
 	sort.Slice(nums, func(i, j int) bool { return nums[i] < nums[j] })
 }
 
+func fillNumsDiff(N1, N2, N3 int) ([]uint64, []uint64, []uint64) {
+	rand.Seed(time.Now().UnixNano())
+
+	commonNums := make([]uint64, N1)
+	blockNums := make([]uint64, N1+N2)
+	otherNums := make([]uint64, N1+N3)
+	allC := make(map[uint64]bool)
+
+	for i := 0; i < N1; i++ {
+		val := rand.Uint64() % 1000
+		commonNums[i] = val
+		blockNums[i] = val
+		otherNums[i] = val
+		allC[val] = true
+	}
+
+	for i := N1; i < N1+N2; i++ {
+		val := rand.Uint64() % 1000
+		blockNums[i] = val
+		allC[val] = true
+	}
+
+	for i := N1; i < N1+N3; i++ {
+		val := rand.Uint64()
+		for ok := true; ok; _, ok = allC[val] {
+			val = rand.Uint64() % 1000
+		}
+		otherNums[i] = val
+	}
+
+	sortUint64(commonNums)
+	sortUint64(blockNums)
+	sortUint64(otherNums)
+
+	return commonNums, blockNums, otherNums
+}
+
 func fillNums(N1, N2 int) ([]uint64, []uint64, []uint64) {
 	rand.Seed(time.Now().UnixNano())
 
@@ -554,12 +591,12 @@ func TestIntersectCompressedWithLinJump(t *testing.T) {
 }
 
 func TestIntersectCompressedWithBin(t *testing.T) {
-	lengths := []int{0, 1, 3, 11, 100, 500, 1000}
+	//lengths := []int{0, 1, 3, 11, 100, 500, 1000}
 
-	for _, N1 := range lengths {
-		for _, N2 := range lengths {
+	for _, N1 := range []int{11} {
+		for _, N2 := range []int{3} {
 			// Intersection of blockNums and otherNums is commonNums.
-			commonNums, blockNums, otherNums := fillNums(N1, N2)
+			commonNums, blockNums, otherNums := fillNumsDiff(N1/10, N1, N2)
 
 			enc := codec.Encoder{BlockSize: 10}
 			for _, num := range blockNums {

--- a/algo/uidlist_test.go
+++ b/algo/uidlist_test.go
@@ -373,7 +373,7 @@ func BenchmarkListIntersectCompressBin(b *testing.B) {
 		for _, r := range rs {
 			sz1 := sz
 			sz2 := int(float64(sz) * r)
-			if sz2 > 1000000 || sz2 == 0 {
+			if sz2 > 10000000 || sz2 == 0 {
 				break
 			}
 

--- a/algo/uidlist_test.go
+++ b/algo/uidlist_test.go
@@ -389,7 +389,17 @@ func BenchmarkListIntersectCompressBin(b *testing.B) {
 			sort.Slice(v1, func(i, j int) bool { return v1[i] < v1[j] })
 
 			dst2 := &pb.List{}
+			dst1 := &pb.List{}
 			compressedUids := codec.Encode(v1, 256)
+
+			b.Run(fmt.Sprintf("linJump:IntersectWith:ratio=%v:size=%d:overlap=%.2f:", r, sz, overlap),
+				func(b *testing.B) {
+					for k := 0; k < b.N; k++ {
+						dec := codec.Decoder{Pack: compressedUids}
+						dec.Seek(0, codec.SeekStart)
+						IntersectCompressedWithLinJump(&dec, u1, &dst1.Uids)
+					}
+				})
 
 			b.Run(fmt.Sprintf("compressed:IntersectWith:ratio=%v:size=%d:overlap=%.2f:", r, sz, overlap),
 				func(b *testing.B) {
@@ -399,7 +409,6 @@ func BenchmarkListIntersectCompressBin(b *testing.B) {
 						IntersectCompressedWithBin(&dec, u1, &dst2.Uids)
 					}
 				})
-			fmt.Println()
 
 			codec.FreePack(compressedUids)
 		}

--- a/algo/uidlist_test.go
+++ b/algo/uidlist_test.go
@@ -554,7 +554,7 @@ func TestIntersectCompressedWithLinJump(t *testing.T) {
 }
 
 func TestIntersectCompressedWithBin(t *testing.T) {
-	lengths := []int{0, 1, 3, 11, 100}
+	lengths := []int{0, 1, 3, 11, 100, 500, 1000}
 
 	for _, N1 := range lengths {
 		for _, N2 := range lengths {
@@ -579,7 +579,7 @@ func TestIntersectCompressedWithBin(t *testing.T) {
 }
 
 func TestIntersectCompressedWithBinMissingSize(t *testing.T) {
-	lengths := []int{0, 1, 3, 11, 100}
+	lengths := []int{0, 1, 3, 11, 100, 500, 1000}
 
 	for _, N1 := range lengths {
 		for _, N2 := range lengths {

--- a/codec/codec.go
+++ b/codec/codec.go
@@ -286,59 +286,39 @@ func (d *Decoder) Seek(uid uint64, whence seekPos) []uint64 {
 	if d.Pack == nil {
 		return []uint64{}
 	}
-
-	prevBlockIdx := d.blockIdx
-	pack := d.Pack
-	blocksToSearch := pack.Blocks
-	offset := 0
-	if len(d.uids) > 0 {
-		first := d.uids[0]
-		second := d.uids[len(d.uids)-1]
-
-		if uid >= first && uid <= second {
-			blocksToSearch = nil
-		} else if uid > second {
-			blocksToSearch = blocksToSearch[prevBlockIdx:]
-			offset = prevBlockIdx
-		} else {
-			blocksToSearch = blocksToSearch[:prevBlockIdx]
-		}
-	}
-
+	d.blockIdx = 0
 	if uid == 0 {
 		return d.UnpackBlock()
 	}
 
+	pack := d.Pack
 	blocksFunc := func() searchFunc {
 		var f searchFunc
 		switch whence {
 		case SeekStart:
-			f = func(i int) bool { return blocksToSearch[i].Base >= uid }
+			f = func(i int) bool { return pack.Blocks[i].Base >= uid }
 		case SeekCurrent:
-			f = func(i int) bool { return blocksToSearch[i].Base > uid }
+			f = func(i int) bool { return pack.Blocks[i].Base > uid }
 		}
 		return f
+	}
+
+	idx := sort.Search(len(pack.Blocks), blocksFunc())
+	// The first block.Base >= uid.
+	if idx == 0 {
+		return d.UnpackBlock()
+	}
+	// The uid is the first entry in the block.
+	if idx < len(pack.Blocks) && pack.Blocks[idx].Base == uid {
+		d.blockIdx = idx
+		return d.UnpackBlock()
 	}
 
 	// Either the idx = len(pack.Blocks) that means it wasn't found in any of the block's base. Or,
 	// we found the first block index whose base is greater than uid. In these cases, go to the
 	// previous block and search there.
-	if blocksToSearch != nil {
-		idx := sort.Search(len(blocksToSearch), blocksFunc()) + offset
-		// The first block.Base >= uid.
-		if idx == 0 {
-			return d.UnpackBlock()
-		}
-
-		// The uid is the first entry in the block.
-		if idx < len(pack.Blocks) && pack.Blocks[idx].Base == uid {
-			d.blockIdx = idx
-			return d.UnpackBlock()
-		}
-
-		d.blockIdx = idx - 1 // Move to the previous block. If blockIdx<0, unpack will deal with it.
-		d.UnpackBlock()      // And get all their uids.
-	}
+	d.blockIdx = idx - 1 // Move to the previous block. If blockIdx<0, unpack will deal with it.
+	d.UnpackBlock()      // And get all their uids.
 
 	uidsFunc := func() searchFunc {
 		var f searchFunc

--- a/codec/codec.go
+++ b/codec/codec.go
@@ -236,6 +236,11 @@ func (d *Decoder) SeekToBlock(uid uint64, whence seekPos) []uint64 {
 		return d.UnpackBlock()
 	}
 
+	// If for some reason we are searching an older uid, we need to search the entire pack
+	if prevBlockIdx > 0 && uid < d.Pack.Blocks[prevBlockIdx].Base {
+		prevBlockIdx = 0
+	}
+
 	pack := d.Pack
 	blocksFunc := func() searchFunc {
 		var f searchFunc
@@ -267,7 +272,7 @@ func (d *Decoder) SeekToBlock(uid uint64, whence seekPos) []uint64 {
 		d.UnpackBlock() // And get all their uids.
 	}
 
-	if uid < d.uids[len(d.uids)-1] {
+	if uid <= d.uids[len(d.uids)-1] {
 		return d.uids
 	}
 


### PR DESCRIPTION
Updated algo to intersect. Getting upto 175% improvment overall
```
goos: linux
goarch: amd64
pkg: github.com/dgraph-io/dgraph/algo
cpu: 11th Gen Intel(R) Core(TM) i7-1185G7 @ 3.00GHz
                                                                                          │     in1      │                 main_in                 │
                                                                                          │    sec/op    │    sec/op      vs base                  │
ListIntersectCompressBin/compressed:IntersectWith:ratio=0.01:size=100:overlap=0.01:-8       91.21n ± ∞ ¹   387.70n ± ∞ ¹         ~ (p=1.000 n=1) ²
ListIntersectCompressBin/compressed:IntersectWith:ratio=0.1:size=100:overlap=0.01:-8        336.0n ± ∞ ¹   1733.0n ± ∞ ¹         ~ (p=1.000 n=1) ²
ListIntersectCompressBin/compressed:IntersectWith:ratio=1:size=100:overlap=0.01:-8          1.093µ ± ∞ ¹    3.481µ ± ∞ ¹         ~ (p=1.000 n=1) ²
ListIntersectCompressBin/compressed:IntersectWith:ratio=10:size=100:overlap=0.01:-8         4.719µ ± ∞ ¹    8.600µ ± ∞ ¹         ~ (p=1.000 n=1) ²
ListIntersectCompressBin/compressed:IntersectWith:ratio=100:size=100:overlap=0.01:-8        19.76µ ± ∞ ¹    44.32µ ± ∞ ¹         ~ (p=1.000 n=1) ²
ListIntersectCompressBin/compressed:IntersectWith:ratio=0.01:size=1000:overlap=0.01:-8      481.7n ± ∞ ¹    784.2n ± ∞ ¹         ~ (p=1.000 n=1) ²
ListIntersectCompressBin/compressed:IntersectWith:ratio=0.1:size=1000:overlap=0.01:-8       1.502µ ± ∞ ¹    3.667µ ± ∞ ¹         ~ (p=1.000 n=1) ²
ListIntersectCompressBin/compressed:IntersectWith:ratio=1:size=1000:overlap=0.01:-8         5.454µ ± ∞ ¹   36.977µ ± ∞ ¹         ~ (p=1.000 n=1) ²
ListIntersectCompressBin/compressed:IntersectWith:ratio=10:size=1000:overlap=0.01:-8        33.14µ ± ∞ ¹    70.73µ ± ∞ ¹         ~ (p=1.000 n=1) ²
ListIntersectCompressBin/compressed:IntersectWith:ratio=100:size=1000:overlap=0.01:-8       179.8µ ± ∞ ¹    485.1µ ± ∞ ¹         ~ (p=1.000 n=1) ²
ListIntersectCompressBin/compressed:IntersectWith:ratio=0.01:size=10000:overlap=0.01:-8     3.214µ ± ∞ ¹    4.459µ ± ∞ ¹         ~ (p=1.000 n=1) ²
ListIntersectCompressBin/compressed:IntersectWith:ratio=0.1:size=10000:overlap=0.01:-8      12.00µ ± ∞ ¹    32.78µ ± ∞ ¹         ~ (p=1.000 n=1) ²
ListIntersectCompressBin/compressed:IntersectWith:ratio=1:size=10000:overlap=0.01:-8        76.90µ ± ∞ ¹   356.05µ ± ∞ ¹         ~ (p=1.000 n=1) ²
ListIntersectCompressBin/compressed:IntersectWith:ratio=10:size=10000:overlap=0.01:-8       371.6µ ± ∞ ¹    923.1µ ± ∞ ¹         ~ (p=1.000 n=1) ²
ListIntersectCompressBin/compressed:IntersectWith:ratio=100:size=10000:overlap=0.01:-8      1.894m ± ∞ ¹    5.141m ± ∞ ¹         ~ (p=1.000 n=1) ²
ListIntersectCompressBin/compressed:IntersectWith:ratio=0.01:size=100000:overlap=0.01:-8    48.13µ ± ∞ ¹    60.59µ ± ∞ ¹         ~ (p=1.000 n=1) ²
ListIntersectCompressBin/compressed:IntersectWith:ratio=0.1:size=100000:overlap=0.01:-8     146.7µ ± ∞ ¹    611.9µ ± ∞ ¹         ~ (p=1.000 n=1) ²
ListIntersectCompressBin/compressed:IntersectWith:ratio=1:size=100000:overlap=0.01:-8       943.7µ ± ∞ ¹   3359.6µ ± ∞ ¹         ~ (p=1.000 n=1) ²
ListIntersectCompressBin/compressed:IntersectWith:ratio=10:size=100000:overlap=0.01:-8      3.926m ± ∞ ¹    8.849m ± ∞ ¹         ~ (p=1.000 n=1) ²
ListIntersectCompressBin/compressed:IntersectWith:ratio=100:size=100000:overlap=0.01:-8     20.78m ± ∞ ¹
ListIntersectCompressBin/compressed:IntersectWith:ratio=0.01:size=1000000:overlap=0.01:-8   862.4µ ± ∞ ¹   1142.5µ ± ∞ ¹         ~ (p=1.000 n=1) ²
ListIntersectCompressBin/compressed:IntersectWith:ratio=0.1:size=1000000:overlap=0.01:-8    1.599m ± ∞ ¹    7.878m ± ∞ ¹         ~ (p=1.000 n=1) ²
ListIntersectCompressBin/compressed:IntersectWith:ratio=1:size=1000000:overlap=0.01:-8      9.791m ± ∞ ¹   33.871m ± ∞ ¹         ~ (p=1.000 n=1) ²
ListIntersectCompressBin/compressed:IntersectWith:ratio=10:size=1000000:overlap=0.01:-8     44.40m ± ∞ ¹
geomean                                                                                     66.19µ          104.6µ        +175.93%               ³
                    

```