### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # CODEOWNERS info: https://help.github.com/en/articles/about-code-owners
 # Owners are automatically requested for review for PRs that changes code
 # that they own.
-* @mangalaman93 @meghalims @sanjayk-github-dev @harshil-goel @all-seeing-code @billprovince @joshua-goldstein
+* @dgraph-io/committers


### PR DESCRIPTION
Updating codeowners to map to GitHub Team for easier management
