### PR TITLE
ci(runners): use larger github hosted runners + reduce cron frequency

### DIFF
--- a/.github/workflows/ci-dgraph-code-coverage.yml
+++ b/.github/workflows/ci-dgraph-code-coverage.yml
@@ -24,8 +24,7 @@ on:
       - 'release/**'
 jobs:
   dgraph-code-coverage:
-    runs-on: [self-hosted, x64]
-    # runs-on: ubuntu-20.04
+    runs-on: ubuntu-20.04-32gb
     steps:
       - uses: actions/checkout@v3 # defaults to SHA of event that triggered workflow
       - name: Get Go Version

--- a/.github/workflows/ci-dgraph-fuzz.yml
+++ b/.github/workflows/ci-dgraph-fuzz.yml
@@ -14,7 +14,7 @@ on:
       - main
       - 'release/**'
   schedule:
-    - cron: "1 */8 * * *" # every 8hrs
+    - cron: "0 0 * * *" # 1 run per day
 jobs:
   fuzz-test:
     runs-on: ubuntu-20.04

--- a/.github/workflows/ci-dgraph-integration2-tests.yml
+++ b/.github/workflows/ci-dgraph-integration2-tests.yml
@@ -14,7 +14,7 @@ on:
       - main
       - 'release/**'
   schedule:
-    - cron: "1 */4 * * *" # every 4hrs
+    - cron: "0 0 * * *" # 1 run per day
 jobs:
   dgraph-integration2-tests:
     if: github.event.pull_request.draft == false

--- a/.github/workflows/ci-dgraph-ldbc-tests.yml
+++ b/.github/workflows/ci-dgraph-ldbc-tests.yml
@@ -32,7 +32,7 @@ on:
       - main
       - 'release/**'
   schedule:
-    - cron: "1 0 * * *" # 1-run per day
+    - cron: "0 0 * * *" # 1-run per day
 jobs:
   dgraph-ldbc-tests:
     if: github.event.pull_request.draft == false

--- a/.github/workflows/ci-dgraph-load-tests.yml
+++ b/.github/workflows/ci-dgraph-load-tests.yml
@@ -32,11 +32,11 @@ on:
       - main
       - 'release/**'
   schedule:
-    - cron: "1 0,6,12,18 * * *"
+    - cron: "0 0 * * *" # 1 run per day
 jobs:
   dgraph-load-tests:
     if: github.event.pull_request.draft == false
-    runs-on: [self-hosted, x64]
+    runs-on: ubuntu-20.04-32gb
     steps:
       - uses: actions/checkout@v3
       - name: Get Go Version

--- a/.github/workflows/ci-dgraph-oss-build.yml
+++ b/.github/workflows/ci-dgraph-oss-build.yml
@@ -32,7 +32,7 @@ on:
       - main
       - 'release/**'
   schedule:
-    - cron: "1 0,6,12,18 * * *"
+    - cron: "0 0 * * *" # 1 run per day
 jobs:
   dgraph-oss-build:
     if: github.event.pull_request.draft == false

--- a/.github/workflows/ci-dgraph-tests-arm64.yml
+++ b/.github/workflows/ci-dgraph-tests-arm64.yml
@@ -32,7 +32,7 @@ on:
       - main
       - 'release/**'
   schedule:
-    - cron: "1 0,6,12,18 * * *"
+    - cron: "0 0 * * *" # 1 run per day
 jobs:
   dgraph-tests:
     if: github.event.pull_request.draft == false

--- a/.github/workflows/ci-dgraph-tests-arm64.yml
+++ b/.github/workflows/ci-dgraph-tests-arm64.yml
@@ -22,15 +22,6 @@ on:
     branches:
       - main
       - 'release/**'
-  pull_request:
-    types:
-      - opened
-      - reopened
-      - synchronize
-      - ready_for_review
-    branches:
-      - main
-      - 'release/**'
   schedule:
     - cron: "0 0 * * *" # 1 run per day
 jobs:

--- a/.github/workflows/ci-dgraph-tests.yml
+++ b/.github/workflows/ci-dgraph-tests.yml
@@ -32,11 +32,11 @@ on:
       - main
       - 'release/**'
   schedule:
-    - cron: "1 0,6,12,18 * * *"
+    - cron: "0 0 * * *" # 1 run per day
 jobs:
   dgraph-tests:
     if: github.event.pull_request.draft == false
-    runs-on: [self-hosted, x64]
+    runs-on: ubuntu-20.04-32gb 
     steps:
       - uses: actions/checkout@v3
       - name: Get Go Version

--- a/.github/workflows/ci-dgraph-upgrade-fixed-versions-tests.yml
+++ b/.github/workflows/ci-dgraph-upgrade-fixed-versions-tests.yml
@@ -1,10 +1,10 @@
 name: ci-dgraph-upgrade-fixed-versions-tests
 on:
   schedule:
-    - cron: "1 */12 * * *" # every 12hrs
+    - cron: "0 3 * *" # 1 run per day
 jobs:
   dgraph-upgrade-fixed-versions-tests:
-    runs-on: [self-hosted, x64]
+    runs-on: ubuntu-20.04-32gb 
     timeout-minutes: 720
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci-dgraph-upgrade-tests.yml
+++ b/.github/workflows/ci-dgraph-upgrade-tests.yml
@@ -4,9 +4,6 @@ on:
     branches:
       - main
       - 'release/**'
-    branches:
-      - main
-      - 'release/**'
   schedule:
     - cron: "0 0 * * *" # 1 run per day
 jobs:

--- a/.github/workflows/ci-dgraph-upgrade-tests.yml
+++ b/.github/workflows/ci-dgraph-upgrade-tests.yml
@@ -4,12 +4,6 @@ on:
     branches:
       - main
       - 'release/**'
-  pull_request:
-    types:
-      - opened
-      - reopened
-      - synchronize
-      - ready_for_review
     branches:
       - main
       - 'release/**'

--- a/.github/workflows/ci-dgraph-upgrade-tests.yml
+++ b/.github/workflows/ci-dgraph-upgrade-tests.yml
@@ -14,11 +14,11 @@ on:
       - main
       - 'release/**'
   schedule:
-    - cron: "1 */4 * * *" # every 4hrs
+    - cron: "0 0 * * *" # 1 run per day
 jobs:
   dgraph-upgrade-tests:
     if: github.event.pull_request.draft == false
-    runs-on: [self-hosted, x64]
+    runs-on: ubuntu-20.04-32gb 
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
Description: Currently we use large 32gb self-hosted runners for jobs that require more resources.  Github now offers their own suite of hosted runners.  We can now transition to these new runners.  We also reduce the frequency of some scheduled jobs and remove some particular workflows from each PR run.