### PR TITLE
fix(raft):alpha leader fails to stream snapshot to new alpha nodes

### DIFF
--- a/dgraphtest/config.go
+++ b/dgraphtest/config.go
@@ -100,23 +100,25 @@ func AllUpgradeCombos(v20 bool) []UpgradeCombo {
 
 // ClusterConfig stores all config for setting up a dgraph cluster
 type ClusterConfig struct {
-	prefix         string
-	numAlphas      int
-	numZeros       int
-	replicas       int
-	verbosity      int
-	acl            bool
-	aclTTL         time.Duration
-	aclAlg         jwt.SigningMethod
-	encryption     bool
-	version        string
-	volumes        map[string]string
-	refillInterval time.Duration
-	uidLease       int
-	portOffset     int // exposed port offset for grpc/http port for both alpha/zero
-	bulkOutDir     string
-	featureFlags   []string
-	customPlugins  bool
+	prefix                string
+	numAlphas             int
+	numZeros              int
+	replicas              int
+	verbosity             int
+	acl                   bool
+	aclTTL                time.Duration
+	aclAlg                jwt.SigningMethod
+	encryption            bool
+	version               string
+	volumes               map[string]string
+	refillInterval        time.Duration
+	uidLease              int
+	portOffset            int // exposed port offset for grpc/http port for both alpha/zero
+	bulkOutDir            string
+	featureFlags          []string
+	customPlugins         bool
+	snapShotAfterEntries  uint64
+	snapshotAfterDuration time.Duration
 }
 
 // NewClusterConfig generates a default ClusterConfig
@@ -236,4 +238,11 @@ func (cc ClusterConfig) WithCustomPlugins() ClusterConfig {
 
 func (cc ClusterConfig) GetClusterVolume(volume string) string {
 	return cc.volumes[volume]
+}
+
+func (cc ClusterConfig) WithSnapshotConfig(snapShotAfterEntries uint64,
+	snapshotAfterDuration time.Duration) ClusterConfig {
+	cc.snapShotAfterEntries = snapShotAfterEntries
+	cc.snapshotAfterDuration = snapshotAfterDuration
+	return cc
 }

--- a/dgraphtest/load.go
+++ b/dgraphtest/load.go
@@ -33,6 +33,7 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/dgraph-io/dgo/v230/protos/api"
 	"github.com/dgraph-io/dgraph/ee/enc"
 	"github.com/dgraph-io/dgraph/x"
 )
@@ -492,4 +493,18 @@ func (c *LocalCluster) BulkLoad(opts BulkOpts) error {
 		log.Println(string(out))
 		return nil
 	}
+}
+
+// AddData will insert a total of end-start triples into the database.
+func AddData(gc *GrpcClient, pred string, start, end int) error {
+	if err := gc.SetupSchema(fmt.Sprintf(`%v: string @index(exact) .`, pred)); err != nil {
+		return err
+	}
+
+	rdf := ""
+	for i := start; i <= end; i++ {
+		rdf = rdf + fmt.Sprintf("_:a%v <%v> \"%v%v\" .	\n", i, pred, pred, i)
+	}
+	_, err := gc.Mutate(&api.Mutation{SetNquads: []byte(rdf), CommitNow: true})
+	return err
 }

--- a/dgraphtest/snapshot.go
+++ b/dgraphtest/snapshot.go
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2023 Dgraph Labs, Inc. and Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dgraphtest
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+func (hc *HTTPClient) GetCurrentSnapshotTs(group uint64) (uint64, error) {
+	snapTsRequest := `query {
+		state {
+		  groups {
+			id
+			snapshotTs
+		  }
+		}
+	  }`
+	params := GraphQLParams{
+		Query: snapTsRequest,
+	}
+	resp, err := hc.RunGraphqlQuery(params, true)
+	if err != nil {
+		return 0, err
+	}
+
+	var stateResp struct {
+		State struct {
+			Groups []struct {
+				SnapshotTs uint64
+			}
+		}
+	}
+
+	err = json.Unmarshal(resp, &stateResp)
+	if err != nil {
+		return 0, err
+	}
+
+	return stateResp.State.Groups[group-1].SnapshotTs, nil
+}
+
+func (hc *HTTPClient) WaitForSnapshot(group, prevSnapshotTs uint64) (uint64, error) {
+
+	for i := 1; i <= 100; i++ {
+		currentSnapshotTs, err := hc.GetCurrentSnapshotTs(group)
+		if err != nil {
+			return 0, errors.Wrapf(err, "error while getting current snapshot timestamp: %v", err)
+		}
+		if currentSnapshotTs > prevSnapshotTs {
+			return currentSnapshotTs, nil
+		}
+
+		time.Sleep(time.Second)
+	}
+	return 0, errors.New("timeout excedded")
+}

--- a/raftwal/storage.go
+++ b/raftwal/storage.go
@@ -313,6 +313,9 @@ func (w *DiskStorage) CreateSnapshot(i uint64, cs *raftpb.ConfState, data []byte
 	return nil
 }
 
+// TODO(Aman): In the raft example here, we store the snapshot first, followed by entries
+// and then, hard state. https://github.com/etcd-io/etcd/blob/main/contrib/raftexample/raft.go
+// We should do the same here.
 // Save would write Entries, HardState and Snapshot to persistent storage in order, i.e. Entries
 // first, then HardState and Snapshot if they are not empty. If persistent storage supports atomic
 // writes then all of them can be written together. Note that when writing an Entry with Index i,

--- a/systest/integration2/snapshot_test.go
+++ b/systest/integration2/snapshot_test.go
@@ -1,0 +1,68 @@
+//go:build integration2
+
+/*
+ * Copyright 2023 Dgraph Labs, Inc. and Contributors *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/dgraph-io/dgraph/dgraphtest"
+	"github.com/dgraph-io/dgraph/x"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSnapshotTranferAfterNewNodeJoins(t *testing.T) {
+	conf := dgraphtest.NewClusterConfig().WithNumAlphas(3).WithNumZeros(1).
+		WithACL(time.Hour).WithReplicas(3).WithSnapshotConfig(11, time.Second)
+	c, err := dgraphtest.NewLocalCluster(conf)
+	require.NoError(t, err)
+	defer func() { c.Cleanup(t.Failed()) }()
+
+	// start zero
+	require.NoError(t, c.StartZero(0))
+	require.NoError(t, c.HealthCheck(true))
+	require.NoError(t, c.StartAlpha(0))
+	require.NoError(t, c.HealthCheck(false))
+
+	hc, err := c.HTTPClient()
+	require.NoError(t, err)
+	hc.LoginIntoNamespace(dgraphtest.DefaultUser, dgraphtest.DefaultPassword, x.GalaxyNamespace)
+
+	gc, cleanup, err := c.Client()
+	require.NoError(t, err)
+	defer cleanup()
+	require.NoError(t, gc.LoginIntoNamespace(context.Background(),
+		dgraphtest.DefaultUser, dgraphtest.DefaultPassword, x.GalaxyNamespace))
+
+	prevSnapshotTs, err := hc.GetCurrentSnapshotTs(1)
+	require.NoError(t, err)
+
+	dgraphtest.AddData(gc, "name", 1, 20)
+
+	_, err = hc.WaitForSnapshot(1, prevSnapshotTs)
+	require.NoError(t, err)
+
+	require.NoError(t, c.StartAlpha(1))
+	require.NoError(t, c.StartAlpha(2))
+
+	// Wait for the other alpha nodes to receive the snapshot from the leader alpha.
+	// If they are healthy, there should be no issues with the snapshot streaming
+	time.Sleep(time.Second)
+	require.NoError(t, c.HealthCheck(false))
+}

--- a/systest/online-restore/namespace-aware/restore_test.go
+++ b/systest/online-restore/namespace-aware/restore_test.go
@@ -25,23 +25,22 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/dgraph-io/dgo/v230/protos/api"
 	"github.com/dgraph-io/dgraph/dgraphtest"
 	"github.com/dgraph-io/dgraph/x"
 )
 
-func addData(gc *dgraphtest.GrpcClient, pred string, start, end int) error {
-	if err := gc.SetupSchema(fmt.Sprintf(`%v: string @index(exact) .`, pred)); err != nil {
-		return err
-	}
+// func addData(gc *dgraphtest.GrpcClient, pred string, start, end int) error {
+// 	if err := gc.SetupSchema(fmt.Sprintf(`%v: string @index(exact) .`, pred)); err != nil {
+// 		return err
+// 	}
 
-	rdf := ""
-	for i := start; i <= end; i++ {
-		rdf = rdf + fmt.Sprintf("_:a%v <%v> \"%v%v\" .	\n", i, pred, pred, i)
-	}
-	_, err := gc.Mutate(&api.Mutation{SetNquads: []byte(rdf), CommitNow: true})
-	return err
-}
+// 	rdf := ""
+// 	for i := start; i <= end; i++ {
+// 		rdf = rdf + fmt.Sprintf("_:a%v <%v> \"%v%v\" .	\n", i, pred, pred, i)
+// 	}
+// 	_, err := gc.Mutate(&api.Mutation{SetNquads: []byte(rdf), CommitNow: true})
+// 	return err
+// }
 
 func commonTest(t *testing.T, existingCluster, freshCluster *dgraphtest.LocalCluster) {
 	hc, err := existingCluster.HTTPClient()
@@ -54,14 +53,14 @@ func commonTest(t *testing.T, existingCluster, freshCluster *dgraphtest.LocalClu
 	require.NoError(t, gc.Login(context.Background(), dgraphtest.DefaultUser, dgraphtest.DefaultPassword))
 
 	namespaces := []uint64{0}
-	require.NoError(t, addData(gc, "pred", 1, 100))
+	require.NoError(t, dgraphtest.AddData(gc, "pred", 1, 100))
 	for i := 1; i <= 5; i++ {
 		ns, err := hc.AddNamespace()
 		require.NoError(t, err)
 		namespaces = append(namespaces, ns)
 		require.NoError(t, gc.LoginIntoNamespace(context.Background(),
 			dgraphtest.DefaultUser, dgraphtest.DefaultPassword, ns))
-		require.NoError(t, addData(gc, "pred", 1, 100+int(ns)))
+		require.NoError(t, dgraphtest.AddData(gc, "pred", 1, 100+int(ns)))
 	}
 
 	require.NoError(t, hc.LoginIntoNamespace(dgraphtest.DefaultUser, dgraphtest.DefaultPassword, x.GalaxyNamespace))
@@ -118,7 +117,7 @@ func commonIncRestoreTest(t *testing.T, existingCluster, freshCluster *dgraphtes
 	require.NoError(t, gc.Login(context.Background(), dgraphtest.DefaultUser, dgraphtest.DefaultPassword))
 
 	require.NoError(t, gc.DropAll())
-	require.NoError(t, addData(gc, "pred", 1, 100))
+	require.NoError(t, dgraphtest.AddData(gc, "pred", 1, 100))
 
 	namespaces := []uint64{}
 	for i := 1; i <= 5; i++ {
@@ -133,7 +132,7 @@ func commonIncRestoreTest(t *testing.T, existingCluster, freshCluster *dgraphtes
 				dgraphtest.DefaultUser, dgraphtest.DefaultPassword, ns))
 			start := i*20 + 1
 			end := (i + 1) * 20
-			require.NoError(t, addData(gc, "pred", start, end))
+			require.NoError(t, dgraphtest.AddData(gc, "pred", start, end))
 		}
 
 		require.NoError(t, hc.LoginIntoNamespace(dgraphtest.DefaultUser, dgraphtest.DefaultPassword, x.GalaxyNamespace))


### PR DESCRIPTION
Description: Certain issues arise when a snapshot is taken by the alpha leader in a cluster and a new node joins afterwards.
Closes: https://linear.app/hypermode/issue/HYP-163/alpha-leader-fails-to-stream-snapshot-to-new-alpha-nodes
