### PR TITLE
fix(acl): fix duplicate groot user creation

### DIFF
--- a/check_upgrade/check_upgrade.go
+++ b/check_upgrade/check_upgrade.go
@@ -1,0 +1,250 @@
+/*
+ * Copyright 2024 Dgraph Labs, Inc. and Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package checkupgrade
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+
+	"github.com/dgraph-io/dgo/v230"
+	"github.com/dgraph-io/dgo/v230/protos/api"
+	"github.com/dgraph-io/dgraph/dgraphapi"
+	"github.com/dgraph-io/dgraph/x"
+)
+
+var (
+	CheckUpgrade x.SubCommand
+)
+
+const (
+	alphaGrpc = "grpc_port"
+	alphaHttp = "http_port"
+	dgUser    = "dgUser"
+	password  = "password"
+)
+
+type commandInput struct {
+	alphaGrpc string
+	alphaHttp string
+	dgUser    string
+	password  string
+}
+
+type aclNode struct {
+	UID        string   `json:"uid"`
+	DgraphXID  string   `json:"dgraph.xid"`
+	DgraphType []string `json:"dgraph.type"`
+}
+
+func setupClients(alphaGrpc, alphaHttp string) (*dgo.Dgraph, *dgraphapi.HTTPClient, error) {
+	d, err := grpc.Dial(alphaGrpc, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		return nil, nil, errors.Wrapf(err, "while dialing gRPC server")
+	}
+
+	httpClient, err := dgraphapi.GetHttpClient(alphaHttp, "")
+	if err != nil {
+		return nil, nil, errors.Wrapf(err, "while getting HTTP client")
+	}
+	return dgo.NewDgraphClient(api.NewDgraphClient(d)), httpClient, nil
+}
+
+func contains(slice []string, value string) bool {
+	for _, v := range slice {
+		if v == value {
+			return true
+		}
+	}
+	return false
+}
+
+func findDuplicateNodes(aclNodes []aclNode) []map[string][]string {
+	du := make(map[string][]string)
+	dg := make(map[string][]string)
+	dug := make(map[string][]string)
+
+	var duplicates []map[string][]string
+
+	for i, node1 := range aclNodes {
+		for j := i + 1; j < len(aclNodes); j++ {
+			node2 := aclNodes[j]
+			if node1.DgraphXID == node2.DgraphXID {
+				if node1.DgraphType[0] == "dgraph.type.User" && node1.DgraphType[0] == node2.DgraphType[0] {
+					if _, exists := du[node1.DgraphXID]; !exists {
+						du[node1.DgraphXID] = []string{}
+					}
+					if !contains(du[node1.DgraphXID], node1.UID) {
+						du[node1.DgraphXID] = append(du[node1.DgraphXID], node1.UID)
+					}
+					if !contains(du[node1.DgraphXID], node2.UID) {
+						du[node1.DgraphXID] = append(du[node1.DgraphXID], node2.UID)
+					}
+				} else if node1.DgraphType[0] == "dgraph.type.Group" && node1.DgraphType[0] == node2.DgraphType[0] {
+					if _, exists := dg[node1.DgraphXID]; !exists {
+						dg[node1.DgraphXID] = []string{}
+					}
+					if !contains(dg[node1.DgraphXID], node1.UID) {
+						dg[node1.DgraphXID] = append(dg[node1.DgraphXID], node1.UID)
+					}
+					if !contains(dg[node1.DgraphXID], node2.UID) {
+						dg[node1.DgraphXID] = append(dg[node1.DgraphXID], node2.UID)
+					}
+				} else {
+					if _, exists := dug[node1.DgraphXID]; !exists {
+						dug[node1.DgraphXID] = []string{}
+					}
+					if !contains(dug[node1.DgraphXID], node1.UID) {
+						dug[node1.DgraphXID] = append(dug[node1.DgraphXID], node1.UID)
+					}
+					if !contains(dug[node1.DgraphXID], node2.UID) {
+						dug[node1.DgraphXID] = append(dug[node1.DgraphXID], node2.UID)
+					}
+				}
+			}
+		}
+	}
+
+	duplicates = append(duplicates, du, dg, dug)
+	return duplicates
+}
+
+func queryACLNodes(ctx context.Context, dg *dgo.Dgraph) ([]map[string][]string, error) {
+	query := `{ 
+		nodes(func: has(dgraph.xid)) {
+			       uid
+			       dgraph.xid
+                   dgraph.type
+		        }
+	}`
+
+	resp, err := dg.NewTxn().Query(ctx, query)
+	if err != nil {
+		return nil, errors.Wrapf(err, "while querying dgraph for duplicate nodes")
+	}
+
+	type Nodes struct {
+		Nodes []aclNode `json:"nodes"`
+	}
+	var result Nodes
+	if err := json.Unmarshal(resp.Json, &result); err != nil {
+		return nil, errors.Wrapf(err, "while unmarshalling response: %v", string(resp.Json))
+
+	}
+	return findDuplicateNodes(result.Nodes), nil
+}
+
+func printDuplicates(entityType string, ns uint64, nodesmap map[string][]string) {
+	if len(nodesmap) == 0 {
+		return
+	}
+
+	fmt.Printf("Found duplicate %ss in namespace: #%v\n", entityType, ns)
+	for key, node := range nodesmap {
+		fmt.Printf("dgraph.xid %v , Uids: %v\n", key, node)
+	}
+	fmt.Println("")
+}
+
+func init() {
+	CheckUpgrade.Cmd = &cobra.Command{
+		Use:   "checkupgrade",
+		Short: "Run the checkupgrade tool",
+		Long:  "The checkupgrade tool is used to check for duplicate dgraph.xid's in the Dgraph database before upgrade.",
+		Run: func(cmd *cobra.Command, args []string) {
+			run()
+		},
+		Annotations: map[string]string{"group": "tool"},
+	}
+	CheckUpgrade.Cmd.SetHelpTemplate(x.NonRootTemplate)
+	flag := CheckUpgrade.Cmd.Flags()
+	flag.String(alphaGrpc, "127.0.0.1:9080", "Dgraph Alpha gRPC server address")
+	flag.String(alphaHttp, "127.0.0.1:8080", "Dgraph Alpha Http server address")
+	flag.String(dgUser, "groot", "Username of galaxy namespace's user")
+	flag.String(password, "password", "Password of galaxy namespace's user")
+}
+
+func run() {
+	if err := checkUpgrade(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+	}
+}
+
+func checkUpgrade() error {
+	fmt.Println("Running check-upgrade tool")
+
+	cmdInput := parseInput()
+	gc, hc, err := setupClients(cmdInput.alphaGrpc, cmdInput.alphaHttp)
+	if err != nil {
+		return errors.Wrapf(err, "while setting up clients")
+	}
+
+	if err = hc.LoginIntoNamespace(cmdInput.dgUser, cmdInput.password, x.GalaxyNamespace); err != nil {
+		return errors.Wrapf(err, "while logging into namespace: %v", x.GalaxyNamespace)
+	}
+
+	namespaces, err := hc.ListNamespaces()
+	if err != nil {
+		return err
+	}
+
+	ctx := context.Background()
+	for _, ns := range namespaces {
+		if err := gc.LoginIntoNamespace(ctx, cmdInput.dgUser, cmdInput.password, ns); err != nil {
+			return errors.Wrapf(err, "while logging into namespace: %v", ns)
+		}
+
+		duplicates, err := queryACLNodes(ctx, gc)
+		if err != nil {
+			return err
+		}
+
+		printDuplicates("user", ns, duplicates[0])
+		// example output:
+		//	Found duplicate users in namespace: #0
+		// dgraph.xid user1 , Uids: [0x4 0x3]
+		printDuplicates("group", ns, duplicates[1])
+		// Found duplicate groups in namespace: #1
+		// dgraph.xid group1 , Uids: [0x2714 0x2711]
+		printDuplicates("groups and user", ns, duplicates[2])
+		// Found duplicate groups and users in namespace: #0
+		// dgraph.xid userGroup1 , Uids: [0x7532 0x7531]
+	}
+
+	fmt.Println("To delete duplicate nodes use following mutation: ")
+	deleteMut := `
+	{
+		delete {
+			<UID> * * .
+		}
+	}`
+	fmt.Fprint(os.Stderr, deleteMut)
+
+	return nil
+}
+
+func parseInput() *commandInput {
+	return &commandInput{alphaGrpc: CheckUpgrade.Conf.GetString(alphaGrpc),
+		alphaHttp: CheckUpgrade.Conf.GetString(alphaHttp), dgUser: CheckUpgrade.Conf.GetString(dgUser),
+		password: CheckUpgrade.Conf.GetString(password)}
+}

--- a/check_upgrade/check_upgrade_test.go
+++ b/check_upgrade/check_upgrade_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build integration2
 
 /*
  * Copyright 2024 Dgraph Labs, Inc. and Contributors

--- a/check_upgrade/check_upgrade_test.go
+++ b/check_upgrade/check_upgrade_test.go
@@ -197,13 +197,3 @@ func TestQueryDuplicateNodes(t *testing.T) {
 	require.NoError(t, deleteDuplicatesGroup(hc, duplicateNodes[1]))
 	require.NoError(t, deleteDuplicatesGroup(hc, duplicateNodes[2]))
 }
-
-func TestDeleteDuplicateUser(t *testing.T) {
-	hc, err := setupClient("localhost:36085")
-
-	require.NoError(t, err)
-
-	require.NoError(t, hc.LoginIntoNamespace(dgraphapi.DefaultUser,
-		dgraphapi.DefaultPassword, x.GalaxyNamespace))
-
-}

--- a/check_upgrade/check_upgrade_test.go
+++ b/check_upgrade/check_upgrade_test.go
@@ -20,6 +20,7 @@ package checkupgrade
 
 import (
 	"context"
+	"fmt"
 	"os/exec"
 	"path/filepath"
 	"regexp"
@@ -73,7 +74,7 @@ func TestCheckUpgrade(t *testing.T) {
 		nss = append(nss, ns)
 	}
 
-	conf1 := dgraphtest.NewClusterConfig().WithNumAlphas(1).WithNumZeros(1).WithReplicas(1).WithACL(time.Hour)
+	conf1 := dgraphtest.NewClusterConfig().WithNumAlphas(1).WithNumZeros(1).WithReplicas(1).WithACL(time.Hour).WithVersion("local")
 	c1, err := dgraphtest.NewLocalCluster(conf1)
 	require.NoError(t, err)
 	defer func() { c1.Cleanup(t.Failed()) }()
@@ -90,13 +91,14 @@ func TestCheckUpgrade(t *testing.T) {
 		"--http_port", "localhost:" + alphaHttp,
 		"--dgUser", "groot",
 		"--password", "password",
+		"--namespace", "1",
 	}
 
 	cmd := exec.Command(filepath.Join(c1.GetTempDir(), "dgraph"), args...)
 	out, err := cmd.CombinedOutput()
 	require.NoError(t, err)
 	actualOutput := string(out)
-
+	fmt.Println("logs of checkupgrade tool\n", actualOutput)
 	expectedOutputPattern := `Found duplicate users in namespace: #\d+\ndgraph\.xid user1 , Uids: \[\d+x\d+ \d+x\d+\]\n`
 	match, err := regexp.MatchString(expectedOutputPattern, actualOutput)
 	require.NoError(t, err)
@@ -105,4 +107,92 @@ func TestCheckUpgrade(t *testing.T) {
 		t.Errorf("Output does not match expected pattern.\nExpected pattern:\n%s\n\nGot:\n%s",
 			expectedOutputPattern, actualOutput)
 	}
+}
+
+func TestQueryDuplicateNodes(t *testing.T) {
+	conf := dgraphtest.NewClusterConfig().WithNumAlphas(1).WithNumZeros(1).WithReplicas(1).
+		WithACL(time.Hour).WithVersion("57aa5c4ac")
+	c, err := dgraphtest.NewLocalCluster(conf)
+	require.NoError(t, err)
+	defer func() { c.Cleanup(t.Failed()) }()
+	require.NoError(t, c.Start())
+	gc, cleanup, err := c.Client()
+	require.NoError(t, err)
+	defer cleanup()
+	require.NoError(t, gc.LoginIntoNamespace(context.Background(),
+		dgraphapi.DefaultUser, dgraphapi.DefaultPassword, x.GalaxyNamespace))
+	hc, err := c.HTTPClient()
+	require.NoError(t, err)
+	require.NoError(t, hc.LoginIntoNamespace(dgraphapi.DefaultUser,
+		dgraphapi.DefaultPassword, x.GalaxyNamespace))
+	rdfs := `
+			<0x40> <dgraph.xid> "user1" .
+			<0x40> <dgraph.type> "dgraph.type.User"  .
+			<0x50> <dgraph.xid> "user1" .
+			<0x50> <dgraph.type> "dgraph.type.User"  .
+			<0x60> <dgraph.xid> "user1" .
+			<0x60> <dgraph.type> "dgraph.type.User"  .
+			<0x70> <dgraph.xid> "user1" .
+			<0x70> <dgraph.type> "dgraph.type.User"  .
+			<0x80> <dgraph.xid> "user3" .
+		    <0x80> <dgraph.type> "dgraph.type.User"  .
+		    <0x90> <dgraph.xid> "user3" .
+		    <0x90> <dgraph.type> "dgraph.type.User"  .
+			<0x100> <dgraph.xid> "Group4" .
+			<0x100> <dgraph.type> "dgraph.type.Group"  .
+			<0x110> <dgraph.xid> "Group4" .
+			<0x110> <dgraph.type> "dgraph.type.Group"  .
+			<0x120> <dgraph.xid> "Group4" .
+			<0x120> <dgraph.type> "dgraph.type.Group"  .
+			<0x130> <dgraph.xid> "Group4" .
+			<0x130> <dgraph.type> "dgraph.type.Group"  .
+			<0x140> <dgraph.xid> "Group4" .
+			<0x140> <dgraph.type> "dgraph.type.Group"  .
+			<0x150> <dgraph.xid> "usrgrp1" .
+			<0x150> <dgraph.type> "dgraph.type.User"  .
+			<0x160> <dgraph.xid> "usrgrp1" .
+			<0x160> <dgraph.type> "dgraph.type.User"  .
+			<0x170> <dgraph.xid> "usrgrp1" .
+			<0x170> <dgraph.type> "dgraph.type.User"  .
+			<0x180> <dgraph.xid> "usrgrp1" .
+			<0x180> <dgraph.type> "dgraph.type.Group"  .
+			<0x200> <dgraph.xid> "usrgrp2" .
+			<0x200> <dgraph.type> "dgraph.type.Group"  .
+			<0x210> <dgraph.xid> "usrgrp2" .
+			<0x210> <dgraph.type> "dgraph.type.User"  .
+		`
+	mu := &api.Mutation{SetNquads: []byte(rdfs), CommitNow: true}
+	_, err = gc.Mutate(mu)
+	require.NoError(t, err)
+
+	duplicateNodes, err := queryDuplicateNodes(context.Background(), gc.Dgraph)
+	require.NoError(t, err)
+
+	du := map[string][]string{
+		"user1":   {"0x40", "0x50", "0x60", "0x70"},
+		"user3":   {"0x80", "0x90"},
+		"usrgrp1": {"0x150", "0x160", "0x170"},
+	}
+
+	dg := map[string][]string{
+		"Group4":  {"0x100", "0x110", "0x120", "0x130", "0x140"},
+		"usrgrp1": {"0x180", "0x190"},
+	}
+
+	dug := map[string][]string{
+		"usrgrp1": {"0x150", "0x160", "0x170", "0x180"},
+		"usrgrp2": {"0x200", "0x210"},
+	}
+
+	expectedDup := [3]map[string][]string{du, dg, dug}
+
+	for i, dn := range duplicateNodes {
+		for j, d := range dn {
+			require.Equal(t, len(expectedDup[i][j]), len(d))
+			for _, uid := range d {
+				require.Contains(t, expectedDup[i][j], uid)
+			}
+		}
+	}
+
 }

--- a/check_upgrade/check_upgrade_test.go
+++ b/check_upgrade/check_upgrade_test.go
@@ -111,7 +111,7 @@ func TestQueryDuplicateNodes(t *testing.T) {
 		WithACL(time.Hour).WithVersion("57aa5c4ac").WithAclAlg(jwt.GetSigningMethod("HS256"))
 	c, err := dgraphtest.NewLocalCluster(conf)
 	require.NoError(t, err)
-	defer func() { c.Cleanup(t.Failed()) }()
+	// defer func() { c.Cleanup(t.Failed()) }()
 	require.NoError(t, c.Start())
 	gc, cleanup, err := c.Client()
 	require.NoError(t, err)
@@ -129,6 +129,8 @@ func TestQueryDuplicateNodes(t *testing.T) {
 			<0x50> <dgraph.type> "dgraph.type.User"  .
 			<0x60> <dgraph.xid> "user1" .
 			<0x60> <dgraph.type> "dgraph.type.User"  .
+			<0x60> <dgraph.user.group> <0x1>  .
+			<0x50> <dgraph.user.group> <0x1>  .
 			<0x70> <dgraph.xid> "user1" .
 			<0x70> <dgraph.type> "dgraph.type.User"  .
 			<0x80> <dgraph.xid> "user3" .
@@ -191,5 +193,17 @@ func TestQueryDuplicateNodes(t *testing.T) {
 			}
 		}
 	}
+	require.NoError(t, deleteDuplicatesGroup(hc, duplicateNodes[0]))
+	require.NoError(t, deleteDuplicatesGroup(hc, duplicateNodes[1]))
+	require.NoError(t, deleteDuplicatesGroup(hc, duplicateNodes[2]))
+}
+
+func TestDeleteDuplicateUser(t *testing.T) {
+	hc, err := setupClient("localhost:36085")
+
+	require.NoError(t, err)
+
+	require.NoError(t, hc.LoginIntoNamespace(dgraphapi.DefaultUser,
+		dgraphapi.DefaultPassword, x.GalaxyNamespace))
 
 }

--- a/check_upgrade/check_upgrade_test.go
+++ b/check_upgrade/check_upgrade_test.go
@@ -1,0 +1,108 @@
+//go:build integration
+
+/*
+ * Copyright 2024 Dgraph Labs, Inc. and Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package checkupgrade
+
+import (
+	"context"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/dgraph-io/dgo/v230/protos/api"
+	"github.com/dgraph-io/dgraph/dgraphapi"
+	"github.com/dgraph-io/dgraph/dgraphtest"
+	"github.com/dgraph-io/dgraph/x"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCheckUpgrade(t *testing.T) {
+	conf := dgraphtest.NewClusterConfig().WithNumAlphas(1).WithNumZeros(1).WithReplicas(1).
+		WithACL(time.Hour).WithVersion("57aa5c4ac")
+	c, err := dgraphtest.NewLocalCluster(conf)
+	require.NoError(t, err)
+	defer func() { c.Cleanup(t.Failed()) }()
+	require.NoError(t, c.Start())
+
+	gc, cleanup, err := c.Client()
+	require.NoError(t, err)
+	defer cleanup()
+	require.NoError(t, gc.LoginIntoNamespace(context.Background(),
+		dgraphapi.DefaultUser, dgraphapi.DefaultPassword, x.GalaxyNamespace))
+
+	hc, err := c.HTTPClient()
+	require.NoError(t, err)
+	require.NoError(t, hc.LoginIntoNamespace(dgraphapi.DefaultUser,
+		dgraphapi.DefaultPassword, x.GalaxyNamespace))
+
+	rdfs := ` 
+		_:a <dgraph.xid> "user1" .
+	    _:a <dgraph.type> "dgraph.type.User"  .
+		_:b <dgraph.xid> "user1" .
+		_:b <dgraph.type> "dgraph.type.User"  .`
+
+	mu := &api.Mutation{SetNquads: []byte(rdfs), CommitNow: true}
+	_, err = gc.Mutate(mu)
+	require.NoError(t, err)
+
+	var nss []uint64
+	for i := 0; i < 5; i++ {
+		ns, err := hc.AddNamespace()
+		require.NoError(t, err)
+		require.NoError(t, gc.LoginIntoNamespace(context.Background(), "groot", "password", ns))
+		mu = &api.Mutation{SetNquads: []byte(rdfs), CommitNow: true}
+		_, err = gc.Mutate(mu)
+		require.NoError(t, err)
+		nss = append(nss, ns)
+	}
+
+	conf1 := dgraphtest.NewClusterConfig().WithNumAlphas(1).WithNumZeros(1).WithReplicas(1).WithACL(time.Hour)
+	c1, err := dgraphtest.NewLocalCluster(conf1)
+	require.NoError(t, err)
+	defer func() { c1.Cleanup(t.Failed()) }()
+	require.NoError(t, c1.Start())
+	alphaHttp, err := c.GetAlphaHttpPublicPort()
+	require.NoError(t, err)
+
+	alphaGrpc, err := c.GetAlphaGrpcPublicPort()
+	require.NoError(t, err)
+
+	args := []string{
+		"checkupgrade",
+		"--grpc_port", "localhost:" + alphaGrpc,
+		"--http_port", "localhost:" + alphaHttp,
+		"--dgUser", "groot",
+		"--password", "password",
+	}
+
+	cmd := exec.Command(filepath.Join(c1.GetTempDir(), "dgraph"), args...)
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err)
+	actualOutput := string(out)
+
+	expectedOutputPattern := `Found duplicate users in namespace: #\d+\ndgraph\.xid user1 , Uids: \[\d+x\d+ \d+x\d+\]\n`
+	match, err := regexp.MatchString(expectedOutputPattern, actualOutput)
+	require.NoError(t, err)
+
+	if !match {
+		t.Errorf("Output does not match expected pattern.\nExpected pattern:\n%s\n\nGot:\n%s",
+			expectedOutputPattern, actualOutput)
+	}
+}

--- a/dgraph/cmd/root.go
+++ b/dgraph/cmd/root.go
@@ -32,6 +32,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
+	checkupgrade "github.com/dgraph-io/dgraph/check_upgrade"
 	"github.com/dgraph-io/dgraph/dgraph/cmd/alpha"
 	"github.com/dgraph-io/dgraph/dgraph/cmd/bulk"
 	"github.com/dgraph-io/dgraph/dgraph/cmd/cert"
@@ -84,6 +85,7 @@ var rootConf = viper.New()
 var subcommands = []*x.SubCommand{
 	&bulk.Bulk, &cert.Cert, &conv.Conv, &live.Live, &alpha.Alpha, &zero.Zero, &version.Version,
 	&debug.Debug, &migrate.Migrate, &debuginfo.DebugInfo, &upgrade.Upgrade, &decrypt.Decrypt, &increment.Increment,
+	&checkupgrade.CheckUpgrade,
 }
 
 func initCmds() {

--- a/dgraphapi/cluster.go
+++ b/dgraphapi/cluster.go
@@ -793,5 +793,6 @@ func GetHttpClient(alphaUrl, zeroUrl string) (*HTTPClient, error) {
 		licenseURL: licenseUrl,
 		stateURL:   stateUrl,
 		dqlURL:     dqlUrl,
+		HttpToken:  &HttpToken{},
 	}, nil
 }

--- a/dgraphapi/ee.go
+++ b/dgraphapi/ee.go
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package dgraphtest
+package dgraphapi
 
 import (
 	"encoding/json"
@@ -123,7 +123,7 @@ func (hc *HTTPClient) CreateGroup(name string) (string, error) {
 	}
 	resp, err := hc.RunGraphqlQuery(params, true)
 	if err != nil {
-		return "", nil
+		return "", err
 	}
 	type Response struct {
 		AddGroup struct {
@@ -452,4 +452,28 @@ func (hc *HTTPClient) DeleteNamespace(nsID uint64) (uint64, error) {
 		return result.DeleteNamespace.NamespaceId, nil
 	}
 	return 0, errors.New(result.DeleteNamespace.Message)
+}
+
+func (hc *HTTPClient) ListNamespaces() ([]uint64, error) {
+	const listNss = `{ state {
+		namespaces
+	  }
+	}`
+
+	params := GraphQLParams{Query: listNss}
+	resp, err := hc.RunGraphqlQuery(params, true)
+	if err != nil {
+		return nil, err
+	}
+
+	var result struct {
+		State struct {
+			Namespaces []uint64 `json:"namespaces"`
+		} `json:"state"`
+	}
+	if err := json.Unmarshal(resp, &result); err != nil {
+		return nil, errors.Wrap(err, "error unmarshalling response")
+	}
+
+	return result.State.Namespaces, nil
 }

--- a/dgraphapi/json.go
+++ b/dgraphapi/json.go
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package dgraphtest
+package dgraphapi
 
 import (
 	"encoding/json"
@@ -28,6 +28,11 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+)
+
+const (
+	waitDurBeforeRetry = time.Second
+	requestTimeout     = 120 * time.Second
 )
 
 func PollTillPassOrTimeout(gcli *GrpcClient, query, want string, timeout time.Duration) error {

--- a/dgraphapi/snapshot.go
+++ b/dgraphapi/snapshot.go
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package dgraphtest
+package dgraphapi
 
 import (
 	"encoding/json"

--- a/dgraphapi/vector.go
+++ b/dgraphapi/vector.go
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package dgraphtest
+package dgraphapi
 
 import (
 	"encoding/json"

--- a/dgraphtest/compose_cluster.go
+++ b/dgraphtest/compose_cluster.go
@@ -18,6 +18,7 @@ package dgraphtest
 
 import (
 	"github.com/dgraph-io/dgo/v230"
+	"github.com/dgraph-io/dgraph/dgraphapi"
 	"github.com/dgraph-io/dgraph/testutil"
 )
 
@@ -27,30 +28,23 @@ func NewComposeCluster() *ComposeCluster {
 	return &ComposeCluster{}
 }
 
-func (c *ComposeCluster) Client() (*GrpcClient, func(), error) {
+func (c *ComposeCluster) Client() (*dgraphapi.GrpcClient, func(), error) {
 	client, err := testutil.DgraphClient(testutil.SockAddr)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	return &GrpcClient{Dgraph: client}, func() {}, nil
+	return &dgraphapi.GrpcClient{Dgraph: client}, func() {}, nil
 }
 
 // HTTPClient creates an HTTP client
-func (c *ComposeCluster) HTTPClient() (*HTTPClient, error) {
-	adminUrl := "http://" + testutil.SockAddrHttp + "/admin"
-	graphQLUrl := "http://" + testutil.SockAddrHttp + "/graphql"
-	licenseUrl := "http://" + testutil.SockAddrZeroHttp + "/enterpriseLicense"
-	stateUrl := "http://" + testutil.SockAddrZeroHttp + "/state"
-	dqlUrl := "http://" + testutil.SockAddrHttp + "/query"
-	return &HTTPClient{
-		adminURL:   adminUrl,
-		graphqlURL: graphQLUrl,
-		licenseURL: licenseUrl,
-		stateURL:   stateUrl,
-		dqlURL:     dqlUrl,
-		HttpToken:  &HttpToken{},
-	}, nil
+func (c *ComposeCluster) HTTPClient() (*dgraphapi.HTTPClient, error) {
+	httpClient, err := dgraphapi.GetHttpClient(testutil.SockAddrHttp, testutil.SockAddrZeroHttp)
+	if err != nil {
+		return nil, err
+	}
+	httpClient.HttpToken = &dgraphapi.HttpToken{}
+	return httpClient, nil
 }
 
 func (c *ComposeCluster) AlphasHealth() ([]string, error) {
@@ -70,5 +64,10 @@ func (c *ComposeCluster) GetVersion() string {
 }
 
 func (c *ComposeCluster) GetEncKeyPath() (string, error) {
+	return "", errNotImplemented
+}
+
+// GetRepoDir returns the repositroty directory of the cluster
+func (c *ComposeCluster) GetRepoDir() (string, error) {
 	return "", errNotImplemented
 }

--- a/dgraphtest/config.go
+++ b/dgraphtest/config.go
@@ -119,6 +119,7 @@ type ClusterConfig struct {
 	customPlugins         bool
 	snapShotAfterEntries  uint64
 	snapshotAfterDuration time.Duration
+	repoDir               string
 }
 
 func (cc ClusterConfig) WithGraphqlLambdaURL(url string) ClusterConfig {

--- a/dgraphtest/dcloud_cluster.go
+++ b/dgraphtest/dcloud_cluster.go
@@ -167,3 +167,11 @@ func (c *DCloudCluster) GetVersion() string {
 func (c *DCloudCluster) GetRepoDir() (string, error) {
 	return "", errNotImplemented
 }
+
+func (c *DCloudCluster) AlphasLogs() ([]string, error) {
+	return nil, errNotImplemented
+}
+
+func (c *DCloudCluster) GetEncKeyPath() (string, error) {
+	return "", errNotImplemented
+}

--- a/dgraphtest/dcloud_cluster.go
+++ b/dgraphtest/dcloud_cluster.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/dgraph-io/dgo/v230"
 	"github.com/dgraph-io/dgo/v230/protos/api"
+	"github.com/dgraph-io/dgraph/dgraphapi"
 )
 
 type DCloudCluster struct {
@@ -71,7 +72,7 @@ func (c *DCloudCluster) init() error {
 	return nil
 }
 
-func (c *DCloudCluster) Client() (*GrpcClient, func(), error) {
+func (c *DCloudCluster) Client() (*dgraphapi.GrpcClient, func(), error) {
 	var conns []*grpc.ClientConn
 	conn, err := dgo.DialCloud(c.url, c.token)
 	if err != nil {
@@ -87,10 +88,10 @@ func (c *DCloudCluster) Client() (*GrpcClient, func(), error) {
 		}
 	}
 	client := dgo.NewDgraphClient(api.NewDgraphClient(conn))
-	return &GrpcClient{Dgraph: client}, cleanup, nil
+	return &dgraphapi.GrpcClient{Dgraph: client}, cleanup, nil
 }
 
-func (c *DCloudCluster) HTTPClient() (*HTTPClient, error) {
+func (c *DCloudCluster) HTTPClient() (*dgraphapi.HTTPClient, error) {
 	return nil, errNotImplemented
 }
 
@@ -160,4 +161,9 @@ func (c1 *DCloudCluster) AssignUids(client *dgo.Dgraph, num uint64) error {
 
 func (c *DCloudCluster) GetVersion() string {
 	return localVersion
+}
+
+// GetRepoDir returns the repositroty directory of the cluster
+func (c *DCloudCluster) GetRepoDir() (string, error) {
+	return "", errNotImplemented
 }

--- a/dgraphtest/dgraph.go
+++ b/dgraphtest/dgraph.go
@@ -23,6 +23,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"testing"
 	"time"
 
 	"github.com/docker/docker/api/types/mount"
@@ -56,9 +57,6 @@ const (
 	aclSecretMountPath = "/secrets/secret-key"
 	encKeyFile         = "enc-key"
 	encKeyMountPath    = "/secrets/enc-key"
-
-	DefaultUser     = "groot"
-	DefaultPassword = "password"
 
 	goBinMountPath     = "/gobin"
 	localVersion       = "local"
@@ -414,4 +412,16 @@ func mountBinary(c *LocalCluster) (mount.Mount, error) {
 		Target:   goBinMountPath,
 		ReadOnly: true,
 	}, nil
+}
+
+// ShouldSkipTest skips a given test if clusterVersion < minVersion
+func ShouldSkipTest(t *testing.T, minVersion, clusterVersion string) error {
+	supported, err := IsHigherVersion(clusterVersion, minVersion)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !supported {
+		t.Skipf("test is valid for commits greater than [%v]", minVersion)
+	}
+	return nil
 }

--- a/dgraphtest/load.go
+++ b/dgraphtest/load.go
@@ -34,6 +34,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/dgraph-io/dgo/v230/protos/api"
+	"github.com/dgraph-io/dgraph/dgraphapi"
 	"github.com/dgraph-io/dgraph/ee/enc"
 	"github.com/dgraph-io/dgraph/x"
 )
@@ -138,7 +139,7 @@ func setDQLSchema(c *LocalCluster, files []string) error {
 	if c.conf.acl {
 		ctx, cancel := context.WithTimeout(context.Background(), requestTimeout)
 		defer cancel()
-		err := gc.LoginIntoNamespace(ctx, DefaultUser, DefaultPassword, x.GalaxyNamespace)
+		err := gc.LoginIntoNamespace(ctx, dgraphapi.DefaultUser, dgraphapi.DefaultPassword, x.GalaxyNamespace)
 		if err != nil {
 			return errors.Wrap(err, "error login to default namespace")
 		}
@@ -188,7 +189,7 @@ func setGraphQLSchema(c *LocalCluster, files []string) error {
 			}
 
 			if c.conf.acl {
-				err := hc.LoginIntoNamespace(DefaultUser, DefaultPassword, nss.Namespace)
+				err := hc.LoginIntoNamespace(dgraphapi.DefaultUser, dgraphapi.DefaultPassword, nss.Namespace)
 				if err != nil {
 					return errors.Wrap(err, "error login into default namespace")
 				}
@@ -233,7 +234,7 @@ func (c *LocalCluster) LiveLoad(opts LiveOpts) error {
 	}
 	if c.conf.acl {
 		args = append(args, fmt.Sprintf("--creds=user=%s;password=%s;namespace=%d",
-			DefaultUser, DefaultPassword, x.GalaxyNamespace))
+			dgraphapi.DefaultUser, dgraphapi.DefaultPassword, x.GalaxyNamespace))
 	}
 	if c.conf.encryption {
 		args = append(args, fmt.Sprintf("--encryption=key-file=%v", c.encKeyPath))
@@ -261,7 +262,7 @@ func findGrootAndGuardians(c *LocalCluster) (string, string, error) {
 	if c.conf.acl {
 		ctx, cancel := context.WithTimeout(context.Background(), requestTimeout)
 		defer cancel()
-		err = gc.LoginIntoNamespace(ctx, DefaultUser, DefaultPassword, x.GalaxyNamespace)
+		err = gc.LoginIntoNamespace(ctx, dgraphapi.DefaultUser, dgraphapi.DefaultPassword, x.GalaxyNamespace)
 		if err != nil {
 			return "", "", errors.Wrapf(err, "error logging in as groot")
 		}
@@ -502,7 +503,7 @@ func (c *LocalCluster) BulkLoad(opts BulkOpts) error {
 }
 
 // AddData will insert a total of end-start triples into the database.
-func AddData(gc *GrpcClient, pred string, start, end int) error {
+func AddData(gc *dgraphapi.GrpcClient, pred string, start, end int) error {
 	if err := gc.SetupSchema(fmt.Sprintf(`%v: string @index(exact) .`, pred)); err != nil {
 		return err
 	}

--- a/edgraph/server.go
+++ b/edgraph/server.go
@@ -303,7 +303,7 @@ func parseSchemaFromAlterOperation(ctx context.Context, op *api.Operation) (
 
 		// Pre-defined predicates cannot be altered but let the update go through
 		// if the update is equal to the existing one.
-		if schema.IsPreDefPredChanged(update) {
+		if schema.CheckAndModifyPreDefPredicate(update) {
 			return nil, errors.Errorf("predicate %s is pre-defined and is not allowed to be"+
 				" modified", x.ParseAttr(update.Predicate))
 		}

--- a/ee/acl/acl_curl_test.go
+++ b/ee/acl/acl_curl_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/golang/glog"
 	"github.com/stretchr/testify/require"
 
-	"github.com/dgraph-io/dgraph/dgraphtest"
+	"github.com/dgraph-io/dgraph/dgraphapi"
 	"github.com/dgraph-io/dgraph/testutil"
 	"github.com/dgraph-io/dgraph/x"
 )
@@ -37,13 +37,13 @@ func (asuite *AclTestSuite) TestCurlAuthorization() {
 	gc, cleanup, err := asuite.dc.Client()
 	require.NoError(t, err)
 	defer cleanup()
-	require.NoError(t, gc.LoginIntoNamespace(ctx, dgraphtest.DefaultUser,
-		dgraphtest.DefaultPassword, x.GalaxyNamespace))
+	require.NoError(t, gc.LoginIntoNamespace(ctx, dgraphapi.DefaultUser,
+		dgraphapi.DefaultPassword, x.GalaxyNamespace))
 
 	hc, err := asuite.dc.HTTPClient()
 	require.NoError(t, err)
-	require.NoError(t, hc.LoginIntoNamespace(dgraphtest.DefaultUser,
-		dgraphtest.DefaultPassword, x.GalaxyNamespace))
+	require.NoError(t, hc.LoginIntoNamespace(dgraphapi.DefaultUser,
+		dgraphapi.DefaultPassword, x.GalaxyNamespace))
 	createAccountAndData(t, gc, hc)
 
 	// test query through curl
@@ -104,8 +104,8 @@ func (asuite *AclTestSuite) TestCurlAuthorization() {
 	require.NoError(t, err, fmt.Sprintf("login through refresh httpToken failed: %v", err))
 	hcWithGroot, err := asuite.dc.HTTPClient()
 	require.NoError(t, err)
-	require.NoError(t, hcWithGroot.LoginIntoNamespace(dgraphtest.DefaultUser,
-		dgraphtest.DefaultPassword, x.GalaxyNamespace))
+	require.NoError(t, hcWithGroot.LoginIntoNamespace(dgraphapi.DefaultUser,
+		dgraphapi.DefaultPassword, x.GalaxyNamespace))
 	createGroupAndAcls(t, unusedGroup, false, hcWithGroot)
 	time.Sleep(expireJwtSleep)
 	testutil.VerifyCurlCmd(t, queryArgs(hc.AccessJwt), &testutil.CurlFailureConfig{
@@ -129,8 +129,8 @@ func (asuite *AclTestSuite) TestCurlAuthorization() {
 		ShouldFail:   true,
 		DgraphErrMsg: "PermissionDenied",
 	})
-	require.NoError(t, hcWithGroot.LoginIntoNamespace(dgraphtest.DefaultUser,
-		dgraphtest.DefaultPassword, x.GalaxyNamespace))
+	require.NoError(t, hcWithGroot.LoginIntoNamespace(dgraphapi.DefaultUser,
+		dgraphapi.DefaultPassword, x.GalaxyNamespace))
 	createGroupAndAcls(t, devGroup, true, hcWithGroot)
 	time.Sleep(defaultTimeToSleep)
 	// refresh the jwts again

--- a/ee/acl/acl_integration_test.go
+++ b/ee/acl/acl_integration_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/dgraph-io/dgo/v230/protos/api"
-	"github.com/dgraph-io/dgraph/dgraphtest"
+	"github.com/dgraph-io/dgraph/dgraphapi"
 	"github.com/dgraph-io/dgraph/x"
 )
 
@@ -46,9 +46,9 @@ func (asuite *AclTestSuite) TestPasswordReturn() {
 	t := asuite.T()
 	hc, err := asuite.dc.HTTPClient()
 	require.NoError(t, err)
-	require.NoError(t, hc.LoginIntoNamespace(dgraphtest.DefaultUser,
-		dgraphtest.DefaultPassword, x.GalaxyNamespace))
-	query := dgraphtest.GraphQLParams{
+	require.NoError(t, hc.LoginIntoNamespace(dgraphapi.DefaultUser,
+		dgraphapi.DefaultPassword, x.GalaxyNamespace))
+	query := dgraphapi.GraphQLParams{
 		Query: `
 	query {
 		getCurrentUser {
@@ -66,8 +66,8 @@ func (asuite *AclTestSuite) TestHealthForAcl() {
 	t := asuite.T()
 	hc, err := asuite.dc.HTTPClient()
 	require.NoError(t, err)
-	require.NoError(t, hc.LoginIntoNamespace(dgraphtest.DefaultUser,
-		dgraphtest.DefaultPassword, x.GalaxyNamespace))
+	require.NoError(t, hc.LoginIntoNamespace(dgraphapi.DefaultUser,
+		dgraphapi.DefaultPassword, x.GalaxyNamespace))
 
 	resetUser(t, hc)
 	require.NoError(t, hc.LoginIntoNamespace(userid, userpassword, x.GalaxyNamespace))
@@ -77,8 +77,8 @@ func (asuite *AclTestSuite) TestHealthForAcl() {
 	assertNonGuardianFailure(t, "health", false, gqlResp, err)
 
 	// assert data for guardians
-	require.NoError(t, hc.LoginIntoNamespace(dgraphtest.DefaultUser,
-		dgraphtest.DefaultPassword, x.GalaxyNamespace))
+	require.NoError(t, hc.LoginIntoNamespace(dgraphapi.DefaultUser,
+		dgraphapi.DefaultPassword, x.GalaxyNamespace))
 
 	resp, err := hc.HealthForInstance()
 	require.NoError(t, err, "health request failed")
@@ -336,11 +336,11 @@ func (asuite *AclTestSuite) TestGuardianOnlyAccessForAdminEndpoints() {
 
 	for _, tcase := range tcases {
 		t.Run(tcase.name, func(t *testing.T) {
-			params := dgraphtest.GraphQLParams{Query: tcase.query}
+			params := dgraphapi.GraphQLParams{Query: tcase.query}
 			hc, err := asuite.dc.HTTPClient()
 			require.NoError(t, err)
-			require.NoError(t, hc.LoginIntoNamespace(dgraphtest.DefaultUser,
-				dgraphtest.DefaultPassword, x.GalaxyNamespace))
+			require.NoError(t, hc.LoginIntoNamespace(dgraphapi.DefaultUser,
+				dgraphapi.DefaultPassword, x.GalaxyNamespace))
 
 			resetUser(t, hc)
 			require.NoError(t, hc.LoginIntoNamespace(userid, userpassword, x.GalaxyNamespace))
@@ -351,8 +351,8 @@ func (asuite *AclTestSuite) TestGuardianOnlyAccessForAdminEndpoints() {
 
 			// for guardians, assert non-ACL error or success
 			if tcase.testGuardianAccess {
-				require.NoError(t, hc.LoginIntoNamespace(dgraphtest.DefaultUser,
-					dgraphtest.DefaultPassword, x.GalaxyNamespace))
+				require.NoError(t, hc.LoginIntoNamespace(dgraphapi.DefaultUser,
+					dgraphapi.DefaultPassword, x.GalaxyNamespace))
 
 				resp, err := hc.RunGraphqlQuery(params, true)
 				if tcase.guardianErr == "" {
@@ -378,13 +378,13 @@ func (asuite *AclTestSuite) TestFailedLogin() {
 	gc, cleanup, err := asuite.dc.Client()
 	require.NoError(t, err)
 	defer cleanup()
-	require.NoError(t, gc.LoginIntoNamespace(ctx, dgraphtest.DefaultUser,
-		dgraphtest.DefaultPassword, x.GalaxyNamespace))
+	require.NoError(t, gc.LoginIntoNamespace(ctx, dgraphapi.DefaultUser,
+		dgraphapi.DefaultPassword, x.GalaxyNamespace))
 
 	hc, err := asuite.dc.HTTPClient()
 	require.NoError(t, err)
-	require.NoError(t, hc.LoginIntoNamespace(dgraphtest.DefaultUser,
-		dgraphtest.DefaultPassword, x.GalaxyNamespace))
+	require.NoError(t, hc.LoginIntoNamespace(dgraphapi.DefaultUser,
+		dgraphapi.DefaultPassword, x.GalaxyNamespace))
 
 	require.NoError(t, gc.DropAll())
 
@@ -410,8 +410,9 @@ func (asuite *AclTestSuite) TestWrongPermission() {
 	gc, cleanup, err := asuite.dc.Client()
 	require.NoError(t, err)
 	defer cleanup()
-	require.NoError(t, gc.LoginIntoNamespace(ctx, dgraphtest.DefaultUser,
-		dgraphtest.DefaultPassword, x.GalaxyNamespace))
+	require.NoError(t, gc.LoginIntoNamespace(ctx, dgraphapi.DefaultUser,
+		dgraphapi.DefaultPassword, x.GalaxyNamespace))
+	require.NoError(t, gc.DropAll())
 
 	mu := &api.Mutation{SetNquads: []byte(`
 	_:dev <dgraph.type> "dgraph.type.Group" .
@@ -436,4 +437,21 @@ func (asuite *AclTestSuite) TestWrongPermission() {
 
 	require.Error(t, err, "Setting permission to -1 should have returned error")
 	require.Contains(t, err.Error(), "Value for this predicate should be between 0 and 7")
+}
+
+func (asuite *AclTestSuite) TestACLDuplicateGrootUser() {
+	t := asuite.T()
+	gc, cleanup, err := asuite.dc.Client()
+	require.NoError(t, err)
+	defer cleanup()
+	require.NoError(t, gc.LoginIntoNamespace(context.Background(),
+		dgraphapi.DefaultUser, dgraphapi.DefaultPassword, x.GalaxyNamespace))
+
+	rdfs := `_:a <dgraph.xid> "groot" .
+	         _:a <dgraph.type> "dgraph.type.User"  .`
+
+	mu := &api.Mutation{SetNquads: []byte(rdfs), CommitNow: true}
+	_, err = gc.Mutate(mu)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "could not insert duplicate value [groot] for predicate [dgraph.xid]")
 }

--- a/ee/acl/acl_test.go
+++ b/ee/acl/acl_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/dgraph-io/dgo/v230"
 	"github.com/dgraph-io/dgo/v230/protos/api"
+	"github.com/dgraph-io/dgraph/dgraphapi"
 	"github.com/dgraph-io/dgraph/dgraphtest"
 	"github.com/dgraph-io/dgraph/x"
 )
@@ -33,6 +34,274 @@ import (
 var (
 	userid       = "alice"
 	userpassword = "simplepassword"
+)
+
+const (
+
+	// This is the groot schema before adding @unique directive to the dgraph.xid predicate
+	oldGrootSchema = `{
+	"schema": [
+	  {
+		"predicate": "dgraph.acl.rule",
+		"type": "uid",
+		"list": true
+	  },
+	  {
+		  "predicate":"dgraph.drop.op",
+		  "type":"string"
+	  },
+	  {
+		  "predicate":"dgraph.graphql.p_query",
+		  "type":"string",
+		  "index":true,
+		  "tokenizer":["sha256"]
+	  },
+	  {
+		"predicate": "dgraph.graphql.schema",
+		"type": "string"
+	  },
+	  {
+		"predicate": "dgraph.graphql.xid",
+		"type": "string",
+		"index": true,
+		"tokenizer": [
+		  "exact"
+		],
+		"upsert": true
+	  },
+	  {
+		"predicate": "dgraph.password",
+		"type": "password"
+	  },
+	  {
+		"predicate": "dgraph.rule.permission",
+		"type": "int"
+	  },
+	  {
+		"predicate": "dgraph.rule.predicate",
+		"type": "string",
+		"index": true,
+		"tokenizer": [
+		  "exact"
+		],
+		"upsert": true
+	  },
+	  {
+		"predicate": "dgraph.type",
+		"type": "string",
+		"index": true,
+		"tokenizer": [
+		  "exact"
+		],
+		"list": true
+	  },
+	  {
+		"predicate": "dgraph.user.group",
+		"type": "uid",
+		"reverse": true,
+		"list": true
+	  },
+	  {
+		"predicate": "dgraph.xid",
+		"type": "string",
+		"index": true,
+		"tokenizer": [
+		  "exact"
+		],
+		"upsert": true
+	  }
+	],
+	"types": [
+	  {
+		"fields": [
+		  {
+			"name": "dgraph.graphql.schema"
+		  },
+		  {
+			"name": "dgraph.graphql.xid"
+		  }
+		],
+		"name": "dgraph.graphql"
+	  },
+	  {
+		  "fields": [
+			  {
+				  "name": "dgraph.graphql.p_query"
+			  }
+		  ],
+		  "name": "dgraph.graphql.persisted_query"
+	  },
+	  {
+		"fields": [
+		  {
+			"name": "dgraph.xid"
+		  },
+		  {
+			"name": "dgraph.acl.rule"
+		  }
+		],
+		"name": "dgraph.type.Group"
+	  },
+	  {
+		"fields": [
+		  {
+			"name": "dgraph.rule.predicate"
+		  },
+		  {
+			"name": "dgraph.rule.permission"
+		  }
+		],
+		"name": "dgraph.type.Rule"
+	  },
+	  {
+		"fields": [
+		  {
+			"name": "dgraph.xid"
+		  },
+		  {
+			"name": "dgraph.password"
+		  },
+		  {
+			"name": "dgraph.user.group"
+		  }
+		],
+		"name": "dgraph.type.User"
+	  }
+	]
+  }`
+
+	// This is the groot schema after adding @unique directive to the dgraph.xid predicate
+	newGrootSchema = `{
+	"schema": [
+	  {
+		"predicate": "dgraph.acl.rule",
+		"type": "uid",
+		"list": true
+	  },
+	  {
+		  "predicate":"dgraph.drop.op",
+		  "type":"string"
+	  },
+	  {
+		  "predicate":"dgraph.graphql.p_query",
+		  "type":"string",
+		  "index":true,
+		  "tokenizer":["sha256"]
+	  },
+	  {
+		"predicate": "dgraph.graphql.schema",
+		"type": "string"
+	  },
+	  {
+		"predicate": "dgraph.graphql.xid",
+		"type": "string",
+		"index": true,
+		"tokenizer": [
+		  "exact"
+		],
+		"upsert": true
+		},
+	  {
+		"predicate": "dgraph.password",
+		"type": "password"
+	  },
+	  {
+		"predicate": "dgraph.rule.permission",
+		"type": "int"
+	  },
+	  {
+		"predicate": "dgraph.rule.predicate",
+		"type": "string",
+		"index": true,
+		"tokenizer": [
+		  "exact"
+		],
+		"upsert": true
+	  },
+	  {
+		"predicate": "dgraph.type",
+		"type": "string",
+		"index": true,
+		"tokenizer": [
+		  "exact"
+		],
+		"list": true
+	  },
+	  {
+		"predicate": "dgraph.user.group",
+		"type": "uid",
+		"reverse": true,
+		"list": true
+	  },
+	  {
+		"predicate": "dgraph.xid",
+		"type": "string",
+		"index": true,
+		"tokenizer": [
+		  "exact"
+		],
+		"upsert": true,
+		"unique": true
+	  }
+	],
+	"types": [
+	  {
+		"fields": [
+		  {
+			"name": "dgraph.graphql.schema"
+		  },
+		  {
+			"name": "dgraph.graphql.xid"
+		  }
+		],
+		"name": "dgraph.graphql"
+	  },
+	  {
+		  "fields": [
+			  {
+				  "name": "dgraph.graphql.p_query"
+			  }
+		  ],
+		  "name": "dgraph.graphql.persisted_query"
+	  },
+	  {
+		"fields": [
+		  {
+			"name": "dgraph.xid"
+		  },
+		  {
+			"name": "dgraph.acl.rule"
+		  }
+		],
+		"name": "dgraph.type.Group"
+	  },
+	  {
+		"fields": [
+		  {
+			"name": "dgraph.rule.predicate"
+		  },
+		  {
+			"name": "dgraph.rule.permission"
+		  }
+		],
+		"name": "dgraph.type.Rule"
+	  },
+	  {
+		"fields": [
+		  {
+			"name": "dgraph.xid"
+		  },
+		  {
+			"name": "dgraph.password"
+		  },
+		  {
+			"name": "dgraph.user.group"
+		  }
+		],
+		"name": "dgraph.type.User"
+	  }
+	]
+  }`
 )
 
 func checkUserCount(t *testing.T, resp []byte, expected int) {
@@ -68,8 +337,8 @@ func (asuite *AclTestSuite) TestGetCurrentUser() {
 
 	hc, err := asuite.dc.HTTPClient()
 	require.NoError(t, err)
-	require.NoError(t, hc.LoginIntoNamespace(dgraphtest.DefaultUser,
-		dgraphtest.DefaultPassword, x.GalaxyNamespace), "login failed")
+	require.NoError(t, hc.LoginIntoNamespace(dgraphapi.DefaultUser,
+		dgraphapi.DefaultPassword, x.GalaxyNamespace), "login failed")
 	currentUser, err := hc.GetCurrentUser()
 	require.NoError(t, err)
 	require.Equal(t, currentUser, "groot")
@@ -100,8 +369,8 @@ func (asuite *AclTestSuite) TestCreateAndDeleteUsers() {
 	resetUser(t, hc)
 
 	// adding the user again should fail
-	require.NoError(t, hc.LoginIntoNamespace(dgraphtest.DefaultUser,
-		dgraphtest.DefaultPassword, x.GalaxyNamespace))
+	require.NoError(t, hc.LoginIntoNamespace(dgraphapi.DefaultUser,
+		dgraphapi.DefaultPassword, x.GalaxyNamespace))
 	user, err := hc.CreateUser(userid, userpassword)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "because id alice already exists")
@@ -112,16 +381,16 @@ func (asuite *AclTestSuite) TestCreateAndDeleteUsers() {
 	// delete the user
 	hc, err = asuite.dc.HTTPClient()
 	require.NoError(t, err)
-	require.NoError(t, hc.LoginIntoNamespace(dgraphtest.DefaultUser,
-		dgraphtest.DefaultPassword, x.GalaxyNamespace))
+	require.NoError(t, hc.LoginIntoNamespace(dgraphapi.DefaultUser,
+		dgraphapi.DefaultPassword, x.GalaxyNamespace))
 	require.NoError(t, hc.DeleteUser(userid), "error while deleteing user")
 	user, err = hc.CreateUser(userid, userpassword)
 	require.NoError(t, err)
 	require.Equal(t, userid, user)
 }
 
-func resetUser(t *testing.T, hc *dgraphtest.HTTPClient) {
-	require.NoError(t, hc.LoginIntoNamespace(dgraphtest.DefaultUser, dgraphtest.DefaultPassword, x.GalaxyNamespace))
+func resetUser(t *testing.T, hc *dgraphapi.HTTPClient) {
+	require.NoError(t, hc.LoginIntoNamespace(dgraphapi.DefaultUser, dgraphapi.DefaultPassword, x.GalaxyNamespace))
 
 	// clean up the user to allow repeated running of this test
 	require.NoError(t, hc.DeleteUser(userid), "error while deleteing user")
@@ -140,9 +409,9 @@ func (asuite *AclTestSuite) TestPreDefinedPredicates() {
 	require.NoError(t, err)
 	defer cleanup()
 	ctx := context.Background()
-	require.NoError(t, gc.LoginIntoNamespace(ctx, dgraphtest.DefaultUser,
-		dgraphtest.DefaultPassword, x.GalaxyNamespace))
-	alterPreDefinedPredicates(t, gc.Dgraph)
+	require.NoError(t, gc.LoginIntoNamespace(ctx, dgraphapi.DefaultUser,
+		dgraphapi.DefaultPassword, x.GalaxyNamespace))
+	alterPreDefinedPredicates(t, gc.Dgraph, asuite.dc.GetVersion())
 }
 
 func (asuite *AclTestSuite) TestPreDefinedTypes() {
@@ -154,8 +423,8 @@ func (asuite *AclTestSuite) TestPreDefinedTypes() {
 	require.NoError(t, err)
 	defer cleanup()
 	ctx := context.Background()
-	require.NoError(t, gc.LoginIntoNamespace(ctx, dgraphtest.DefaultUser,
-		dgraphtest.DefaultPassword, x.GalaxyNamespace))
+	require.NoError(t, gc.LoginIntoNamespace(ctx, dgraphapi.DefaultUser,
+		dgraphapi.DefaultPassword, x.GalaxyNamespace))
 
 	alterPreDefinedTypes(t, gc.Dgraph)
 }
@@ -172,7 +441,7 @@ func (asuite *AclTestSuite) TestAuthorization() {
 	testAuthorization(t, gc, hc, asuite)
 }
 
-func getGrootAndGuardiansUid(t *testing.T, gc *dgraphtest.GrpcClient) (string, string) {
+func getGrootAndGuardiansUid(t *testing.T, gc *dgraphapi.GrpcClient) (string, string) {
 	grootUserQuery := `
 	{
 		grootUser(func:eq(dgraph.xid, "groot")){
@@ -228,7 +497,7 @@ const (
 	expireJwtSleep     = 21 * time.Second
 )
 
-func testAuthorization(t *testing.T, gc *dgraphtest.GrpcClient, hc *dgraphtest.HTTPClient, asuite *AclTestSuite) {
+func testAuthorization(t *testing.T, gc *dgraphapi.GrpcClient, hc *dgraphapi.HTTPClient, asuite *AclTestSuite) {
 	createAccountAndData(t, gc, hc)
 	asuite.Upgrade()
 
@@ -239,7 +508,7 @@ func testAuthorization(t *testing.T, gc *dgraphtest.GrpcClient, hc *dgraphtest.H
 
 	hc, err = asuite.dc.HTTPClient()
 	require.NoError(t, err)
-	require.NoError(t, hc.LoginIntoNamespace(dgraphtest.DefaultUser, dgraphtest.DefaultPassword, x.GalaxyNamespace))
+	require.NoError(t, hc.LoginIntoNamespace(dgraphapi.DefaultUser, dgraphapi.DefaultPassword, x.GalaxyNamespace))
 
 	// initially the query should return empty result, mutate and alter
 	// operations should all fail when there are no rules defined on the predicates
@@ -295,16 +564,27 @@ var (
 	}`, predicateToRead, queryAttr)
 )
 
-func alterPreDefinedPredicates(t *testing.T, dg *dgo.Dgraph) {
+func alterPreDefinedPredicates(t *testing.T, dg *dgo.Dgraph, clusterVersion string) {
 	ctx := context.Background()
 
-	// Test that alter requests are allowed if the new update is the same as
-	// the initial update for a pre-defined predicate.
-	require.NoError(t, dg.Alter(ctx, &api.Operation{
-		Schema: "dgraph.xid: string @index(exact) @upsert .",
-	}))
+	// Commit daa5805739ed258e913a157c6e0f126b2291b1b0 represents the latest update to the main branch.
+	// In this commit, the @unique directive is not applied to ACL predicates.
+	// Therefore, we are now deciding which schema to test.
+	// 'newGrootSchema' refers to the default schema with the @unique directive defined on ACL predicates.
+	// 'oldGrootSchema' refers to the default schema without the @unique directive on ACL predicates.
+	supported, err := dgraphtest.IsHigherVersion(clusterVersion, "daa5805739ed258e913a157c6e0f126b2291b1b0")
+	require.NoError(t, err)
+	if supported {
+		require.NoError(t, dg.Alter(ctx, &api.Operation{
+			Schema: "dgraph.xid: string @index(exact) @upsert @unique .",
+		}))
+	} else {
+		require.NoError(t, dg.Alter(ctx, &api.Operation{
+			Schema: "dgraph.xid: string @index(exact) @upsert .",
+		}))
+	}
 
-	err := dg.Alter(ctx, &api.Operation{Schema: "dgraph.xid: int ."})
+	err = dg.Alter(ctx, &api.Operation{Schema: "dgraph.xid: int ."})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "predicate dgraph.xid is pre-defined and is not allowed to be modified")
 
@@ -351,7 +631,7 @@ func alterPreDefinedTypes(t *testing.T, dg *dgo.Dgraph) {
 	require.Contains(t, err.Error(), "type dgraph.type.Group is pre-defined and is not allowed to be dropped")
 }
 
-func queryWithShouldFail(t *testing.T, gc *dgraphtest.GrpcClient, shouldFail bool, query string) {
+func queryWithShouldFail(t *testing.T, gc *dgraphapi.GrpcClient, shouldFail bool, query string) {
 	_, err := gc.Query(query)
 	if shouldFail {
 		require.Error(t, err, "the query should have failed")
@@ -360,7 +640,7 @@ func queryWithShouldFail(t *testing.T, gc *dgraphtest.GrpcClient, shouldFail boo
 	}
 }
 
-func mutatePredicateWithUserAccount(t *testing.T, gc *dgraphtest.GrpcClient, shouldFail bool) {
+func mutatePredicateWithUserAccount(t *testing.T, gc *dgraphapi.GrpcClient, shouldFail bool) {
 	mu := &api.Mutation{SetNquads: []byte(fmt.Sprintf(`_:a <%s>  "string" .`, predicateToWrite)), CommitNow: true}
 	_, err := gc.Mutate(mu)
 	if shouldFail {
@@ -370,7 +650,7 @@ func mutatePredicateWithUserAccount(t *testing.T, gc *dgraphtest.GrpcClient, sho
 	}
 }
 
-func alterPredicateWithUserAccount(t *testing.T, gc *dgraphtest.GrpcClient, shouldFail bool) {
+func alterPredicateWithUserAccount(t *testing.T, gc *dgraphapi.GrpcClient, shouldFail bool) {
 	err := gc.Alter(context.Background(), &api.Operation{Schema: fmt.Sprintf(`%s: int .`, predicateToAlter)})
 	if shouldFail {
 		require.Error(t, err, "the alter should have failed")
@@ -379,10 +659,10 @@ func alterPredicateWithUserAccount(t *testing.T, gc *dgraphtest.GrpcClient, shou
 	}
 }
 
-func createAccountAndData(t *testing.T, gc *dgraphtest.GrpcClient, hc *dgraphtest.HTTPClient) {
+func createAccountAndData(t *testing.T, gc *dgraphapi.GrpcClient, hc *dgraphapi.HTTPClient) {
 	// use the groot account to clean the database
-	require.NoError(t, gc.LoginIntoNamespace(context.Background(), dgraphtest.DefaultUser,
-		dgraphtest.DefaultPassword, x.GalaxyNamespace))
+	require.NoError(t, gc.LoginIntoNamespace(context.Background(), dgraphapi.DefaultUser,
+		dgraphapi.DefaultPassword, x.GalaxyNamespace))
 
 	require.NoError(t, gc.DropAll(), "Unable to cleanup db")
 	require.NoError(t, gc.Alter(context.Background(), &api.Operation{
@@ -409,7 +689,7 @@ type group struct {
 	Rules []rule `json:"rules"`
 }
 
-func createGroupAndAcls(t *testing.T, group string, addUserToGroup bool, hc *dgraphtest.HTTPClient) {
+func createGroupAndAcls(t *testing.T, group string, addUserToGroup bool, hc *dgraphapi.HTTPClient) {
 	// create a new group
 	createdGroup, err := hc.CreateGroup(group)
 	require.NoError(t, err)
@@ -420,7 +700,7 @@ func createGroupAndAcls(t *testing.T, group string, addUserToGroup bool, hc *dgr
 		require.NoError(t, hc.AddUserToGroup(userid, group))
 	}
 
-	rules := []dgraphtest.AclRule{
+	rules := []dgraphapi.AclRule{
 		{
 			Predicate: predicateToRead, Permission: Read.Code,
 		},
@@ -454,9 +734,9 @@ func (asuite *AclTestSuite) TestPredicatePermission() {
 
 	hc, err := asuite.dc.HTTPClient()
 	require.NoError(t, err)
-	require.NoError(t, hc.LoginIntoNamespace(dgraphtest.DefaultUser, dgraphtest.DefaultPassword, x.GalaxyNamespace))
-	require.NoError(t, gc.LoginIntoNamespace(ctx, dgraphtest.DefaultUser,
-		dgraphtest.DefaultPassword, x.GalaxyNamespace))
+	require.NoError(t, hc.LoginIntoNamespace(dgraphapi.DefaultUser, dgraphapi.DefaultPassword, x.GalaxyNamespace))
+	require.NoError(t, gc.LoginIntoNamespace(ctx, dgraphapi.DefaultUser,
+		dgraphapi.DefaultPassword, x.GalaxyNamespace))
 
 	createAccountAndData(t, gc, hc)
 
@@ -466,12 +746,12 @@ func (asuite *AclTestSuite) TestPredicatePermission() {
 	require.NoError(t, err)
 	defer cleanup()
 
-	require.NoError(t, gc.LoginIntoNamespace(ctx, dgraphtest.DefaultUser,
-		dgraphtest.DefaultPassword, x.GalaxyNamespace))
+	require.NoError(t, gc.LoginIntoNamespace(ctx, dgraphapi.DefaultUser,
+		dgraphapi.DefaultPassword, x.GalaxyNamespace))
 	hc, err = asuite.dc.HTTPClient()
 	require.NoError(t, err)
-	require.NoError(t, hc.LoginIntoNamespace(dgraphtest.DefaultUser,
-		dgraphtest.DefaultPassword, x.GalaxyNamespace))
+	require.NoError(t, hc.LoginIntoNamespace(dgraphapi.DefaultUser,
+		dgraphapi.DefaultPassword, x.GalaxyNamespace))
 
 	require.NoError(t, gc.LoginIntoNamespace(ctx, userid, userpassword, x.GalaxyNamespace),
 		"Logging in with the current password should have succeeded")
@@ -509,9 +789,9 @@ func (asuite *AclTestSuite) TestAccessWithoutLoggingIn() {
 
 	hc, err := asuite.dc.HTTPClient()
 	require.NoError(t, err)
-	require.NoError(t, hc.LoginIntoNamespace(dgraphtest.DefaultUser, dgraphtest.DefaultPassword, x.GalaxyNamespace))
-	require.NoError(t, gc.LoginIntoNamespace(ctx, dgraphtest.DefaultUser,
-		dgraphtest.DefaultPassword, x.GalaxyNamespace))
+	require.NoError(t, hc.LoginIntoNamespace(dgraphapi.DefaultUser, dgraphapi.DefaultPassword, x.GalaxyNamespace))
+	require.NoError(t, gc.LoginIntoNamespace(ctx, dgraphapi.DefaultUser,
+		dgraphapi.DefaultPassword, x.GalaxyNamespace))
 
 	createAccountAndData(t, gc, hc)
 
@@ -540,8 +820,8 @@ func (asuite *AclTestSuite) TestUnauthorizedDeletion() {
 	gc, cleanup, err := asuite.dc.Client()
 	require.NoError(t, err)
 	defer cleanup()
-	require.NoError(t, gc.LoginIntoNamespace(ctx, dgraphtest.DefaultUser,
-		dgraphtest.DefaultPassword, x.GalaxyNamespace))
+	require.NoError(t, gc.LoginIntoNamespace(ctx, dgraphapi.DefaultUser,
+		dgraphapi.DefaultPassword, x.GalaxyNamespace))
 
 	require.NoError(t, gc.DropAll())
 
@@ -551,8 +831,8 @@ func (asuite *AclTestSuite) TestUnauthorizedDeletion() {
 
 	hc, err := asuite.dc.HTTPClient()
 	require.NoError(t, err)
-	require.NoError(t, hc.LoginIntoNamespace(dgraphtest.DefaultUser,
-		dgraphtest.DefaultPassword, x.GalaxyNamespace))
+	require.NoError(t, hc.LoginIntoNamespace(dgraphapi.DefaultUser,
+		dgraphapi.DefaultPassword, x.GalaxyNamespace))
 
 	resetUser(t, hc)
 
@@ -567,7 +847,7 @@ func (asuite *AclTestSuite) TestUnauthorizedDeletion() {
 	nodeUID, ok := resp.Uids["a"]
 	require.True(t, ok)
 
-	require.NoError(t, hc.AddRulesToGroup(devGroup, []dgraphtest.AclRule{{Predicate: unAuthPred, Permission: 0}}, true))
+	require.NoError(t, hc.AddRulesToGroup(devGroup, []dgraphapi.AclRule{{Predicate: unAuthPred, Permission: 0}}, true))
 
 	asuite.Upgrade()
 
@@ -598,9 +878,9 @@ func (asuite *AclTestSuite) TestGuardianAccess() {
 
 	hc, err := asuite.dc.HTTPClient()
 	require.NoError(t, err)
-	require.NoError(t, hc.LoginIntoNamespace(dgraphtest.DefaultUser, dgraphtest.DefaultPassword, x.GalaxyNamespace))
-	require.NoError(t, gc.LoginIntoNamespace(ctx, dgraphtest.DefaultUser,
-		dgraphtest.DefaultPassword, x.GalaxyNamespace))
+	require.NoError(t, hc.LoginIntoNamespace(dgraphapi.DefaultUser, dgraphapi.DefaultPassword, x.GalaxyNamespace))
+	require.NoError(t, gc.LoginIntoNamespace(ctx, dgraphapi.DefaultUser,
+		dgraphapi.DefaultPassword, x.GalaxyNamespace))
 
 	require.NoError(t, gc.DropAll())
 	op := api.Operation{Schema: "unauthpred: string @index(exact) ."}
@@ -651,7 +931,7 @@ func (asuite *AclTestSuite) TestGuardianAccess() {
 
 	hc, err = asuite.dc.HTTPClient()
 	require.NoError(t, err)
-	require.NoError(t, hc.LoginIntoNamespace(dgraphtest.DefaultUser, dgraphtest.DefaultPassword, x.GalaxyNamespace))
+	require.NoError(t, hc.LoginIntoNamespace(dgraphapi.DefaultUser, dgraphapi.DefaultPassword, x.GalaxyNamespace))
 
 	require.NoError(t, hc.RemoveUserFromGroup("guardian", "guardians"))
 
@@ -667,13 +947,13 @@ func (asuite *AclTestSuite) TestQueryRemoveUnauthorizedPred() {
 	gc, cleanup, err := asuite.dc.Client()
 	require.NoError(t, err)
 	defer cleanup()
-	require.NoError(t, gc.LoginIntoNamespace(ctx, dgraphtest.DefaultUser,
-		dgraphtest.DefaultPassword, x.GalaxyNamespace))
+	require.NoError(t, gc.LoginIntoNamespace(ctx, dgraphapi.DefaultUser,
+		dgraphapi.DefaultPassword, x.GalaxyNamespace))
 
 	hc, err := asuite.dc.HTTPClient()
 	require.NoError(t, err)
-	require.NoError(t, hc.LoginIntoNamespace(dgraphtest.DefaultUser,
-		dgraphtest.DefaultPassword, x.GalaxyNamespace))
+	require.NoError(t, hc.LoginIntoNamespace(dgraphapi.DefaultUser,
+		dgraphapi.DefaultPassword, x.GalaxyNamespace))
 
 	require.NoError(t, gc.DropAll())
 
@@ -711,7 +991,7 @@ func (asuite *AclTestSuite) TestQueryRemoveUnauthorizedPred() {
 
 	// give read access of <name> to alice
 	require.NoError(t, hc.AddRulesToGroup(devGroup,
-		[]dgraphtest.AclRule{{Predicate: "name", Permission: Read.Code}}, true))
+		[]dgraphapi.AclRule{{Predicate: "name", Permission: Read.Code}}, true))
 	asuite.Upgrade()
 	userClient, cleanup, err := asuite.dc.Client()
 	require.NoError(t, err)
@@ -804,7 +1084,7 @@ func (asuite *AclTestSuite) TestQueryRemoveUnauthorizedPred() {
 		t.Run(tc.description, func(t *testing.T) {
 			// testify does not support subtests running in parallel with suite package
 			// t.Parallel()
-			require.NoError(t, dgraphtest.PollTillPassOrTimeout(userClient, tc.input, tc.output, timeout))
+			require.NoError(t, dgraphapi.PollTillPassOrTimeout(userClient, tc.input, tc.output, timeout))
 		})
 	}
 }
@@ -817,12 +1097,12 @@ func (asuite *AclTestSuite) TestExpandQueryWithACLPermissions() {
 	gc, cleanup, err := asuite.dc.Client()
 	require.NoError(t, err)
 	defer cleanup()
-	require.NoError(t, gc.LoginIntoNamespace(ctx, dgraphtest.DefaultUser,
-		dgraphtest.DefaultPassword, x.GalaxyNamespace))
+	require.NoError(t, gc.LoginIntoNamespace(ctx, dgraphapi.DefaultUser,
+		dgraphapi.DefaultPassword, x.GalaxyNamespace))
 
 	hc, err := asuite.dc.HTTPClient()
 	require.NoError(t, err)
-	require.NoError(t, hc.LoginIntoNamespace(dgraphtest.DefaultUser, dgraphtest.DefaultPassword, x.GalaxyNamespace))
+	require.NoError(t, hc.LoginIntoNamespace(dgraphapi.DefaultUser, dgraphapi.DefaultPassword, x.GalaxyNamespace))
 
 	require.NoError(t, gc.DropAll())
 
@@ -846,7 +1126,7 @@ func (asuite *AclTestSuite) TestExpandQueryWithACLPermissions() {
 	createdGroup, err = hc.CreateGroup(sreGroup)
 	require.NoError(t, err)
 	require.Equal(t, sreGroup, createdGroup)
-	require.NoError(t, hc.AddRulesToGroup(sreGroup, []dgraphtest.AclRule{{Predicate: "age", Permission: Read.Code},
+	require.NoError(t, hc.AddRulesToGroup(sreGroup, []dgraphapi.AclRule{{Predicate: "age", Permission: Read.Code},
 		{Predicate: "name", Permission: Write.Code}}, true))
 
 	require.NoError(t, hc.AddUserToGroup(userid, devGroup))
@@ -870,7 +1150,7 @@ func (asuite *AclTestSuite) TestExpandQueryWithACLPermissions() {
 	query := "{me(func: has(name)){expand(_all_)}}"
 	resp, err := gc.Query(query)
 	require.NoError(t, err, "Error while querying data")
-	require.NoError(t, dgraphtest.CompareJSON(
+	require.NoError(t, dgraphapi.CompareJSON(
 		`{"me":[{"name":"RandomGuy","age":23, "nickname":"RG"},{"name":"RandomGuy2","age":25, "nickname":"RG2"}]}`,
 		string(resp.GetJson())))
 
@@ -881,41 +1161,41 @@ func (asuite *AclTestSuite) TestExpandQueryWithACLPermissions() {
 	defer cleanup()
 	hc, err = asuite.dc.HTTPClient()
 	require.NoError(t, err)
-	require.NoError(t, hc.LoginIntoNamespace(dgraphtest.DefaultUser,
-		dgraphtest.DefaultPassword, x.GalaxyNamespace))
+	require.NoError(t, hc.LoginIntoNamespace(dgraphapi.DefaultUser,
+		dgraphapi.DefaultPassword, x.GalaxyNamespace))
 
 	time.Sleep(defaultTimeToSleep)
 
 	require.NoError(t, userClient.LoginIntoNamespace(ctx, userid, userpassword, x.GalaxyNamespace))
 
 	// Query via user when user has no permissions
-	require.NoError(t, dgraphtest.PollTillPassOrTimeout(userClient, query, `{}`, timeout))
+	require.NoError(t, dgraphapi.PollTillPassOrTimeout(userClient, query, `{}`, timeout))
 
 	// Give read access of <name>, write access of <age> to dev
-	require.NoError(t, hc.AddRulesToGroup(devGroup, []dgraphtest.AclRule{{Predicate: "age", Permission: Write.Code},
+	require.NoError(t, hc.AddRulesToGroup(devGroup, []dgraphapi.AclRule{{Predicate: "age", Permission: Write.Code},
 		{Predicate: "name", Permission: Read.Code}}, true))
 
-	require.NoError(t, dgraphtest.PollTillPassOrTimeout(userClient, query,
+	require.NoError(t, dgraphapi.PollTillPassOrTimeout(userClient, query,
 		`{"me":[{"name":"RandomGuy"},{"name":"RandomGuy2"}]}`, timeout))
 
 	// Login to groot to modify accesses (2)
-	require.NoError(t, hc.LoginIntoNamespace(dgraphtest.DefaultUser,
-		dgraphtest.DefaultPassword, x.GalaxyNamespace))
+	require.NoError(t, hc.LoginIntoNamespace(dgraphapi.DefaultUser,
+		dgraphapi.DefaultPassword, x.GalaxyNamespace))
 	// Add alice to sre group which has read access to <age> and write access to <name>
 	require.NoError(t, hc.AddUserToGroup(userid, sreGroup))
 
-	require.NoError(t, dgraphtest.PollTillPassOrTimeout(userClient, query,
+	require.NoError(t, dgraphapi.PollTillPassOrTimeout(userClient, query,
 		`{"me":[{"name":"RandomGuy","age":23},{"name":"RandomGuy2","age":25}]}`, timeout))
 
 	// Login to groot to modify accesses (3)
-	require.NoError(t, hc.LoginIntoNamespace(dgraphtest.DefaultUser,
-		dgraphtest.DefaultPassword, x.GalaxyNamespace))
+	require.NoError(t, hc.LoginIntoNamespace(dgraphapi.DefaultUser,
+		dgraphapi.DefaultPassword, x.GalaxyNamespace))
 
 	// Give read access of <name> and <nickname>, write access of <age> to dev
-	require.NoError(t, hc.AddRulesToGroup(devGroup, []dgraphtest.AclRule{{Predicate: "age", Permission: Write.Code},
+	require.NoError(t, hc.AddRulesToGroup(devGroup, []dgraphapi.AclRule{{Predicate: "age", Permission: Write.Code},
 		{Predicate: "name", Permission: Read.Code}, {Predicate: "nickname", Permission: Read.Code}}, true))
 
-	require.NoError(t, dgraphtest.PollTillPassOrTimeout(userClient, query,
+	require.NoError(t, dgraphapi.PollTillPassOrTimeout(userClient, query,
 		`{"me":[{"name":"RandomGuy","age":23, "nickname":"RG"},{"name":"RandomGuy2","age":25, "nickname":"RG2"}]}`,
 		timeout))
 }
@@ -928,12 +1208,12 @@ func (asuite *AclTestSuite) TestDeleteQueryWithACLPermissions() {
 	gc, cleanup, err := asuite.dc.Client()
 	require.NoError(t, err)
 	defer cleanup()
-	require.NoError(t, gc.LoginIntoNamespace(ctx, dgraphtest.DefaultUser,
-		dgraphtest.DefaultPassword, x.GalaxyNamespace))
+	require.NoError(t, gc.LoginIntoNamespace(ctx, dgraphapi.DefaultUser,
+		dgraphapi.DefaultPassword, x.GalaxyNamespace))
 
 	hc, err := asuite.dc.HTTPClient()
 	require.NoError(t, err)
-	require.NoError(t, hc.LoginIntoNamespace(dgraphtest.DefaultUser, dgraphtest.DefaultPassword, x.GalaxyNamespace))
+	require.NoError(t, hc.LoginIntoNamespace(dgraphapi.DefaultUser, dgraphapi.DefaultPassword, x.GalaxyNamespace))
 
 	require.NoError(t, gc.DropAll())
 
@@ -978,20 +1258,20 @@ func (asuite *AclTestSuite) TestDeleteQueryWithACLPermissions() {
 	// Test that groot has access to all the predicates
 	resp, err = gc.Query(query)
 	require.NoError(t, err, "Error while querying data")
-	require.NoError(t, dgraphtest.CompareJSON(
+	require.NoError(t, dgraphapi.CompareJSON(
 		`{"q1":[{"name":"RandomGuy","age":23, "nickname": "RG"},{"name":"RandomGuy2","age":25,  "nickname": "RG2"}]}`,
 		string(resp.GetJson())))
 
 	// Give Write Access to alice for name and age predicate
-	require.NoError(t, hc.AddRulesToGroup(devGroup, []dgraphtest.AclRule{{Predicate: "name", Permission: Write.Code},
+	require.NoError(t, hc.AddRulesToGroup(devGroup, []dgraphapi.AclRule{{Predicate: "name", Permission: Write.Code},
 		{Predicate: "age", Permission: Write.Code}}, true))
 
 	asuite.Upgrade()
 
 	gc, _, err = asuite.dc.Client()
 	require.NoError(t, err)
-	require.NoError(t, gc.LoginIntoNamespace(ctx, dgraphtest.DefaultUser,
-		dgraphtest.DefaultPassword, x.GalaxyNamespace))
+	require.NoError(t, gc.LoginIntoNamespace(ctx, dgraphapi.DefaultUser,
+		dgraphapi.DefaultPassword, x.GalaxyNamespace))
 
 	userClient, cleanup, err := asuite.dc.Client()
 	require.NoError(t, err)
@@ -1006,18 +1286,18 @@ func (asuite *AclTestSuite) TestDeleteQueryWithACLPermissions() {
 
 	hc, err = asuite.dc.HTTPClient()
 	require.NoError(t, err)
-	require.NoError(t, hc.LoginIntoNamespace(dgraphtest.DefaultUser,
-		dgraphtest.DefaultPassword, x.GalaxyNamespace))
+	require.NoError(t, hc.LoginIntoNamespace(dgraphapi.DefaultUser,
+		dgraphapi.DefaultPassword, x.GalaxyNamespace))
 
 	resp, err = gc.Query(query)
 	require.NoError(t, err, "Error while querying data")
 	// Only name and age predicates got deleted via user - alice
-	require.NoError(t, dgraphtest.CompareJSON(
+	require.NoError(t, dgraphapi.CompareJSON(
 		`{"q1":[{"nickname": "RG"},{"name":"RandomGuy2","age":25,  "nickname": "RG2"}]}`,
 		string(resp.GetJson())))
 
 	// Give write access of <name> <dgraph.type> to dev
-	require.NoError(t, hc.AddRulesToGroup(devGroup, []dgraphtest.AclRule{{Predicate: "name", Permission: Write.Code},
+	require.NoError(t, hc.AddRulesToGroup(devGroup, []dgraphapi.AclRule{{Predicate: "name", Permission: Write.Code},
 		{Predicate: "age", Permission: Write.Code}, {Predicate: "dgraph.type", Permission: Write.Code}}, true))
 	time.Sleep(defaultTimeToSleep)
 
@@ -1029,7 +1309,7 @@ func (asuite *AclTestSuite) TestDeleteQueryWithACLPermissions() {
 	resp, err = gc.Query(query)
 	require.NoError(t, err, "Error while querying data")
 	// Because alise had permission to dgraph.type the node reference has been deleted
-	require.NoError(t, dgraphtest.CompareJSON(`{"q1":[{"name":"RandomGuy2","age":25,  "nickname": "RG2"}]}`,
+	require.NoError(t, dgraphapi.CompareJSON(`{"q1":[{"name":"RandomGuy2","age":25,  "nickname": "RG2"}]}`,
 		string(resp.GetJson())))
 }
 
@@ -1041,12 +1321,12 @@ func (asuite *AclTestSuite) TestValQueryWithACLPermissions() {
 	gc, cleanup, err := asuite.dc.Client()
 	require.NoError(t, err)
 	defer cleanup()
-	require.NoError(t, gc.LoginIntoNamespace(ctx, dgraphtest.DefaultUser,
-		dgraphtest.DefaultPassword, x.GalaxyNamespace))
+	require.NoError(t, gc.LoginIntoNamespace(ctx, dgraphapi.DefaultUser,
+		dgraphapi.DefaultPassword, x.GalaxyNamespace))
 
 	hc, err := asuite.dc.HTTPClient()
 	require.NoError(t, err)
-	require.NoError(t, hc.LoginIntoNamespace(dgraphtest.DefaultUser, dgraphtest.DefaultPassword, x.GalaxyNamespace))
+	require.NoError(t, hc.LoginIntoNamespace(dgraphapi.DefaultUser, dgraphapi.DefaultPassword, x.GalaxyNamespace))
 
 	require.NoError(t, gc.DropAll())
 
@@ -1093,7 +1373,7 @@ func (asuite *AclTestSuite) TestValQueryWithACLPermissions() {
 	// Test that groot has access to all the predicates
 	resp, err := gc.Query(query)
 	require.NoError(t, err, "Error while querying data")
-	require.NoError(t, dgraphtest.CompareJSON(
+	require.NoError(t, dgraphapi.CompareJSON(
 		`{"q1":[{"name":"RandomGuy","age":23},{"name":"RandomGuy2","age":25}],`+
 			`"q2":[{"val(v)":"RandomGuy","val(a)":23}]}`, string(resp.GetJson())))
 
@@ -1203,8 +1483,8 @@ func (asuite *AclTestSuite) TestValQueryWithACLPermissions() {
 
 	hc, err = asuite.dc.HTTPClient()
 	require.NoError(t, err)
-	require.NoError(t, hc.LoginIntoNamespace(dgraphtest.DefaultUser,
-		dgraphtest.DefaultPassword, x.GalaxyNamespace))
+	require.NoError(t, hc.LoginIntoNamespace(dgraphapi.DefaultUser,
+		dgraphapi.DefaultPassword, x.GalaxyNamespace))
 
 	time.Sleep(defaultTimeToSleep)
 
@@ -1214,13 +1494,13 @@ func (asuite *AclTestSuite) TestValQueryWithACLPermissions() {
 		t.Run(desc, func(t *testing.T) {
 			resp, err := userClient.Query(tc.input)
 			require.NoError(t, err)
-			require.NoError(t, dgraphtest.CompareJSON(tc.outputNoPerm, string(resp.Json)))
+			require.NoError(t, dgraphapi.CompareJSON(tc.outputNoPerm, string(resp.Json)))
 		})
 	}
 
 	// Give read access of <name> to dev
 	require.NoError(t, hc.AddRulesToGroup(devGroup,
-		[]dgraphtest.AclRule{{Predicate: "name", Permission: Read.Code}}, true))
+		[]dgraphapi.AclRule{{Predicate: "name", Permission: Read.Code}}, true))
 	time.Sleep(defaultTimeToSleep)
 
 	for _, tc := range tests {
@@ -1228,16 +1508,16 @@ func (asuite *AclTestSuite) TestValQueryWithACLPermissions() {
 		t.Run(desc, func(t *testing.T) {
 			resp, err := userClient.Query(tc.input)
 			require.NoError(t, err)
-			require.NoError(t, dgraphtest.CompareJSON(tc.outputNamePerm, string(resp.Json)))
+			require.NoError(t, dgraphapi.CompareJSON(tc.outputNamePerm, string(resp.Json)))
 		})
 	}
 
 	// Login to groot to modify accesses (1)
-	require.NoError(t, hc.LoginIntoNamespace(dgraphtest.DefaultUser,
-		dgraphtest.DefaultPassword, x.GalaxyNamespace))
+	require.NoError(t, hc.LoginIntoNamespace(dgraphapi.DefaultUser,
+		dgraphapi.DefaultPassword, x.GalaxyNamespace))
 
 	// Give read access of <name> and <age> to dev
-	require.NoError(t, hc.AddRulesToGroup(devGroup, []dgraphtest.AclRule{{Predicate: "name", Permission: Read.Code},
+	require.NoError(t, hc.AddRulesToGroup(devGroup, []dgraphapi.AclRule{{Predicate: "name", Permission: Read.Code},
 		{Predicate: "age", Permission: Read.Code}}, true))
 
 	time.Sleep(defaultTimeToSleep)
@@ -1247,7 +1527,7 @@ func (asuite *AclTestSuite) TestValQueryWithACLPermissions() {
 		t.Run(desc, func(t *testing.T) {
 			resp, err := userClient.Query(tc.input)
 			require.NoError(t, err)
-			require.NoError(t, dgraphtest.CompareJSON(tc.outputNameAgePerm, string(resp.Json)))
+			require.NoError(t, dgraphapi.CompareJSON(tc.outputNameAgePerm, string(resp.Json)))
 		})
 	}
 
@@ -1261,13 +1541,13 @@ func (asuite *AclTestSuite) TestAllPredsPermission() {
 	gc, cleanup, err := asuite.dc.Client()
 	require.NoError(t, err)
 	defer cleanup()
-	require.NoError(t, gc.LoginIntoNamespace(ctx, dgraphtest.DefaultUser,
-		dgraphtest.DefaultPassword, x.GalaxyNamespace))
+	require.NoError(t, gc.LoginIntoNamespace(ctx, dgraphapi.DefaultUser,
+		dgraphapi.DefaultPassword, x.GalaxyNamespace))
 
 	hc, err := asuite.dc.HTTPClient()
 	require.NoError(t, err)
-	require.NoError(t, hc.LoginIntoNamespace(dgraphtest.DefaultUser,
-		dgraphtest.DefaultPassword, x.GalaxyNamespace))
+	require.NoError(t, hc.LoginIntoNamespace(dgraphapi.DefaultUser,
+		dgraphapi.DefaultPassword, x.GalaxyNamespace))
 
 	require.NoError(t, gc.DropAll())
 
@@ -1317,7 +1597,7 @@ func (asuite *AclTestSuite) TestAllPredsPermission() {
 	// Test that groot has access to all the predicates
 	resp, err := gc.Query(query)
 	require.NoError(t, err, "Error while querying data")
-	require.NoError(t, dgraphtest.CompareJSON(
+	require.NoError(t, dgraphapi.CompareJSON(
 		`{"q1":[{"name":"RandomGuy","age":23},{"name":"RandomGuy2","age":25}],`+
 			`"q2":[{"val(v)":"RandomGuy","val(a)":23}]}`, string(resp.GetJson())))
 
@@ -1370,19 +1650,19 @@ func (asuite *AclTestSuite) TestAllPredsPermission() {
 		t.Run(desc, func(t *testing.T) {
 			resp, err := userClient.Query(tc.input)
 			require.NoError(t, err)
-			require.NoError(t, dgraphtest.CompareJSON(tc.outputNoPerm, string(resp.Json)))
+			require.NoError(t, dgraphapi.CompareJSON(tc.outputNoPerm, string(resp.Json)))
 		})
 	}
 
 	// Login to groot to modify accesses (1)
 	hc, err = asuite.dc.HTTPClient()
 	require.NoError(t, err)
-	require.NoError(t, hc.LoginIntoNamespace(dgraphtest.DefaultUser,
-		dgraphtest.DefaultPassword, x.GalaxyNamespace))
+	require.NoError(t, hc.LoginIntoNamespace(dgraphapi.DefaultUser,
+		dgraphapi.DefaultPassword, x.GalaxyNamespace))
 
 	// Give read access of all predicates to dev
 	require.NoError(t, hc.AddRulesToGroup(devGroup,
-		[]dgraphtest.AclRule{{Predicate: "dgraph.all", Permission: Read.Code}}, true))
+		[]dgraphapi.AclRule{{Predicate: "dgraph.all", Permission: Read.Code}}, true))
 	time.Sleep(defaultTimeToSleep)
 
 	for _, tc := range tests {
@@ -1390,7 +1670,7 @@ func (asuite *AclTestSuite) TestAllPredsPermission() {
 		t.Run(desc, func(t *testing.T) {
 			resp, err := userClient.Query(tc.input)
 			require.NoError(t, err)
-			require.NoError(t, dgraphtest.CompareJSON(tc.outputNameAgePerm, string(resp.Json)))
+			require.NoError(t, dgraphapi.CompareJSON(tc.outputNameAgePerm, string(resp.Json)))
 		})
 	}
 
@@ -1408,7 +1688,7 @@ func (asuite *AclTestSuite) TestAllPredsPermission() {
 
 	// Give write access of all predicates to dev. Now mutation should succeed.
 	require.NoError(t, hc.AddRulesToGroup(devGroup,
-		[]dgraphtest.AclRule{{Predicate: "dgraph.all", Permission: Write.Code | Read.Code}}, true))
+		[]dgraphapi.AclRule{{Predicate: "dgraph.all", Permission: Write.Code | Read.Code}}, true))
 	time.Sleep(defaultTimeToSleep)
 
 	_, err = userClient.Mutate(mu)
@@ -1423,12 +1703,12 @@ func (asuite *AclTestSuite) TestNewACLPredicates() {
 	gc, cleanup, err := asuite.dc.Client()
 	require.NoError(t, err)
 	defer cleanup()
-	require.NoError(t, gc.LoginIntoNamespace(ctx, dgraphtest.DefaultUser,
-		dgraphtest.DefaultPassword, x.GalaxyNamespace))
+	require.NoError(t, gc.LoginIntoNamespace(ctx, dgraphapi.DefaultUser,
+		dgraphapi.DefaultPassword, x.GalaxyNamespace))
 
 	hc, err := asuite.dc.HTTPClient()
 	require.NoError(t, err)
-	require.NoError(t, hc.LoginIntoNamespace(dgraphtest.DefaultUser, dgraphtest.DefaultPassword, x.GalaxyNamespace))
+	require.NoError(t, hc.LoginIntoNamespace(dgraphapi.DefaultUser, dgraphapi.DefaultPassword, x.GalaxyNamespace))
 
 	addDataAndRules(ctx, t, gc, hc)
 
@@ -1482,7 +1762,7 @@ func (asuite *AclTestSuite) TestNewACLPredicates() {
 
 			resp, err := userClient.NewTxn().Query(ctx, tc.input)
 			require.NoError(t, err)
-			require.NoError(t, dgraphtest.CompareJSON(tc.output, string(resp.Json)))
+			require.NoError(t, dgraphapi.CompareJSON(tc.output, string(resp.Json)))
 		})
 	}
 
@@ -1524,12 +1804,12 @@ func (asuite *AclTestSuite) TestDeleteRule() {
 	gc, cleanup, err := asuite.dc.Client()
 	require.NoError(t, err)
 	defer cleanup()
-	require.NoError(t, gc.LoginIntoNamespace(ctx, dgraphtest.DefaultUser,
-		dgraphtest.DefaultPassword, x.GalaxyNamespace))
+	require.NoError(t, gc.LoginIntoNamespace(ctx, dgraphapi.DefaultUser,
+		dgraphapi.DefaultPassword, x.GalaxyNamespace))
 
 	hc, err := asuite.dc.HTTPClient()
 	require.NoError(t, err)
-	require.NoError(t, hc.LoginIntoNamespace(dgraphtest.DefaultUser, dgraphtest.DefaultPassword, x.GalaxyNamespace))
+	require.NoError(t, hc.LoginIntoNamespace(dgraphapi.DefaultUser, dgraphapi.DefaultPassword, x.GalaxyNamespace))
 
 	addDataAndRules(ctx, t, gc, hc)
 
@@ -1537,8 +1817,8 @@ func (asuite *AclTestSuite) TestDeleteRule() {
 
 	hc, err = asuite.dc.HTTPClient()
 	require.NoError(t, err)
-	require.NoError(t, hc.LoginIntoNamespace(dgraphtest.DefaultUser,
-		dgraphtest.DefaultPassword, x.GalaxyNamespace))
+	require.NoError(t, hc.LoginIntoNamespace(dgraphapi.DefaultUser,
+		dgraphapi.DefaultPassword, x.GalaxyNamespace))
 
 	userClient, cleanup, err := asuite.dc.Client()
 	require.NoError(t, err)
@@ -1551,7 +1831,7 @@ func (asuite *AclTestSuite) TestDeleteRule() {
 	resp, err := userClient.Query(queryName)
 	require.NoError(t, err, "Error while querying data")
 
-	require.NoError(t, dgraphtest.CompareJSON(`{"me":[{"name":"RandomGuy"},{"name":"RandomGuy2"}]}`,
+	require.NoError(t, dgraphapi.CompareJSON(`{"me":[{"name":"RandomGuy"},{"name":"RandomGuy2"}]}`,
 		string(resp.GetJson())))
 
 	require.NoError(t, hc.RemovePredicateFromGroup(devGroup, "name"))
@@ -1559,10 +1839,10 @@ func (asuite *AclTestSuite) TestDeleteRule() {
 
 	resp, err = userClient.Query(queryName)
 	require.NoError(t, err, "Error while querying data")
-	require.NoError(t, dgraphtest.CompareJSON(string(resp.GetJson()), `{}`))
+	require.NoError(t, dgraphapi.CompareJSON(string(resp.GetJson()), `{}`))
 }
 
-func addDataAndRules(ctx context.Context, t *testing.T, gc *dgraphtest.GrpcClient, hc *dgraphtest.HTTPClient) {
+func addDataAndRules(ctx context.Context, t *testing.T, gc *dgraphapi.GrpcClient, hc *dgraphapi.HTTPClient) {
 	require.NoError(t, gc.DropAll())
 	op := api.Operation{Schema: `
 		name	 : string @index(exact) .
@@ -1636,12 +1916,12 @@ func (asuite *AclTestSuite) TestQueryUserInfo() {
 	gc, cleanup, err := asuite.dc.Client()
 	require.NoError(t, err)
 	defer cleanup()
-	require.NoError(t, gc.LoginIntoNamespace(ctx, dgraphtest.DefaultUser,
-		dgraphtest.DefaultPassword, x.GalaxyNamespace))
+	require.NoError(t, gc.LoginIntoNamespace(ctx, dgraphapi.DefaultUser,
+		dgraphapi.DefaultPassword, x.GalaxyNamespace))
 
 	hc, err := asuite.dc.HTTPClient()
 	require.NoError(t, err)
-	require.NoError(t, hc.LoginIntoNamespace(dgraphtest.DefaultUser, dgraphtest.DefaultPassword, x.GalaxyNamespace))
+	require.NoError(t, hc.LoginIntoNamespace(dgraphapi.DefaultUser, dgraphapi.DefaultPassword, x.GalaxyNamespace))
 
 	addDataAndRules(ctx, t, gc, hc)
 	require.NoError(t, hc.LoginIntoNamespace(userid, userpassword, x.GalaxyNamespace))
@@ -1663,12 +1943,12 @@ func (asuite *AclTestSuite) TestQueryUserInfo() {
 		}
 	}
 	`
-	params := dgraphtest.GraphQLParams{
+	params := dgraphapi.GraphQLParams{
 		Query: gqlQuery,
 	}
 	gqlResp, err := hc.RunGraphqlQuery(params, true)
 	require.NoError(t, err)
-	require.NoError(t, dgraphtest.CompareJSON(`
+	require.NoError(t, dgraphapi.CompareJSON(`
 	{
 	  "queryUser": [
 		{
@@ -1734,7 +2014,7 @@ func (asuite *AclTestSuite) TestQueryUserInfo() {
 
 	resp, err := userClient.Query(query)
 	require.NoError(t, err, "Error while querying ACL")
-	require.NoError(t, dgraphtest.CompareJSON(`{"me":[]}`, string(resp.GetJson())))
+	require.NoError(t, dgraphapi.CompareJSON(`{"me":[]}`, string(resp.GetJson())))
 
 	gqlQuery = `
 	query {
@@ -1749,12 +2029,12 @@ func (asuite *AclTestSuite) TestQueryUserInfo() {
 			}
 		}
 	}`
-	params = dgraphtest.GraphQLParams{Query: gqlQuery}
+	params = dgraphapi.GraphQLParams{Query: gqlQuery}
 	gqlResp, err = hc.RunGraphqlQuery(params, true)
 	require.NoError(t, err)
 
 	// The user should only be able to see their group dev and themselves as the user.
-	require.NoError(t, dgraphtest.CompareJSON(`{
+	require.NoError(t, dgraphapi.CompareJSON(`{
 		  "queryGroup": [
 			{
 			  "name": "dev",
@@ -1799,27 +2079,28 @@ func (asuite *AclTestSuite) TestQueryUserInfo() {
 				}
 			}
 		}`
-	params = dgraphtest.GraphQLParams{Query: gqlQuery}
+	params = dgraphapi.GraphQLParams{Query: gqlQuery}
 	gqlResp, err = hc.RunGraphqlQuery(params, true)
 	require.NoError(t, err)
-	require.NoError(t, dgraphtest.CompareJSON(`{"getGroup": null}`, string(gqlResp)))
+	require.NoError(t, dgraphapi.CompareJSON(`{"getGroup": null}`, string(gqlResp)))
 }
 
 func (asuite *AclTestSuite) TestQueriesWithUserAndGroupOfSameName() {
 	t := asuite.T()
+	dgraphtest.ShouldSkipTest(t, asuite.dc.GetVersion(), "7b1f473ddf01547e24b44f580a68e6b049502d69")
 	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Second)
 	defer cancel()
 
 	gc, cleanup, err := asuite.dc.Client()
 	require.NoError(t, err)
 	defer cleanup()
-	require.NoError(t, gc.LoginIntoNamespace(ctx, dgraphtest.DefaultUser,
-		dgraphtest.DefaultPassword, x.GalaxyNamespace))
+	require.NoError(t, gc.LoginIntoNamespace(ctx, dgraphapi.DefaultUser,
+		dgraphapi.DefaultPassword, x.GalaxyNamespace))
 
 	hc, err := asuite.dc.HTTPClient()
 	require.NoError(t, err)
-	require.NoError(t, hc.LoginIntoNamespace(dgraphtest.DefaultUser,
-		dgraphtest.DefaultPassword, x.GalaxyNamespace))
+	require.NoError(t, hc.LoginIntoNamespace(dgraphapi.DefaultUser,
+		dgraphapi.DefaultPassword, x.GalaxyNamespace))
 
 	require.NoError(t, gc.DropAll())
 	// Creates a user -- alice
@@ -1847,7 +2128,7 @@ func (asuite *AclTestSuite) TestQueriesWithUserAndGroupOfSameName() {
 
 	// add rules to groups
 	require.NoError(t, hc.AddRulesToGroup("alice",
-		[]dgraphtest.AclRule{{Predicate: "name", Permission: Read.Code}}, true))
+		[]dgraphapi.AclRule{{Predicate: "name", Permission: Read.Code}}, true))
 
 	asuite.Upgrade()
 
@@ -1863,7 +2144,7 @@ func (asuite *AclTestSuite) TestQueriesWithUserAndGroupOfSameName() {
 			age
 		}
 	}`
-	require.NoError(t, dgraphtest.PollTillPassOrTimeout(dc, query,
+	require.NoError(t, dgraphapi.PollTillPassOrTimeout(dc, query,
 		`{"q":[{"name":"RandomGuy"},{"name":"RandomGuy2"}]}`, timeout))
 }
 
@@ -1872,8 +2153,8 @@ func (asuite *AclTestSuite) TestQueriesForNonGuardianUserWithoutGroup() {
 
 	hc, err := asuite.dc.HTTPClient()
 	require.NoError(t, err)
-	require.NoError(t, hc.LoginIntoNamespace(dgraphtest.DefaultUser,
-		dgraphtest.DefaultPassword, x.GalaxyNamespace))
+	require.NoError(t, hc.LoginIntoNamespace(dgraphapi.DefaultUser,
+		dgraphapi.DefaultPassword, x.GalaxyNamespace))
 
 	// Create a new user without any groups, queryGroup should return an empty result.
 	resetUser(t, hc)
@@ -1895,10 +2176,10 @@ func (asuite *AclTestSuite) TestQueriesForNonGuardianUserWithoutGroup() {
 	}
 	`
 
-	params := dgraphtest.GraphQLParams{Query: gqlQuery}
+	params := dgraphapi.GraphQLParams{Query: gqlQuery}
 	gqlResp, err := hc.RunGraphqlQuery(params, true)
 	require.NoError(t, err)
-	require.NoError(t, dgraphtest.CompareJSON(`{"queryGroup": []}`, string(gqlResp)))
+	require.NoError(t, dgraphapi.CompareJSON(`{"queryGroup": []}`, string(gqlResp)))
 
 	gqlQuery = `
 	query {
@@ -1909,10 +2190,10 @@ func (asuite *AclTestSuite) TestQueriesForNonGuardianUserWithoutGroup() {
 			}
 		}
 	}`
-	params = dgraphtest.GraphQLParams{Query: gqlQuery}
+	params = dgraphapi.GraphQLParams{Query: gqlQuery}
 	gqlResp, err = hc.RunGraphqlQuery(params, true)
 	require.NoError(t, err)
-	require.NoError(t, dgraphtest.CompareJSON(`{"queryUser": [{ "groups": [], "name": "alice"}]}`, string(gqlResp)))
+	require.NoError(t, dgraphapi.CompareJSON(`{"queryUser": [{ "groups": [], "name": "alice"}]}`, string(gqlResp)))
 }
 
 func (asuite *AclTestSuite) TestSchemaQueryWithACL() {
@@ -1923,136 +2204,7 @@ func (asuite *AclTestSuite) TestSchemaQueryWithACL() {
 	defer cancel()
 
 	schemaQuery := "schema{}"
-	grootSchema := `{
-  "schema": [
-    {
-      "predicate": "dgraph.acl.rule",
-      "type": "uid",
-      "list": true
-	},
-	{
-		"predicate":"dgraph.drop.op",
-		"type":"string"
-	},
-	{
-		"predicate":"dgraph.graphql.p_query",
-		"type":"string",
-		"index":true,
-		"tokenizer":["sha256"]
-	},
-    {
-      "predicate": "dgraph.graphql.schema",
-      "type": "string"
-	},
-    {
-      "predicate": "dgraph.graphql.xid",
-      "type": "string",
-      "index": true,
-      "tokenizer": [
-        "exact"
-      ],
-      "upsert": true
-    },
-    {
-      "predicate": "dgraph.password",
-      "type": "password"
-    },
-    {
-      "predicate": "dgraph.rule.permission",
-      "type": "int"
-    },
-    {
-      "predicate": "dgraph.rule.predicate",
-      "type": "string",
-      "index": true,
-      "tokenizer": [
-        "exact"
-      ],
-      "upsert": true
-    },
-    {
-      "predicate": "dgraph.type",
-      "type": "string",
-      "index": true,
-      "tokenizer": [
-        "exact"
-      ],
-      "list": true
-    },
-    {
-      "predicate": "dgraph.user.group",
-      "type": "uid",
-      "reverse": true,
-      "list": true
-    },
-    {
-      "predicate": "dgraph.xid",
-      "type": "string",
-      "index": true,
-      "tokenizer": [
-        "exact"
-      ],
-      "upsert": true
-    }
-  ],
-  "types": [
-    {
-      "fields": [
-        {
-          "name": "dgraph.graphql.schema"
-        },
-        {
-          "name": "dgraph.graphql.xid"
-        }
-      ],
-      "name": "dgraph.graphql"
-	},
-	{
-		"fields": [
-			{
-				"name": "dgraph.graphql.p_query"
-			}
-		],
-		"name": "dgraph.graphql.persisted_query"
-	},
-    {
-      "fields": [
-        {
-          "name": "dgraph.xid"
-        },
-        {
-          "name": "dgraph.acl.rule"
-        }
-      ],
-      "name": "dgraph.type.Group"
-    },
-    {
-      "fields": [
-        {
-          "name": "dgraph.rule.predicate"
-        },
-        {
-          "name": "dgraph.rule.permission"
-        }
-      ],
-      "name": "dgraph.type.Rule"
-    },
-    {
-      "fields": [
-        {
-          "name": "dgraph.xid"
-        },
-        {
-          "name": "dgraph.password"
-        },
-        {
-          "name": "dgraph.user.group"
-        }
-      ],
-      "name": "dgraph.type.User"
-    }
-  ]
-}`
+
 	aliceSchema := `{
   "schema": [
     {
@@ -2092,17 +2244,23 @@ func (asuite *AclTestSuite) TestSchemaQueryWithACL() {
 	gc, cleanup, err := asuite.dc.Client()
 	require.NoError(t, err)
 	defer cleanup()
-	require.NoError(t, gc.LoginIntoNamespace(ctx, dgraphtest.DefaultUser,
-		dgraphtest.DefaultPassword, x.GalaxyNamespace))
+	require.NoError(t, gc.LoginIntoNamespace(ctx, dgraphapi.DefaultUser,
+		dgraphapi.DefaultPassword, x.GalaxyNamespace))
 
 	hc, err := asuite.dc.HTTPClient()
 	require.NoError(t, err)
-	require.NoError(t, hc.LoginIntoNamespace(dgraphtest.DefaultUser, dgraphtest.DefaultPassword, x.GalaxyNamespace))
+	require.NoError(t, hc.LoginIntoNamespace(dgraphapi.DefaultUser, dgraphapi.DefaultPassword, x.GalaxyNamespace))
 
 	require.NoError(t, gc.DropAll())
 	resp, err := gc.Query(schemaQuery)
 	require.NoError(t, err)
-	require.JSONEq(t, grootSchema, string(resp.GetJson()))
+	supported, err := dgraphtest.IsHigherVersion(asuite.dc.GetVersion(), "daa5805739ed258e913a157c6e0f126b2291b1b0")
+	require.NoError(t, err)
+	if supported {
+		require.JSONEq(t, newGrootSchema, string(resp.GetJson()))
+	} else {
+		require.JSONEq(t, oldGrootSchema, string(resp.GetJson()))
+	}
 
 	// add another user and some data for that user with permissions on predicates
 	resetUser(t, hc)
@@ -2129,12 +2287,12 @@ func (asuite *AclTestSuite) TestDeleteUserShouldDeleteUserFromGroup() {
 	gc, cleanup, err := asuite.dc.Client()
 	require.NoError(t, err)
 	defer cleanup()
-	require.NoError(t, gc.LoginIntoNamespace(ctx, dgraphtest.DefaultUser,
-		dgraphtest.DefaultPassword, x.GalaxyNamespace))
+	require.NoError(t, gc.LoginIntoNamespace(ctx, dgraphapi.DefaultUser,
+		dgraphapi.DefaultPassword, x.GalaxyNamespace))
 
 	hc, err := asuite.dc.HTTPClient()
 	require.NoError(t, err)
-	require.NoError(t, hc.LoginIntoNamespace(dgraphtest.DefaultUser, dgraphtest.DefaultPassword, x.GalaxyNamespace))
+	require.NoError(t, hc.LoginIntoNamespace(dgraphapi.DefaultUser, dgraphapi.DefaultPassword, x.GalaxyNamespace))
 
 	resetUser(t, hc)
 	addDataAndRules(ctx, t, gc, hc)
@@ -2143,8 +2301,8 @@ func (asuite *AclTestSuite) TestDeleteUserShouldDeleteUserFromGroup() {
 
 	hc, err = asuite.dc.HTTPClient()
 	require.NoError(t, err)
-	require.NoError(t, hc.LoginIntoNamespace(dgraphtest.DefaultUser,
-		dgraphtest.DefaultPassword, x.GalaxyNamespace))
+	require.NoError(t, hc.LoginIntoNamespace(dgraphapi.DefaultUser,
+		dgraphapi.DefaultPassword, x.GalaxyNamespace))
 	require.NoError(t, hc.DeleteUser(userid))
 
 	gqlQuery := `
@@ -2153,7 +2311,7 @@ func (asuite *AclTestSuite) TestDeleteUserShouldDeleteUserFromGroup() {
 			name
 		}
 	}`
-	params := dgraphtest.GraphQLParams{Query: gqlQuery}
+	params := dgraphapi.GraphQLParams{Query: gqlQuery}
 	gqlResp, err := hc.RunGraphqlQuery(params, true)
 	require.NoError(t, err)
 	require.JSONEq(t, `{"queryUser":[{"name":"groot"}]}`, string(gqlResp))
@@ -2168,10 +2326,10 @@ func (asuite *AclTestSuite) TestDeleteUserShouldDeleteUserFromGroup() {
 			}
 		}
 	}`
-	params = dgraphtest.GraphQLParams{Query: gqlQuery}
+	params = dgraphapi.GraphQLParams{Query: gqlQuery}
 	gqlResp, err = hc.RunGraphqlQuery(params, true)
 	require.NoError(t, err)
-	require.NoError(t, dgraphtest.CompareJSON(`{
+	require.NoError(t, dgraphapi.CompareJSON(`{
 		  "queryGroup": [
 			{
 			  "name": "guardians",
@@ -2205,12 +2363,12 @@ func (asuite *AclTestSuite) TestGroupDeleteShouldDeleteGroupFromUser() {
 	gc, cleanup, err := asuite.dc.Client()
 	require.NoError(t, err)
 	defer cleanup()
-	require.NoError(t, gc.LoginIntoNamespace(ctx, dgraphtest.DefaultUser,
-		dgraphtest.DefaultPassword, x.GalaxyNamespace))
+	require.NoError(t, gc.LoginIntoNamespace(ctx, dgraphapi.DefaultUser,
+		dgraphapi.DefaultPassword, x.GalaxyNamespace))
 
 	hc, err := asuite.dc.HTTPClient()
 	require.NoError(t, err)
-	require.NoError(t, hc.LoginIntoNamespace(dgraphtest.DefaultUser, dgraphtest.DefaultPassword, x.GalaxyNamespace))
+	require.NoError(t, hc.LoginIntoNamespace(dgraphapi.DefaultUser, dgraphapi.DefaultPassword, x.GalaxyNamespace))
 	resetUser(t, hc)
 
 	addDataAndRules(ctx, t, gc, hc)
@@ -2219,8 +2377,8 @@ func (asuite *AclTestSuite) TestGroupDeleteShouldDeleteGroupFromUser() {
 
 	hc, err = asuite.dc.HTTPClient()
 	require.NoError(t, err)
-	require.NoError(t, hc.LoginIntoNamespace(dgraphtest.DefaultUser,
-		dgraphtest.DefaultPassword, x.GalaxyNamespace))
+	require.NoError(t, hc.LoginIntoNamespace(dgraphapi.DefaultUser,
+		dgraphapi.DefaultPassword, x.GalaxyNamespace))
 	require.NoError(t, hc.DeleteGroup("dev-a"))
 
 	gqlQuery := `
@@ -2229,10 +2387,10 @@ func (asuite *AclTestSuite) TestGroupDeleteShouldDeleteGroupFromUser() {
 			name
 		}
 	}`
-	params := dgraphtest.GraphQLParams{Query: gqlQuery}
+	params := dgraphapi.GraphQLParams{Query: gqlQuery}
 	gqlResp, err := hc.RunGraphqlQuery(params, true)
 	require.NoError(t, err)
-	require.NoError(t, dgraphtest.CompareJSON(`{
+	require.NoError(t, dgraphapi.CompareJSON(`{
 		  "queryGroup": [
 			{
 			  "name": "guardians"
@@ -2255,10 +2413,10 @@ func (asuite *AclTestSuite) TestGroupDeleteShouldDeleteGroupFromUser() {
 			}
 		}
 	}`
-	params = dgraphtest.GraphQLParams{Query: gqlQuery}
+	params = dgraphapi.GraphQLParams{Query: gqlQuery}
 	gqlResp, err = hc.RunGraphqlQuery(params, true)
 	require.NoError(t, err)
-	require.NoError(t, dgraphtest.CompareJSON(`{
+	require.NoError(t, dgraphapi.CompareJSON(`{
 		"getUser": {
 			"name": "alice",
 			"groups": [
@@ -2300,11 +2458,11 @@ func (asuite *AclTestSuite) TestAddUpdateGroupWithDuplicateRules() {
 
 	hc, err := asuite.dc.HTTPClient()
 	require.NoError(t, err)
-	require.NoError(t, hc.LoginIntoNamespace(dgraphtest.DefaultUser,
-		dgraphtest.DefaultPassword, x.GalaxyNamespace))
+	require.NoError(t, hc.LoginIntoNamespace(dgraphapi.DefaultUser,
+		dgraphapi.DefaultPassword, x.GalaxyNamespace))
 
 	groupName := "testGroup"
-	addedRules := []dgraphtest.AclRule{
+	addedRules := []dgraphapi.AclRule{
 		{
 			Predicate:  "test",
 			Permission: 1,
@@ -2330,9 +2488,9 @@ func (asuite *AclTestSuite) TestAddUpdateGroupWithDuplicateRules() {
 
 	hc, err = asuite.dc.HTTPClient()
 	require.NoError(t, err)
-	require.NoError(t, hc.LoginIntoNamespace(dgraphtest.DefaultUser,
-		dgraphtest.DefaultPassword, x.GalaxyNamespace))
-	updatedRules := []dgraphtest.AclRule{
+	require.NoError(t, hc.LoginIntoNamespace(dgraphapi.DefaultUser,
+		dgraphapi.DefaultPassword, x.GalaxyNamespace))
+	updatedRules := []dgraphapi.AclRule{
 		{
 			Predicate:  "test",
 			Permission: 3,
@@ -2350,7 +2508,7 @@ func (asuite *AclTestSuite) TestAddUpdateGroupWithDuplicateRules() {
 	require.NoError(t, err)
 	require.Equal(t, groupName, updatedGroup.Name)
 	require.Len(t, updatedGroup.Rules, 3)
-	require.ElementsMatch(t, []dgraphtest.AclRule{updatedRules[0], addedRules[2], updatedRules[2]},
+	require.ElementsMatch(t, []dgraphapi.AclRule{updatedRules[0], addedRules[2], updatedRules[2]},
 		updatedGroup.Rules)
 
 	updatedGroup1, err := hc.UpdateGroup(groupName, nil,
@@ -2359,7 +2517,7 @@ func (asuite *AclTestSuite) TestAddUpdateGroupWithDuplicateRules() {
 
 	require.Equal(t, groupName, updatedGroup1.Name)
 	require.Len(t, updatedGroup1.Rules, 2)
-	require.ElementsMatch(t, []dgraphtest.AclRule{updatedRules[0], updatedRules[2]}, updatedGroup1.Rules)
+	require.ElementsMatch(t, []dgraphapi.AclRule{updatedRules[0], updatedRules[2]}, updatedGroup1.Rules)
 
 	// cleanup
 	require.NoError(t, hc.DeleteGroup(groupName))
@@ -2373,12 +2531,12 @@ func (asuite *AclTestSuite) TestAllowUIDAccess() {
 	gc, cleanup, err := asuite.dc.Client()
 	require.NoError(t, err)
 	defer cleanup()
-	require.NoError(t, gc.LoginIntoNamespace(ctx, dgraphtest.DefaultUser,
-		dgraphtest.DefaultPassword, x.GalaxyNamespace))
+	require.NoError(t, gc.LoginIntoNamespace(ctx, dgraphapi.DefaultUser,
+		dgraphapi.DefaultPassword, x.GalaxyNamespace))
 
 	hc, err := asuite.dc.HTTPClient()
 	require.NoError(t, err)
-	require.NoError(t, hc.LoginIntoNamespace(dgraphtest.DefaultUser, dgraphtest.DefaultPassword, x.GalaxyNamespace))
+	require.NoError(t, hc.LoginIntoNamespace(dgraphapi.DefaultUser, dgraphapi.DefaultPassword, x.GalaxyNamespace))
 
 	require.NoError(t, gc.DropAll())
 	op := api.Operation{Schema: `
@@ -2400,7 +2558,7 @@ func (asuite *AclTestSuite) TestAllowUIDAccess() {
 
 	// give read access of <name> to alice
 	require.NoError(t, hc.AddRulesToGroup(devGroup,
-		[]dgraphtest.AclRule{{Predicate: "name", Permission: Read.Code}}, true))
+		[]dgraphapi.AclRule{{Predicate: "name", Permission: Read.Code}}, true))
 
 	asuite.Upgrade()
 
@@ -2420,7 +2578,7 @@ func (asuite *AclTestSuite) TestAllowUIDAccess() {
 	}`
 	resp, err := userClient.Query(uidQuery)
 	require.NoError(t, err)
-	require.NoError(t, dgraphtest.CompareJSON(`{"me":[{"name":"100th User", "uid": "0x64"}]}`, string(resp.GetJson())))
+	require.NoError(t, dgraphapi.CompareJSON(`{"me":[{"name":"100th User", "uid": "0x64"}]}`, string(resp.GetJson())))
 }
 
 func (asuite *AclTestSuite) TestAddNewPredicate() {
@@ -2431,12 +2589,12 @@ func (asuite *AclTestSuite) TestAddNewPredicate() {
 	gc, cleanup, err := asuite.dc.Client()
 	require.NoError(t, err)
 	defer cleanup()
-	require.NoError(t, gc.LoginIntoNamespace(ctx, dgraphtest.DefaultUser,
-		dgraphtest.DefaultPassword, x.GalaxyNamespace))
+	require.NoError(t, gc.LoginIntoNamespace(ctx, dgraphapi.DefaultUser,
+		dgraphapi.DefaultPassword, x.GalaxyNamespace))
 
 	hc, err := asuite.dc.HTTPClient()
 	require.NoError(t, err)
-	require.NoError(t, hc.LoginIntoNamespace(dgraphtest.DefaultUser, dgraphtest.DefaultPassword, x.GalaxyNamespace))
+	require.NoError(t, hc.LoginIntoNamespace(dgraphapi.DefaultUser, dgraphapi.DefaultPassword, x.GalaxyNamespace))
 
 	require.NoError(t, gc.DropAll())
 	resetUser(t, hc)
@@ -2445,8 +2603,8 @@ func (asuite *AclTestSuite) TestAddNewPredicate() {
 
 	hc, err = asuite.dc.HTTPClient()
 	require.NoError(t, err)
-	require.NoError(t, hc.LoginIntoNamespace(dgraphtest.DefaultUser,
-		dgraphtest.DefaultPassword, x.GalaxyNamespace))
+	require.NoError(t, hc.LoginIntoNamespace(dgraphapi.DefaultUser,
+		dgraphapi.DefaultPassword, x.GalaxyNamespace))
 	userClient, cancel, err := asuite.dc.Client()
 	defer cleanup()
 	require.NoError(t, err)
@@ -2474,13 +2632,13 @@ func (asuite *AclTestSuite) TestCrossGroupPermission() {
 	gc, cleanup, err := asuite.dc.Client()
 	require.NoError(t, err)
 	defer cleanup()
-	require.NoError(t, gc.LoginIntoNamespace(ctx, dgraphtest.DefaultUser,
-		dgraphtest.DefaultPassword, x.GalaxyNamespace))
+	require.NoError(t, gc.LoginIntoNamespace(ctx, dgraphapi.DefaultUser,
+		dgraphapi.DefaultPassword, x.GalaxyNamespace))
 
 	hc, err := asuite.dc.HTTPClient()
 	require.NoError(t, err)
-	require.NoError(t, hc.LoginIntoNamespace(dgraphtest.DefaultUser,
-		dgraphtest.DefaultPassword, x.GalaxyNamespace))
+	require.NoError(t, hc.LoginIntoNamespace(dgraphapi.DefaultUser,
+		dgraphapi.DefaultPassword, x.GalaxyNamespace))
 
 	require.NoError(t, gc.DropAll())
 
@@ -2498,14 +2656,14 @@ func (asuite *AclTestSuite) TestCrossGroupPermission() {
 	require.NoError(t, err)
 	require.Equal(t, "alterer", createdGroup)
 	// add rules to groups
-	require.NoError(t, hc.AddRulesToGroup("reader", []dgraphtest.AclRule{{Predicate: "newpred", Permission: 4}}, true))
-	require.NoError(t, hc.AddRulesToGroup("writer", []dgraphtest.AclRule{{Predicate: "newpred", Permission: 2}}, true))
-	require.NoError(t, hc.AddRulesToGroup("alterer", []dgraphtest.AclRule{{Predicate: "newpred", Permission: 1}}, true))
+	require.NoError(t, hc.AddRulesToGroup("reader", []dgraphapi.AclRule{{Predicate: "newpred", Permission: 4}}, true))
+	require.NoError(t, hc.AddRulesToGroup("writer", []dgraphapi.AclRule{{Predicate: "newpred", Permission: 2}}, true))
+	require.NoError(t, hc.AddRulesToGroup("alterer", []dgraphapi.AclRule{{Predicate: "newpred", Permission: 1}}, true))
 	// Wait for acl cache to be refreshed
 	time.Sleep(defaultTimeToSleep)
 
-	require.NoError(t, hc.LoginIntoNamespace(dgraphtest.DefaultUser,
-		dgraphtest.DefaultPassword, x.GalaxyNamespace))
+	require.NoError(t, hc.LoginIntoNamespace(dgraphapi.DefaultUser,
+		dgraphapi.DefaultPassword, x.GalaxyNamespace))
 	// create 8 users.
 	for i := 0; i < 8; i++ {
 		userIdx := strconv.Itoa(i)
@@ -2530,7 +2688,7 @@ func (asuite *AclTestSuite) TestCrossGroupPermission() {
 	time.Sleep(defaultTimeToSleep)
 
 	// operations
-	dgQuery := func(client *dgraphtest.GrpcClient, shouldFail bool, user string) {
+	dgQuery := func(client *dgraphapi.GrpcClient, shouldFail bool, user string) {
 		_, err := client.Query(`
 		{
 			me(func: has(newpred)) {
@@ -2541,7 +2699,7 @@ func (asuite *AclTestSuite) TestCrossGroupPermission() {
 		require.True(t, (err != nil) == shouldFail,
 			"Query test Failed for: "+user+", shouldFail: "+strconv.FormatBool(shouldFail))
 	}
-	dgMutation := func(client *dgraphtest.GrpcClient, shouldFail bool, user string) {
+	dgMutation := func(client *dgraphapi.GrpcClient, shouldFail bool, user string) {
 		_, err := client.Mutate(&api.Mutation{
 			Set: []*api.NQuad{
 				{
@@ -2555,7 +2713,7 @@ func (asuite *AclTestSuite) TestCrossGroupPermission() {
 		require.True(t, (err != nil) == shouldFail,
 			"Mutation test failed for: "+user+", shouldFail: "+strconv.FormatBool(shouldFail))
 	}
-	dgAlter := func(client *dgraphtest.GrpcClient, shouldFail bool, user string) {
+	dgAlter := func(client *dgraphapi.GrpcClient, shouldFail bool, user string) {
 		err := client.Alter(ctx, &api.Operation{Schema: `newpred: string @index(exact) .`})
 		require.True(t, (err != nil) == shouldFail,
 			"Alter test failed for: "+user+", shouldFail: "+strconv.FormatBool(shouldFail))
@@ -2592,12 +2750,12 @@ func (asuite *AclTestSuite) TestMutationWithValueVar() {
 	gc, cleanup, err := asuite.dc.Client()
 	require.NoError(t, err)
 	defer cleanup()
-	require.NoError(t, gc.LoginIntoNamespace(ctx, dgraphtest.DefaultUser,
-		dgraphtest.DefaultPassword, x.GalaxyNamespace))
+	require.NoError(t, gc.LoginIntoNamespace(ctx, dgraphapi.DefaultUser,
+		dgraphapi.DefaultPassword, x.GalaxyNamespace))
 
 	hc, err := asuite.dc.HTTPClient()
 	require.NoError(t, err)
-	require.NoError(t, hc.LoginIntoNamespace(dgraphtest.DefaultUser, dgraphtest.DefaultPassword, x.GalaxyNamespace))
+	require.NoError(t, hc.LoginIntoNamespace(dgraphapi.DefaultUser, dgraphapi.DefaultPassword, x.GalaxyNamespace))
 
 	require.NoError(t, gc.DropAll())
 	err = gc.Alter(ctx, &api.Operation{
@@ -2623,7 +2781,7 @@ func (asuite *AclTestSuite) TestMutationWithValueVar() {
 	require.NoError(t, err)
 	require.Equal(t, devGroup, createdGroup)
 	require.NoError(t, hc.AddUserToGroup(userid, devGroup))
-	require.NoError(t, hc.AddRulesToGroup(devGroup, []dgraphtest.AclRule{
+	require.NoError(t, hc.AddRulesToGroup(devGroup, []dgraphapi.AclRule{
 		{
 			Predicate:  "name",
 			Permission: Read.Code | Write.Code,
@@ -2683,7 +2841,7 @@ func (asuite *AclTestSuite) TestMutationWithValueVar() {
 
 	resp, err := userClient.Query(query)
 	require.NoError(t, err)
-	require.NoError(t, dgraphtest.CompareJSON(`{"me": [{"name":"r1","nickname":"r1"}]}`, string(resp.GetJson())))
+	require.NoError(t, dgraphapi.CompareJSON(`{"me": [{"name":"r1","nickname":"r1"}]}`, string(resp.GetJson())))
 }
 
 func (asuite *AclTestSuite) TestDeleteGuardiansGroupShouldFail() {
@@ -2694,12 +2852,12 @@ func (asuite *AclTestSuite) TestDeleteGuardiansGroupShouldFail() {
 	gc, cleanup, err := asuite.dc.Client()
 	require.NoError(t, err)
 	defer cleanup()
-	require.NoError(t, gc.LoginIntoNamespace(ctx, dgraphtest.DefaultUser,
-		dgraphtest.DefaultPassword, x.GalaxyNamespace))
+	require.NoError(t, gc.LoginIntoNamespace(ctx, dgraphapi.DefaultUser,
+		dgraphapi.DefaultPassword, x.GalaxyNamespace))
 
 	hc, err := asuite.dc.HTTPClient()
 	require.NoError(t, err)
-	require.NoError(t, hc.LoginIntoNamespace(dgraphtest.DefaultUser, dgraphtest.DefaultPassword, x.GalaxyNamespace))
+	require.NoError(t, hc.LoginIntoNamespace(dgraphapi.DefaultUser, dgraphapi.DefaultPassword, x.GalaxyNamespace))
 
 	addDataAndRules(ctx, t, gc, hc)
 
@@ -2707,7 +2865,7 @@ func (asuite *AclTestSuite) TestDeleteGuardiansGroupShouldFail() {
 
 	hc, err = asuite.dc.HTTPClient()
 	require.NoError(t, err)
-	require.NoError(t, hc.LoginIntoNamespace(dgraphtest.DefaultUser, dgraphtest.DefaultPassword, x.GalaxyNamespace))
+	require.NoError(t, hc.LoginIntoNamespace(dgraphapi.DefaultUser, dgraphapi.DefaultPassword, x.GalaxyNamespace))
 
 	err = hc.DeleteGroup("guardians")
 	require.Error(t, err)
@@ -2722,13 +2880,13 @@ func (asuite *AclTestSuite) TestDeleteGrootUserShouldFail() {
 	gc, cleanup, err := asuite.dc.Client()
 	require.NoError(t, err)
 	defer cleanup()
-	require.NoError(t, gc.LoginIntoNamespace(ctx, dgraphtest.DefaultUser,
-		dgraphtest.DefaultPassword, x.GalaxyNamespace))
+	require.NoError(t, gc.LoginIntoNamespace(ctx, dgraphapi.DefaultUser,
+		dgraphapi.DefaultPassword, x.GalaxyNamespace))
 
 	hc, err := asuite.dc.HTTPClient()
 	require.NoError(t, err)
-	require.NoError(t, hc.LoginIntoNamespace(dgraphtest.DefaultUser,
-		dgraphtest.DefaultPassword, x.GalaxyNamespace))
+	require.NoError(t, hc.LoginIntoNamespace(dgraphapi.DefaultUser,
+		dgraphapi.DefaultPassword, x.GalaxyNamespace))
 
 	addDataAndRules(ctx, t, gc, hc)
 
@@ -2736,7 +2894,7 @@ func (asuite *AclTestSuite) TestDeleteGrootUserShouldFail() {
 
 	hc, err = asuite.dc.HTTPClient()
 	require.NoError(t, err)
-	require.NoError(t, hc.LoginIntoNamespace(dgraphtest.DefaultUser, dgraphtest.DefaultPassword, x.GalaxyNamespace))
+	require.NoError(t, hc.LoginIntoNamespace(dgraphapi.DefaultUser, dgraphapi.DefaultPassword, x.GalaxyNamespace))
 
 	err = hc.DeleteUser("groot")
 	require.Error(t, err)
@@ -2752,12 +2910,12 @@ func (asuite *AclTestSuite) TestDeleteGrootUserFromGuardiansGroupShouldFail() {
 	gc, cleanup, err := asuite.dc.Client()
 	require.NoError(t, err)
 	defer cleanup()
-	require.NoError(t, gc.LoginIntoNamespace(ctx, dgraphtest.DefaultUser,
-		dgraphtest.DefaultPassword, x.GalaxyNamespace))
+	require.NoError(t, gc.LoginIntoNamespace(ctx, dgraphapi.DefaultUser,
+		dgraphapi.DefaultPassword, x.GalaxyNamespace))
 
 	hc, err := asuite.dc.HTTPClient()
 	require.NoError(t, err)
-	require.NoError(t, hc.LoginIntoNamespace(dgraphtest.DefaultUser, dgraphtest.DefaultPassword, x.GalaxyNamespace))
+	require.NoError(t, hc.LoginIntoNamespace(dgraphapi.DefaultUser, dgraphapi.DefaultPassword, x.GalaxyNamespace))
 
 	addDataAndRules(ctx, t, gc, hc)
 
@@ -2765,7 +2923,7 @@ func (asuite *AclTestSuite) TestDeleteGrootUserFromGuardiansGroupShouldFail() {
 
 	hc, err = asuite.dc.HTTPClient()
 	require.NoError(t, err)
-	require.NoError(t, hc.LoginIntoNamespace(dgraphtest.DefaultUser, dgraphtest.DefaultPassword, x.GalaxyNamespace))
+	require.NoError(t, hc.LoginIntoNamespace(dgraphapi.DefaultUser, dgraphapi.DefaultPassword, x.GalaxyNamespace))
 
 	err = hc.RemoveUserFromGroup("groot", "guardians")
 	require.Error(t, err)
@@ -2780,12 +2938,12 @@ func (asuite *AclTestSuite) TestDeleteGrootAndGuardiansUsingDelNQuadShouldFail()
 	gc, cleanup, err := asuite.dc.Client()
 	require.NoError(t, err)
 	defer cleanup()
-	require.NoError(t, gc.LoginIntoNamespace(ctx, dgraphtest.DefaultUser,
-		dgraphtest.DefaultPassword, x.GalaxyNamespace))
+	require.NoError(t, gc.LoginIntoNamespace(ctx, dgraphapi.DefaultUser,
+		dgraphapi.DefaultPassword, x.GalaxyNamespace))
 
 	hc, err := asuite.dc.HTTPClient()
 	require.NoError(t, err)
-	require.NoError(t, hc.LoginIntoNamespace(dgraphtest.DefaultUser, dgraphtest.DefaultPassword, x.GalaxyNamespace))
+	require.NoError(t, hc.LoginIntoNamespace(dgraphapi.DefaultUser, dgraphapi.DefaultPassword, x.GalaxyNamespace))
 
 	addDataAndRules(ctx, t, gc, hc)
 
@@ -2794,8 +2952,8 @@ func (asuite *AclTestSuite) TestDeleteGrootAndGuardiansUsingDelNQuadShouldFail()
 	gc, cleanup, err = asuite.dc.Client()
 	require.NoError(t, err)
 	defer cleanup()
-	require.NoError(t, gc.LoginIntoNamespace(ctx, dgraphtest.DefaultUser,
-		dgraphtest.DefaultPassword, x.GalaxyNamespace))
+	require.NoError(t, gc.LoginIntoNamespace(ctx, dgraphapi.DefaultUser,
+		dgraphapi.DefaultPassword, x.GalaxyNamespace))
 
 	grootUid, guardiansUid := getGrootAndGuardiansUid(t, gc)
 
@@ -2812,7 +2970,7 @@ func (asuite *AclTestSuite) TestDeleteGrootAndGuardiansUsingDelNQuadShouldFail()
 	require.Contains(t, err.Error(), "Properties of guardians group and groot user cannot be deleted")
 }
 
-func deleteGuardiansGroupAndGrootUserShouldFail(t *testing.T, hc *dgraphtest.HTTPClient) {
+func deleteGuardiansGroupAndGrootUserShouldFail(t *testing.T, hc *dgraphapi.HTTPClient) {
 	// Try deleting guardians group should fail
 	err := hc.DeleteGroup("guardians")
 	require.Error(t, err)
@@ -2831,12 +2989,12 @@ func (asuite *AclTestSuite) TestDropAllShouldResetGuardiansAndGroot() {
 	gc, cleanup, err := asuite.dc.Client()
 	require.NoError(t, err)
 	defer cleanup()
-	require.NoError(t, gc.LoginIntoNamespace(ctx, dgraphtest.DefaultUser,
-		dgraphtest.DefaultPassword, x.GalaxyNamespace))
+	require.NoError(t, gc.LoginIntoNamespace(ctx, dgraphapi.DefaultUser,
+		dgraphapi.DefaultPassword, x.GalaxyNamespace))
 	hc, err := asuite.dc.HTTPClient()
 
 	require.NoError(t, err)
-	require.NoError(t, hc.LoginIntoNamespace(dgraphtest.DefaultUser, dgraphtest.DefaultPassword, x.GalaxyNamespace))
+	require.NoError(t, hc.LoginIntoNamespace(dgraphapi.DefaultUser, dgraphapi.DefaultPassword, x.GalaxyNamespace))
 
 	addDataAndRules(ctx, t, gc, hc)
 
@@ -2845,8 +3003,8 @@ func (asuite *AclTestSuite) TestDropAllShouldResetGuardiansAndGroot() {
 	gc, cleanup, err = asuite.dc.Client()
 	defer cleanup()
 	require.NoError(t, err)
-	require.NoError(t, gc.LoginIntoNamespace(ctx, dgraphtest.DefaultUser,
-		dgraphtest.DefaultPassword, x.GalaxyNamespace))
+	require.NoError(t, gc.LoginIntoNamespace(ctx, dgraphapi.DefaultUser,
+		dgraphapi.DefaultPassword, x.GalaxyNamespace))
 
 	// Try Drop All
 	op := api.Operation{
@@ -2861,7 +3019,7 @@ func (asuite *AclTestSuite) TestDropAllShouldResetGuardiansAndGroot() {
 
 	hc, err = asuite.dc.HTTPClient()
 	require.NoError(t, err)
-	require.NoError(t, hc.LoginIntoNamespace(dgraphtest.DefaultUser, dgraphtest.DefaultPassword, x.GalaxyNamespace))
+	require.NoError(t, hc.LoginIntoNamespace(dgraphapi.DefaultUser, dgraphapi.DefaultPassword, x.GalaxyNamespace))
 	deleteGuardiansGroupAndGrootUserShouldFail(t, hc)
 
 	// Try Drop Data
@@ -2875,6 +3033,6 @@ func (asuite *AclTestSuite) TestDropAllShouldResetGuardiansAndGroot() {
 
 	hc, err = asuite.dc.HTTPClient()
 	require.NoError(t, err)
-	require.NoError(t, hc.LoginIntoNamespace(dgraphtest.DefaultUser, dgraphtest.DefaultPassword, x.GalaxyNamespace))
+	require.NoError(t, hc.LoginIntoNamespace(dgraphapi.DefaultUser, dgraphapi.DefaultPassword, x.GalaxyNamespace))
 	deleteGuardiansGroupAndGrootUserShouldFail(t, hc)
 }

--- a/ee/acl/integration_test.go
+++ b/ee/acl/integration_test.go
@@ -17,12 +17,13 @@ import (
 
 	"github.com/stretchr/testify/suite"
 
+	"github.com/dgraph-io/dgraph/dgraphapi"
 	"github.com/dgraph-io/dgraph/dgraphtest"
 )
 
 type AclTestSuite struct {
 	suite.Suite
-	dc dgraphtest.Cluster
+	dc dgraphapi.Cluster
 }
 
 func (suite *AclTestSuite) SetupTest() {

--- a/ee/acl/jwt_algo_test.go
+++ b/ee/acl/jwt_algo_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/stretchr/testify/require"
 
+	"github.com/dgraph-io/dgraph/dgraphapi"
 	"github.com/dgraph-io/dgraph/dgraphtest"
 	"github.com/dgraph-io/dgraph/x"
 )
@@ -48,7 +49,7 @@ func TestACLJwtAlgo(t *testing.T) {
 			require.NoError(t, err)
 			defer cleanup()
 			require.NoError(t, gc.LoginIntoNamespace(context.Background(),
-				dgraphtest.DefaultUser, dgraphtest.DefaultPassword, x.GalaxyNamespace))
+				dgraphapi.DefaultUser, dgraphapi.DefaultPassword, x.GalaxyNamespace))
 
 			// op with Grpc client
 			_, err = gc.Query(`{q(func: uid(0x1)) {uid}}`)
@@ -61,8 +62,8 @@ func TestACLJwtAlgo(t *testing.T) {
 
 			hc, err := c.HTTPClient()
 			require.NoError(t, err)
-			require.NoError(t, hc.LoginIntoNamespace(dgraphtest.DefaultUser,
-				dgraphtest.DefaultPassword, x.GalaxyNamespace))
+			require.NoError(t, hc.LoginIntoNamespace(dgraphapi.DefaultUser,
+				dgraphapi.DefaultPassword, x.GalaxyNamespace))
 
 			// op with HTTP client
 			require.NoError(t, hc.Backup(c, true, dgraphtest.DefaultBackupDir))

--- a/ee/acl/upgrade_test.go
+++ b/ee/acl/upgrade_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
+	"github.com/dgraph-io/dgraph/dgraphapi"
 	"github.com/dgraph-io/dgraph/dgraphtest"
 	"github.com/dgraph-io/dgraph/x"
 )
@@ -27,7 +28,7 @@ import (
 type AclTestSuite struct {
 	suite.Suite
 	lc *dgraphtest.LocalCluster
-	dc dgraphtest.Cluster
+	dc dgraphapi.Cluster
 	uc dgraphtest.UpgradeCombo
 }
 

--- a/query/cloud_test.go
+++ b/query/cloud_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/dgraph-io/dgraph/dgraphapi"
 	"github.com/dgraph-io/dgraph/dgraphtest"
 	"github.com/dgraph-io/dgraph/x"
 )
@@ -37,7 +38,7 @@ func TestMain(m *testing.M) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
-	x.Panic(dg.LoginIntoNamespace(ctx, dgraphtest.DefaultUser, dgraphtest.DefaultPassword, x.GalaxyNamespace))
+	x.Panic(dg.LoginIntoNamespace(ctx, dgraphapi.DefaultUser, dgraphapi.DefaultPassword, x.GalaxyNamespace))
 
 	dc = c
 	client = dg.Dgraph

--- a/query/cloud_test.go
+++ b/query/cloud_test.go
@@ -41,7 +41,7 @@ func TestMain(m *testing.M) {
 	x.Panic(dg.LoginIntoNamespace(ctx, dgraphapi.DefaultUser, dgraphapi.DefaultPassword, x.GalaxyNamespace))
 
 	dc = c
-	client = dg.Dgraph
+	client.Dgraph = dg
 	populateCluster(dc)
 	m.Run()
 }

--- a/query/common_test.go
+++ b/query/common_test.go
@@ -30,7 +30,6 @@ import (
 
 	"github.com/dgraph-io/dgo/v230/protos/api"
 	"github.com/dgraph-io/dgraph/dgraphapi"
-	"github.com/dgraph-io/dgraph/dgraphtest"
 	"github.com/dgraph-io/dgraph/x"
 )
 

--- a/query/common_test.go
+++ b/query/common_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/dgraph-io/dgo/v230/protos/api"
+	"github.com/dgraph-io/dgraph/dgraphapi"
 	"github.com/dgraph-io/dgraph/dgraphtest"
 	"github.com/dgraph-io/dgraph/x"
 )
@@ -347,7 +348,7 @@ name2                          : string @index(term)  .
 age2                           : int @index(int) .
 `
 
-func populateCluster(dc dgraphtest.Cluster) {
+func populateCluster(dc dgraphapi.Cluster) {
 	x.Panic(client.Alter(context.Background(), &api.Operation{DropAll: true}))
 
 	// In the query package, we test using hard coded UIDs so that we know what results

--- a/query/integration_test.go
+++ b/query/integration_test.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/dgraph-io/dgraph/dgraphapi"
 	"github.com/dgraph-io/dgraph/dgraphtest"
 	"github.com/dgraph-io/dgraph/x"
 )
@@ -34,8 +35,8 @@ func TestMain(m *testing.M) {
 	client, cleanup, err = dc.Client()
 	x.Panic(err)
 	defer cleanup()
-	x.Panic(client.LoginIntoNamespace(context.Background(), dgraphtest.DefaultUser,
-		dgraphtest.DefaultPassword, x.GalaxyNamespace))
+	x.Panic(client.LoginIntoNamespace(context.Background(), dgraphapi.DefaultUser,
+		dgraphapi.DefaultPassword, x.GalaxyNamespace))
 
 	populateCluster(dc)
 	m.Run()

--- a/query/query0_test.go
+++ b/query/query0_test.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/dgraph-io/dgraph/dgraphapi"
 	"github.com/dgraph-io/dgraph/dgraphtest"
 	"github.com/dgraph-io/dgraph/dql"
 )
@@ -3621,5 +3622,5 @@ func TestInvalidRegex(t *testing.T) {
 	}
 }
 
-var client *dgraphtest.GrpcClient
-var dc dgraphtest.Cluster
+var client *dgraphapi.GrpcClient
+var dc dgraphapi.Cluster

--- a/query/query3_test.go
+++ b/query/query3_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/metadata"
 
-	"github.com/dgraph-io/dgraph/dgraphtest"
+	"github.com/dgraph-io/dgraph/dgraphapi"
 	"github.com/dgraph-io/dgraph/testutil"
 )
 
@@ -2346,9 +2346,9 @@ func TestPasswordExpandAll1(t *testing.T) {
 	`
 	js := processQueryNoErr(t, query)
 	// During upgrade tests, UIDs of groot and guardians nodes might change.
-	a := dgraphtest.CompareJSON(`{"data":{"me":[{"alive":true,
+	a := dgraphapi.CompareJSON(`{"data":{"me":[{"alive":true,
 	"gender":"female", "name":"Michonne"}]}}`, js)
-	b := dgraphtest.CompareJSON(`{"data":{"me":[{"alive":true, "dgraph.xid":"guardians",
+	b := dgraphapi.CompareJSON(`{"data":{"me":[{"alive":true, "dgraph.xid":"guardians",
 	"gender":"female","name":"Michonne"}]}}`, js)
 	if a != nil && b != nil {
 		t.Error(a)
@@ -2366,9 +2366,9 @@ func TestPasswordExpandAll2(t *testing.T) {
 	`
 	js := processQueryNoErr(t, query)
 	// During upgrade tests, UIDs of groot and guardians nodes might change.
-	a := dgraphtest.CompareJSON(`{"data":{"me":[{"alive":true, "checkpwd(password)":false,
+	a := dgraphapi.CompareJSON(`{"data":{"me":[{"alive":true, "checkpwd(password)":false,
 	"gender":"female", "name":"Michonne"}]}}`, js)
-	b := dgraphtest.CompareJSON(`{"data":{"me":[{"alive":true, "dgraph.xid":"guardians",
+	b := dgraphapi.CompareJSON(`{"data":{"me":[{"alive":true, "dgraph.xid":"guardians",
 	"checkpwd(password)":false, "gender":"female", "name":"Michonne"}]}}`, js)
 	if a != nil && b != nil {
 		t.Error(a)
@@ -3213,8 +3213,8 @@ func TestMultiRegexInFilter(t *testing.T) {
 	`
 	res := processQueryNoErr(t, query)
 	// During upgrade tests, UIDs of groot and guardians nodes might change.
-	a := dgraphtest.CompareJSON(`{"data": {"q": [{"alive":true, "gender":"female","name":"Michonne"}]}}`, res)
-	b := dgraphtest.CompareJSON(`{"data": {"q": [{"alive":true, "dgraph.xid":"guardians",
+	a := dgraphapi.CompareJSON(`{"data": {"q": [{"alive":true, "gender":"female","name":"Michonne"}]}}`, res)
+	b := dgraphapi.CompareJSON(`{"data": {"q": [{"alive":true, "dgraph.xid":"guardians",
 		"gender":"female","name":"Michonne"}]}}`, res)
 	if a != nil && b != nil {
 		t.Error(a)

--- a/query/query4_test.go
+++ b/query/query4_test.go
@@ -28,7 +28,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/dgraph-io/dgo/v230/protos/api"
-	"github.com/dgraph-io/dgraph/dgraphtest"
+	"github.com/dgraph-io/dgraph/dgraphapi"
 	"github.com/dgraph-io/dgraph/x"
 )
 
@@ -638,9 +638,9 @@ func TestFilterAtSameLevelOnUIDWithExpand(t *testing.T) {
 	}`
 	js := processQueryNoErr(t, query)
 	// Because the UID for guardians and groot can change while upgrade tests are running
-	a := dgraphtest.CompareJSON(`{"data":{"q":[{"name":"Michonne","gender":"female","alive":true,
+	a := dgraphapi.CompareJSON(`{"data":{"q":[{"name":"Michonne","gender":"female","alive":true,
 	"friend":[{"gender":"male","alive":true,"name":"Rick Grimes"}]}]}}`, js)
-	b := dgraphtest.CompareJSON(`{"data":{"q":[{"name":"Michonne","gender":"female","alive":true,
+	b := dgraphapi.CompareJSON(`{"data":{"q":[{"name":"Michonne","gender":"female","alive":true,
 	"dgraph.xid":"guardians","friend":[{"gender":"male","alive":true,"name":"Rick Grimes"}]}]}}`, js)
 	if a != nil && b != nil {
 		t.Error(a)

--- a/query/upgrade_test.go
+++ b/query/upgrade_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/dgraph-io/dgraph/dgraphapi"
 	"github.com/dgraph-io/dgraph/dgraphtest"
 	"github.com/dgraph-io/dgraph/x"
 )
@@ -34,8 +35,8 @@ func TestMain(m *testing.M) {
 		dg, cleanup, err := c.Client()
 		x.Panic(err)
 		defer cleanup()
-		x.Panic(dg.LoginIntoNamespace(context.Background(), dgraphtest.DefaultUser,
-			dgraphtest.DefaultPassword, x.GalaxyNamespace))
+		x.Panic(dg.LoginIntoNamespace(context.Background(), dgraphapi.DefaultUser,
+			dgraphapi.DefaultPassword, x.GalaxyNamespace))
 
 		client = dg
 		dc = c
@@ -46,8 +47,8 @@ func TestMain(m *testing.M) {
 		dg, cleanup, err := c.Client()
 		x.Panic(err)
 		defer cleanup()
-		x.Panic(dg.LoginIntoNamespace(context.Background(), dgraphtest.DefaultUser,
-			dgraphtest.DefaultPassword, x.GalaxyNamespace))
+		x.Panic(dg.LoginIntoNamespace(context.Background(), dgraphapi.DefaultUser,
+			dgraphapi.DefaultPassword, x.GalaxyNamespace))
 
 		client = dg
 		dc = c
@@ -65,7 +66,7 @@ func TestMain(m *testing.M) {
 
 		hc, err := c.HTTPClient()
 		x.Panic(err)
-		x.Panic(hc.LoginIntoNamespace(dgraphtest.DefaultUser, dgraphtest.DefaultPassword, x.GalaxyNamespace))
+		x.Panic(hc.LoginIntoNamespace(dgraphapi.DefaultUser, dgraphapi.DefaultPassword, x.GalaxyNamespace))
 
 		mutate(c)
 		x.Panic(c.Upgrade(uc.After, uc.Strategy))

--- a/query/upgrade_test.go
+++ b/query/upgrade_test.go
@@ -31,7 +31,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	mutate := func(c dgraphtest.Cluster) {
+	mutate := func(c dgraphapi.Cluster) {
 		dg, cleanup, err := c.Client()
 		x.Panic(err)
 		defer cleanup()
@@ -43,7 +43,7 @@ func TestMain(m *testing.M) {
 		populateCluster(dc)
 	}
 
-	query := func(c dgraphtest.Cluster) int {
+	query := func(c dgraphapi.Cluster) int {
 		dg, cleanup, err := c.Client()
 		x.Panic(err)
 		defer cleanup()

--- a/query/vector/integration_test.go
+++ b/query/vector/integration_test.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/dgraph-io/dgraph/dgraphapi"
 	"github.com/dgraph-io/dgraph/dgraphtest"
 	"github.com/dgraph-io/dgraph/x"
 )
@@ -34,8 +35,8 @@ func TestMain(m *testing.M) {
 	client, cleanup, err = dc.Client()
 	x.Panic(err)
 	defer cleanup()
-	x.Panic(client.LoginIntoNamespace(context.Background(), dgraphtest.DefaultUser,
-		dgraphtest.DefaultPassword, x.GalaxyNamespace))
+	x.Panic(client.LoginIntoNamespace(context.Background(), dgraphapi.DefaultUser,
+		dgraphapi.DefaultPassword, x.GalaxyNamespace))
 
 	m.Run()
 }

--- a/query/vector/vector_graphql_test.go
+++ b/query/vector/vector_graphql_test.go
@@ -24,7 +24,7 @@ import (
 	"math/rand"
 	"testing"
 
-	"github.com/dgraph-io/dgraph/dgraphtest"
+	"github.com/dgraph-io/dgraph/dgraphapi"
 	"github.com/stretchr/testify/require"
 )
 
@@ -89,7 +89,7 @@ func generateRandomTitleV(size int) []float32 {
 	return titleV
 }
 
-func addProject(t *testing.T, hc *dgraphtest.HTTPClient, project ProjectInput) {
+func addProject(t *testing.T, hc *dgraphapi.HTTPClient, project ProjectInput) {
 	query := `
 	  mutation addProject($project: AddProjectInput!) {
 		  addProject(input: [$project]) {
@@ -100,7 +100,7 @@ func addProject(t *testing.T, hc *dgraphtest.HTTPClient, project ProjectInput) {
 		  }
 	  }`
 
-	params := dgraphtest.GraphQLParams{
+	params := dgraphapi.GraphQLParams{
 		Query:     query,
 		Variables: map[string]interface{}{"project": project},
 	}
@@ -109,7 +109,7 @@ func addProject(t *testing.T, hc *dgraphtest.HTTPClient, project ProjectInput) {
 	require.NoError(t, err)
 }
 
-func queryProjectUsingTitle(t *testing.T, hc *dgraphtest.HTTPClient, title string) ProjectInput {
+func queryProjectUsingTitle(t *testing.T, hc *dgraphapi.HTTPClient, title string) ProjectInput {
 	query := ` query QueryProject($title: String!) {
 		 queryProject(filter: { title: { eq: $title } }) {
 		   title
@@ -117,7 +117,7 @@ func queryProjectUsingTitle(t *testing.T, hc *dgraphtest.HTTPClient, title strin
 		 }
 	   }`
 
-	params := dgraphtest.GraphQLParams{
+	params := dgraphapi.GraphQLParams{
 		Query:     query,
 		Variables: map[string]interface{}{"title": title},
 	}
@@ -133,7 +133,7 @@ func queryProjectUsingTitle(t *testing.T, hc *dgraphtest.HTTPClient, title strin
 	return resp.QueryProject[0]
 }
 
-func queryProjectsSimilarByEmbedding(t *testing.T, hc *dgraphtest.HTTPClient, vector []float32, topk int) []ProjectInput {
+func queryProjectsSimilarByEmbedding(t *testing.T, hc *dgraphapi.HTTPClient, vector []float32, topk int) []ProjectInput {
 	// query similar project by embedding
 	queryProduct := `query QuerySimilarProjectByEmbedding($by: ProjectEmbedding!, $topK: Int!, $vector: [Float!]!) {
 		 querySimilarProjectByEmbedding(by: $by, topK: $topK, vector: $vector) {
@@ -144,7 +144,7 @@ func queryProjectsSimilarByEmbedding(t *testing.T, hc *dgraphtest.HTTPClient, ve
 
 	 `
 
-	params := dgraphtest.GraphQLParams{
+	params := dgraphapi.GraphQLParams{
 		Query: queryProduct,
 		Variables: map[string]interface{}{
 			"by":     "title_v",
@@ -227,7 +227,7 @@ func TestVectorGraphQlDotProductIndexMutationAndQuery(t *testing.T) {
 	testVectorGraphQlMutationAndQuery(t, hc)
 }
 
-func testVectorGraphQlMutationAndQuery(t *testing.T, hc *dgraphtest.HTTPClient) {
+func testVectorGraphQlMutationAndQuery(t *testing.T, hc *dgraphapi.HTTPClient) {
 	var vectors [][]float32
 	numProjects := 100
 	projects := generateProjects(numProjects)

--- a/query/vector/vector_test.go
+++ b/query/vector/vector_test.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	"github.com/dgraph-io/dgo/v230/protos/api"
+	"github.com/dgraph-io/dgraph/dgraphapi"
 	"github.com/dgraph-io/dgraph/dgraphtest"
 	"github.com/dgraph-io/dgraph/x"
 	"github.com/stretchr/testify/require"
@@ -41,8 +42,8 @@ const (
 	vectorSchemaWithoutIndex = `%v: float32vector .`
 )
 
-var client *dgraphtest.GrpcClient
-var dc dgraphtest.Cluster
+var client *dgraphapi.GrpcClient
+var dc dgraphapi.Cluster
 
 func setSchema(schema string) {
 	var err error
@@ -445,8 +446,8 @@ func TestVectorDeadlockwithTimeout(t *testing.T) {
 		fmt.Println("Testing iteration: ", i)
 		ctx, cancel2 := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel2()
-		err = client.LoginIntoNamespace(ctx, dgraphtest.DefaultUser,
-			dgraphtest.DefaultPassword, x.GalaxyNamespace)
+		err = client.LoginIntoNamespace(ctx, dgraphapi.DefaultUser,
+			dgraphapi.DefaultPassword, x.GalaxyNamespace)
 		require.NoError(t, err)
 
 		err = client.Alter(context.Background(), &api.Operation{

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -830,10 +830,11 @@ func initialSchemaInternal(namespace uint64, all bool) []*pb.SchemaUpdate {
 	return initialSchema
 }
 
-// IsPreDefPredChanged returns true if the initial update for the pre-defined
-// predicate is different than the passed update.
-// If the passed update is not a pre-defined predicate then it just returns false.
-func IsPreDefPredChanged(update *pb.SchemaUpdate) bool {
+// CheckAndModifyPreDefPredicate returns true if the initial update for the pre-defined
+// predicate is different from the passed update. It may also modify certain predicates
+// under specific conditions.
+// If the passed update is not a pre-defined predicate, it returns false.
+func CheckAndModifyPreDefPredicate(update *pb.SchemaUpdate) bool {
 	// Return false for non-pre-defined predicates.
 	if !x.IsPreDefinedPredicate(update.Predicate) {
 		return false
@@ -862,10 +863,7 @@ func IsPreDefPredChanged(update *pb.SchemaUpdate) bool {
 // isDgraphXidChangeValid returns true if the change in the dgraph.xid predicate is valid.
 func isDgraphXidChangeValid(original, update *pb.SchemaUpdate) bool {
 	changed := compareSchemaUpdates(original, update)
-	if len(changed) == 1 && changed[0] == "Unique" {
-		return true
-	}
-	return false
+	return len(changed) == 1 && changed[0] == "Unique"
 }
 
 func compareSchemaUpdates(original, update *pb.SchemaUpdate) []string {

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -791,6 +791,7 @@ func initialSchemaInternal(namespace uint64, all bool) []*pb.SchemaUpdate {
 				ValueType: pb.Posting_STRING,
 				Directive: pb.SchemaUpdate_INDEX,
 				Upsert:    true,
+				Unique:    true,
 				Tokenizer: []string{"exact"},
 			},
 			{

--- a/systest/integration2/acl_test.go
+++ b/systest/integration2/acl_test.go
@@ -1,0 +1,115 @@
+//go:build integration2
+
+/*
+ * Copyright 2024 Dgraph Labs, Inc. and Contributors *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/dgraph-io/dgo/v230/protos/api"
+	"github.com/dgraph-io/dgraph/dgraphapi"
+	"github.com/dgraph-io/dgraph/dgraphtest"
+	"github.com/dgraph-io/dgraph/x"
+
+	"github.com/stretchr/testify/require"
+)
+
+type S struct {
+	Predicate string   `json:"predicate"`
+	Type      string   `json:"type"`
+	Index     bool     `json:"index"`
+	Tokenizer []string `json:"tokenizer"`
+	Unique    bool     `json:"unique"`
+}
+
+type Received struct {
+	Schema []S `json:"schema"`
+}
+
+func testDuplicateUserUpgradeStrat(t *testing.T, strat dgraphtest.UpgradeStrategy) {
+	conf := dgraphtest.NewClusterConfig().WithNumAlphas(1).WithNumZeros(1).WithReplicas(1).WithACL(time.Hour).WithVersion("v23.0.1")
+	c, err := dgraphtest.NewLocalCluster(conf)
+	require.NoError(t, err)
+	defer func() { c.Cleanup(t.Failed()) }()
+	require.NoError(t, c.Start())
+
+	gc, cleanup, err := c.Client()
+	require.NoError(t, err)
+	defer cleanup()
+	require.NoError(t, gc.LoginIntoNamespace(context.Background(),
+		dgraphapi.DefaultUser, dgraphapi.DefaultPassword, x.GalaxyNamespace))
+
+	hc, err := c.HTTPClient()
+	require.NoError(t, err)
+	require.NoError(t, hc.LoginIntoNamespace(dgraphapi.DefaultUser,
+		dgraphapi.DefaultPassword, x.GalaxyNamespace))
+	require.NoError(t, gc.SetupSchema(`name: string  .`))
+
+	rdfs := `
+	_:a <name> "alice" .
+	_:b <name> "bob" .
+	_:c <name> "sagar" .
+	_:d <name> "ajay" .`
+	_, err = gc.Mutate(&api.Mutation{SetNquads: []byte(rdfs), CommitNow: true})
+	require.NoError(t, c.Upgrade("local", strat))
+	gc, cleanup, err = c.Client()
+	require.NoError(t, err)
+	defer cleanup()
+	require.NoError(t, gc.LoginIntoNamespace(context.Background(),
+		dgraphapi.DefaultUser, dgraphapi.DefaultPassword, x.GalaxyNamespace))
+
+	hc, err = c.HTTPClient()
+	require.NoError(t, err)
+	require.NoError(t, hc.LoginIntoNamespace(dgraphapi.DefaultUser,
+		dgraphapi.DefaultPassword, x.GalaxyNamespace))
+
+	query := "schema {}"
+	resp, err := gc.Query(query)
+	require.NoError(t, err)
+
+	var received Received
+	require.NoError(t, json.Unmarshal([]byte(resp.Json), &received))
+	for _, s := range received.Schema {
+		if s.Predicate == "dgraph.xid" {
+			require.True(t, s.Unique)
+		}
+	}
+
+	query = `{
+		q(func: has(name)) {
+		count(uid)			
+		}
+	}`
+	resp, err = gc.Query(query)
+	require.NoError(t, err)
+	require.Contains(t, string(resp.Json), `"count":4`)
+}
+
+func TestDuplicateUserWithLiveLoader(t *testing.T) {
+	testDuplicateUserUpgradeStrat(t, dgraphtest.ExportImport)
+}
+
+func TestDuplicateUserWithBackupRestore(t *testing.T) {
+	testDuplicateUserUpgradeStrat(t, dgraphtest.BackupRestore)
+}
+
+func TestDuplicateUserWithInPlace(t *testing.T) {
+	testDuplicateUserUpgradeStrat(t, dgraphtest.InPlace)
+}

--- a/systest/integration2/bulk_loader_test.go
+++ b/systest/integration2/bulk_loader_test.go
@@ -23,7 +23,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/dgraph-io/dgraph/dgraphapi"
 	"github.com/dgraph-io/dgraph/dgraphtest"
+
 	"github.com/dgraph-io/dgraph/x"
 	"github.com/stretchr/testify/require"
 )
@@ -99,10 +101,10 @@ func TestBulkLoaderNoDqlSchema(t *testing.T) {
 	// run some queries and ensure everything looks good
 	hc, err := c.HTTPClient()
 	require.NoError(t, err)
-	require.NoError(t, hc.LoginIntoNamespace(dgraphtest.DefaultUser,
-		dgraphtest.DefaultPassword, x.GalaxyNamespace))
+	require.NoError(t, hc.LoginIntoNamespace(dgraphapi.DefaultUser,
+		dgraphapi.DefaultPassword, x.GalaxyNamespace))
 
-	params := dgraphtest.GraphQLParams{
+	params := dgraphapi.GraphQLParams{
 		Query: `query {
 			getMessage(uniqueId: 3) {
 				content
@@ -112,15 +114,15 @@ func TestBulkLoaderNoDqlSchema(t *testing.T) {
 	}
 	data, err := hc.RunGraphqlQuery(params, false)
 	require.NoError(t, err)
-	dgraphtest.CompareJSON(`{
+	dgraphapi.CompareJSON(`{
 		"getMessage": {
 		  "content": "DVTCTXCVYI",
 		  "author": "USYMVFJYXA"
 		}
 	  }`, string(data))
 
-	require.NoError(t, hc.LoginIntoNamespace(dgraphtest.DefaultUser, dgraphtest.DefaultPassword, 1))
-	params = dgraphtest.GraphQLParams{
+	require.NoError(t, hc.LoginIntoNamespace(dgraphapi.DefaultUser, dgraphapi.DefaultPassword, 1))
+	params = dgraphapi.GraphQLParams{
 		Query: `query {
 			getTemplate(uniqueId: 2) {
 				content
@@ -129,7 +131,7 @@ func TestBulkLoaderNoDqlSchema(t *testing.T) {
 	}
 	data, err = hc.RunGraphqlQuery(params, false)
 	require.NoError(t, err)
-	dgraphtest.CompareJSON(`{
+	dgraphapi.CompareJSON(`{
 		"getTemplate": {
 		  "content": "t2"
 		}

--- a/systest/integration2/graphql_schema_auth_test.go
+++ b/systest/integration2/graphql_schema_auth_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/dgraph-io/dgraph/dgraphapi"
 	"github.com/dgraph-io/dgraph/dgraphtest"
 	"github.com/dgraph-io/dgraph/x"
 	"github.com/stretchr/testify/require"
@@ -37,8 +38,8 @@ func TestGraphqlSchema(t *testing.T) {
 
 	hc, err := c.HTTPClient()
 	require.NoError(t, err)
-	require.NoError(t, hc.LoginIntoNamespace(dgraphtest.DefaultUser,
-		dgraphtest.DefaultPassword, x.GalaxyNamespace))
+	require.NoError(t, hc.LoginIntoNamespace(dgraphapi.DefaultUser,
+		dgraphapi.DefaultPassword, x.GalaxyNamespace))
 
 	// DGRAPHCORE-329
 	//nolint:lll
@@ -74,7 +75,7 @@ func TestGraphqlSchema(t *testing.T) {
 	# Dgraph.Authorization {"VerificationKey":"secretkey","Header":"X-Test-Auth","Namespace":"https://xyz.io/jwt/claims","Algo":"HS256","Audience":["aud"]}`
 	require.NoError(t, hc.UpdateGQLSchema(sch1))
 
-	params := dgraphtest.GraphQLParams{
+	params := dgraphapi.GraphQLParams{
 		Query: `query {
 			queryCity(filter: { id: { eq: 0 } }) {
 				name
@@ -84,7 +85,7 @@ func TestGraphqlSchema(t *testing.T) {
 	_, err = hc.RunGraphqlQuery(params, false)
 	require.NoError(t, err)
 
-	params = dgraphtest.GraphQLParams{
+	params = dgraphapi.GraphQLParams{
 		Query: `query {
 			queryCity(filter: { id: "0" }) {
 				name
@@ -714,9 +715,9 @@ func TestGraphqlSchema(t *testing.T) {
 	  """
 	  newPlaces: [Place]
 	  """
-	  Uncommon visited places. A place is uncommon if not visited for more than three times prior to the summary date.
+	  Uncommon visited places. A place is Uncommon if not visited for more than three times prior to the summary date.
 	  """
-	  uncommonPlaces: [Place]
+	  UncommonPlaces: [Place]
 	  """
 	  The total number of places visited in the day.
 	  """
@@ -726,9 +727,9 @@ func TestGraphqlSchema(t *testing.T) {
 	  """
 	  newPlaceCount: Int
 	  """
-	  The number of uncommon places visited in the day.
+	  The number of Uncommon places visited in the day.
 	  """
-	  uncommonPlaceCount: Int
+	  UncommonPlaceCount: Int
 	  """
 	  Cummulative time (in seconds) stationary.
 	  """
@@ -738,7 +739,7 @@ func TestGraphqlSchema(t *testing.T) {
 	  """
 	  durationInNewPlaces: Int
 	  """
-	  Cummulative time (in seconds) spent in uncommon places within the day.
+	  Cummulative time (in seconds) spent in Uncommon places within the day.
 	  """
 	  durationInUncommonPlaces: Int
 	  """

--- a/systest/integration2/incremental_restore_test.go
+++ b/systest/integration2/incremental_restore_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/dgraph-io/dgo/v230/protos/api"
+	"github.com/dgraph-io/dgraph/dgraphapi"
 	"github.com/dgraph-io/dgraph/dgraphtest"
 	"github.com/dgraph-io/dgraph/x"
 )
@@ -43,12 +44,12 @@ func TestIncrementalRestore(t *testing.T) {
 	require.NoError(t, err)
 	defer cleanup()
 	require.NoError(t, gc.LoginIntoNamespace(context.Background(),
-		dgraphtest.DefaultUser, dgraphtest.DefaultPassword, x.GalaxyNamespace))
+		dgraphapi.DefaultUser, dgraphapi.DefaultPassword, x.GalaxyNamespace))
 
 	hc, err := c.HTTPClient()
 	require.NoError(t, err)
-	require.NoError(t, hc.LoginIntoNamespace(dgraphtest.DefaultUser,
-		dgraphtest.DefaultPassword, x.GalaxyNamespace))
+	require.NoError(t, hc.LoginIntoNamespace(dgraphapi.DefaultUser,
+		dgraphapi.DefaultPassword, x.GalaxyNamespace))
 
 	uids := []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20}
 	c.AssignUids(gc.Dgraph, uint64(len(uids)))
@@ -69,7 +70,7 @@ func TestIncrementalRestore(t *testing.T) {
 
 		incrFrom := i - 1
 		require.NoError(t, hc.Restore(c, dgraphtest.DefaultBackupDir, "", incrFrom, i))
-		require.NoError(t, dgraphtest.WaitForRestore(c))
+		require.NoError(t, dgraphapi.WaitForRestore(c))
 
 		for j := 1; j <= i; j++ {
 			resp, err := gc.Query(fmt.Sprintf(`{q(func: uid(%v)) {money}}`, j))

--- a/systest/integration2/snapshot_test.go
+++ b/systest/integration2/snapshot_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/dgraph-io/dgraph/dgraphapi"
 	"github.com/dgraph-io/dgraph/dgraphtest"
 	"github.com/dgraph-io/dgraph/x"
 	"github.com/stretchr/testify/require"
@@ -42,13 +43,13 @@ func TestSnapshotTranferAfterNewNodeJoins(t *testing.T) {
 
 	hc, err := c.HTTPClient()
 	require.NoError(t, err)
-	hc.LoginIntoNamespace(dgraphtest.DefaultUser, dgraphtest.DefaultPassword, x.GalaxyNamespace)
+	hc.LoginIntoNamespace(dgraphapi.DefaultUser, dgraphapi.DefaultPassword, x.GalaxyNamespace)
 
 	gc, cleanup, err := c.Client()
 	require.NoError(t, err)
 	defer cleanup()
 	require.NoError(t, gc.LoginIntoNamespace(context.Background(),
-		dgraphtest.DefaultUser, dgraphtest.DefaultPassword, x.GalaxyNamespace))
+		dgraphapi.DefaultUser, dgraphapi.DefaultPassword, x.GalaxyNamespace))
 
 	prevSnapshotTs, err := hc.GetCurrentSnapshotTs(1)
 	require.NoError(t, err)

--- a/systest/license/integration_test.go
+++ b/systest/license/integration_test.go
@@ -23,12 +23,13 @@ import (
 
 	"github.com/stretchr/testify/suite"
 
+	"github.com/dgraph-io/dgraph/dgraphapi"
 	"github.com/dgraph-io/dgraph/dgraphtest"
 )
 
 type LicenseTestSuite struct {
 	suite.Suite
-	dc dgraphtest.Cluster
+	dc dgraphapi.Cluster
 }
 
 func (lsuite *LicenseTestSuite) SetupTest() {

--- a/systest/license/license_test.go
+++ b/systest/license/license_test.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/dgraph-io/dgraph/dgraphtest"
+	"github.com/dgraph-io/dgraph/dgraphapi"
 )
 
 var expiredKey = []byte(`-----BEGIN PGP MESSAGE-----
@@ -138,20 +138,20 @@ func (lsuite *LicenseTestSuite) TestEnterpriseLicenseWithGraphqlEndPoint() {
 		if tt.code == `Success` {
 			require.NoError(t, err)
 			// Check if the license is applied
-			dgraphtest.CompareJSON(`{"enterpriseLicense":{"response":{"code":"Success"}}}`, string(resp))
+			dgraphapi.CompareJSON(`{"enterpriseLicense":{"response":{"code":"Success"}}}`, string(resp))
 
 			// check the user information in case the license is applied
 			// Expired license should not be enabled even after it is applied
 			assertLicenseNotEnabled(t, hcli, tt.user)
 		} else {
-			dgraphtest.CompareJSON(`{"enterpriseLicense":null}`, string(resp))
+			dgraphapi.CompareJSON(`{"enterpriseLicense":null}`, string(resp))
 			// check the error message in case the license is not applied
 			require.Contains(t, err.Error(), tt.message)
 		}
 	}
 }
 
-func assertLicenseNotEnabled(t *testing.T, hcli *dgraphtest.HTTPClient, user string) {
+func assertLicenseNotEnabled(t *testing.T, hcli *dgraphapi.HTTPClient, user string) {
 	response, err := hcli.GetZeroState()
 	require.NoError(t, err)
 

--- a/systest/license/upgrade_test.go
+++ b/systest/license/upgrade_test.go
@@ -24,13 +24,14 @@ import (
 
 	"github.com/stretchr/testify/suite"
 
+	"github.com/dgraph-io/dgraph/dgraphapi"
 	"github.com/dgraph-io/dgraph/dgraphtest"
 	"github.com/dgraph-io/dgraph/x"
 )
 
 type LicenseTestSuite struct {
 	suite.Suite
-	dc dgraphtest.Cluster
+	dc dgraphapi.Cluster
 	lc *dgraphtest.LocalCluster
 	uc dgraphtest.UpgradeCombo
 }

--- a/systest/multi-tenancy/basic_test.go
+++ b/systest/multi-tenancy/basic_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/dgraph-io/dgo/v230/protos/api"
+	"github.com/dgraph-io/dgraph/dgraphapi"
 	"github.com/dgraph-io/dgraph/dgraphtest"
 	"github.com/dgraph-io/dgraph/ee/acl"
 	"github.com/dgraph-io/dgraph/x"
@@ -42,7 +43,7 @@ func (msuite *MultitenancyTestSuite) TestAclBasic() {
 	// Galaxy Login
 	hcli, err := msuite.dc.HTTPClient()
 	require.NoError(t, err)
-	err = hcli.LoginIntoNamespace(dgraphtest.DefaultUser, dgraphtest.DefaultPassword, x.GalaxyNamespace)
+	err = hcli.LoginIntoNamespace(dgraphapi.DefaultUser, dgraphapi.DefaultPassword, x.GalaxyNamespace)
 	require.NotNil(t, hcli.AccessJwt, "galaxy token is nil")
 	require.NoError(t, err, "login with namespace failed")
 
@@ -56,7 +57,7 @@ func (msuite *MultitenancyTestSuite) TestAclBasic() {
 	defer cleanup()
 	require.NoError(t, err)
 	require.NoError(t, gcli.LoginIntoNamespace(context.Background(),
-		dgraphtest.DefaultUser, dgraphtest.DefaultPassword, ns))
+		dgraphapi.DefaultUser, dgraphapi.DefaultPassword, ns))
 	msuite.AddData(gcli)
 
 	// Upgrade
@@ -66,7 +67,7 @@ func (msuite *MultitenancyTestSuite) TestAclBasic() {
 	defer cleanup()
 	require.NoError(t, err)
 	require.NoError(t, gcli.LoginIntoNamespace(context.Background(),
-		dgraphtest.DefaultUser, dgraphtest.DefaultPassword, ns))
+		dgraphapi.DefaultUser, dgraphapi.DefaultPassword, ns))
 
 	query := `{
 		me(func: has(name)) {
@@ -76,7 +77,7 @@ func (msuite *MultitenancyTestSuite) TestAclBasic() {
 	}`
 	resp, err := gcli.Query(query)
 	require.NoError(t, err)
-	require.NoError(t, dgraphtest.CompareJSON(
+	require.NoError(t, dgraphapi.CompareJSON(
 		`{"me": [{"name":"guy1","nickname":"RG"},{"name": "guy2", "nickname":"RG2"}]}`, string(resp.Json)))
 
 	// groot of namespace 0 should not see the data of namespace-1
@@ -84,15 +85,15 @@ func (msuite *MultitenancyTestSuite) TestAclBasic() {
 	defer cleanup()
 	require.NoError(t, err)
 	require.NoError(t, gcli.LoginIntoNamespace(context.Background(),
-		dgraphtest.DefaultUser, dgraphtest.DefaultPassword, x.GalaxyNamespace))
+		dgraphapi.DefaultUser, dgraphapi.DefaultPassword, x.GalaxyNamespace))
 	resp, err = gcli.Query(query)
 	require.NoError(t, err)
-	require.NoError(t, dgraphtest.CompareJSON(`{"me": []}`, string(resp.Json)))
+	require.NoError(t, dgraphapi.CompareJSON(`{"me": []}`, string(resp.Json)))
 
 	// Login to namespace 1 via groot and create new user alice.
 	hcli, err = msuite.dc.HTTPClient()
 	require.NoError(t, err)
-	err = hcli.LoginIntoNamespace(dgraphtest.DefaultUser, dgraphtest.DefaultPassword, ns)
+	err = hcli.LoginIntoNamespace(dgraphapi.DefaultUser, dgraphapi.DefaultPassword, ns)
 	require.NotNil(t, hcli.AccessJwt, "token for the namespace is nil")
 	require.NoErrorf(t, err, "login with namespace %d failed", ns)
 	_, err = hcli.CreateUser("alice", "newpassword")
@@ -105,21 +106,21 @@ func (msuite *MultitenancyTestSuite) TestAclBasic() {
 	require.NoError(t, gcli.LoginIntoNamespace(context.Background(), "alice", "newpassword", ns))
 	resp, err = gcli.Query(query)
 	require.NoError(t, err)
-	require.NoError(t, dgraphtest.CompareJSON(`{}`, string(resp.Json)))
+	require.NoError(t, dgraphapi.CompareJSON(`{}`, string(resp.Json)))
 
 	// Create a new group, add alice to that group and give read access of <name> to dev group.
 	_, err = hcli.CreateGroup("dev")
 	require.NoError(t, err)
 	require.NoError(t, hcli.AddUserToGroup("alice", "dev"))
 	require.NoError(t, hcli.AddRulesToGroup("dev",
-		[]dgraphtest.AclRule{{Predicate: "name", Permission: acl.Read.Code}}, true))
+		[]dgraphapi.AclRule{{Predicate: "name", Permission: acl.Read.Code}}, true))
 
 	// Now alice should see the name predicate but not nickname.
 	gcli, cleanup, err = msuite.dc.Client()
 	defer cleanup()
 	require.NoError(t, err)
 	require.NoError(t, gcli.LoginIntoNamespace(context.Background(), "alice", "newpassword", ns))
-	dgraphtest.PollTillPassOrTimeout(gcli, query, `{"me": [{"name":"guy1"},{"name": "guy2"}]}`, aclQueryTimeout)
+	dgraphapi.PollTillPassOrTimeout(gcli, query, `{"me": [{"name":"guy1"},{"name": "guy2"}]}`, aclQueryTimeout)
 }
 
 func (msuite *MultitenancyTestSuite) TestNameSpaceLimitFlag() {
@@ -128,7 +129,7 @@ func (msuite *MultitenancyTestSuite) TestNameSpaceLimitFlag() {
 	// Galaxy login
 	hcli, err := msuite.dc.HTTPClient()
 	require.NoError(t, err)
-	err = hcli.LoginIntoNamespace(dgraphtest.DefaultUser, dgraphtest.DefaultPassword, x.GalaxyNamespace)
+	err = hcli.LoginIntoNamespace(dgraphapi.DefaultUser, dgraphapi.DefaultPassword, x.GalaxyNamespace)
 	require.NotNil(t, hcli.AccessJwt, "galaxy token is nil")
 	require.NoErrorf(t, err, "login as groot into namespace %d failed", x.GalaxyNamespace)
 
@@ -144,7 +145,7 @@ func (msuite *MultitenancyTestSuite) TestNameSpaceLimitFlag() {
 	defer cleanup()
 	require.NoError(t, e)
 	require.NoError(t, gcli.LoginIntoNamespace(context.Background(),
-		dgraphtest.DefaultUser, dgraphtest.DefaultPassword, ns))
+		dgraphapi.DefaultUser, dgraphapi.DefaultPassword, ns))
 	require.NoError(t, gcli.SetupSchema(`name: string .`))
 
 	// trying to load more triplets than allowed,It should return error.
@@ -167,7 +168,7 @@ func (msuite *MultitenancyTestSuite) TestPersistentQuery() {
 	// Galaxy Login
 	hcli1, err := msuite.dc.HTTPClient()
 	require.NoError(t, err)
-	err = hcli1.LoginIntoNamespace(dgraphtest.DefaultUser, dgraphtest.DefaultPassword, x.GalaxyNamespace)
+	err = hcli1.LoginIntoNamespace(dgraphapi.DefaultUser, dgraphapi.DefaultPassword, x.GalaxyNamespace)
 	require.NotNil(t, hcli1.AccessJwt, "galaxy token is nil")
 	require.NoErrorf(t, err, "login as groot into namespace %d failed", x.GalaxyNamespace)
 
@@ -181,14 +182,14 @@ func (msuite *MultitenancyTestSuite) TestPersistentQuery() {
 	// Galaxy Login
 	hcli1, err = msuite.dc.HTTPClient()
 	require.NoError(t, err)
-	err = hcli1.LoginIntoNamespace(dgraphtest.DefaultUser, dgraphtest.DefaultPassword, x.GalaxyNamespace)
+	err = hcli1.LoginIntoNamespace(dgraphapi.DefaultUser, dgraphapi.DefaultPassword, x.GalaxyNamespace)
 	require.NotNil(t, hcli1.AccessJwt, "galaxy token is nil")
 	require.NoErrorf(t, err, "login as groot into namespace %d failed", x.GalaxyNamespace)
 
 	// Log into ns
 	hcli2, err := msuite.dc.HTTPClient()
 	require.NoError(t, err)
-	err = hcli2.LoginIntoNamespace(dgraphtest.DefaultUser, dgraphtest.DefaultPassword, ns)
+	err = hcli2.LoginIntoNamespace(dgraphapi.DefaultUser, dgraphapi.DefaultPassword, ns)
 	require.NotNil(t, hcli2.AccessJwt, "token is nil")
 	require.NoErrorf(t, err, "login as groot into namespace %d failed", ns)
 
@@ -218,7 +219,7 @@ func (msuite *MultitenancyTestSuite) TestPersistentQuery() {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "PersistedQueryNotFound")
 
-	hcli3 := &dgraphtest.HTTPClient{HttpToken: &dgraphtest.HttpToken{AccessJwt: ""}}
+	hcli3 := &dgraphapi.HTTPClient{HttpToken: &dgraphapi.HttpToken{AccessJwt: ""}}
 	_, err = hcli3.PostPersistentQuery("", sha1)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "unsupported protocol scheme")
@@ -230,7 +231,7 @@ func (msuite *MultitenancyTestSuite) TestTokenExpired() {
 	// Galaxy Login
 	hcli, err := msuite.dc.HTTPClient()
 	require.NoError(t, err)
-	err = hcli.LoginIntoNamespace(dgraphtest.DefaultUser, dgraphtest.DefaultPassword, x.GalaxyNamespace)
+	err = hcli.LoginIntoNamespace(dgraphapi.DefaultUser, dgraphapi.DefaultPassword, x.GalaxyNamespace)
 	require.NotNil(t, hcli.HttpToken, "galaxy token is nil")
 	require.NoErrorf(t, err, "login as groot into namespace %d failed", x.GalaxyNamespace)
 
@@ -244,7 +245,7 @@ func (msuite *MultitenancyTestSuite) TestTokenExpired() {
 	// ns Login
 	hcli, err = msuite.dc.HTTPClient()
 	require.NoError(t, err)
-	err = hcli.LoginIntoNamespace(dgraphtest.DefaultUser, dgraphtest.DefaultPassword, ns)
+	err = hcli.LoginIntoNamespace(dgraphapi.DefaultUser, dgraphapi.DefaultPassword, ns)
 	require.NotNil(t, hcli.HttpToken, "token is nil")
 	require.NoErrorf(t, err, "login as groot into namespace %d failed", ns)
 
@@ -266,7 +267,7 @@ func (msuite *MultitenancyTestSuite) TestTwoPermissionSetsInNameSpacesWithAcl() 
 	// Galaxy Login
 	ghcli, err := msuite.dc.HTTPClient()
 	require.NoError(t, err)
-	err = ghcli.LoginIntoNamespace(dgraphtest.DefaultUser, dgraphtest.DefaultPassword, x.GalaxyNamespace)
+	err = ghcli.LoginIntoNamespace(dgraphapi.DefaultUser, dgraphapi.DefaultPassword, x.GalaxyNamespace)
 	require.NotNil(t, ghcli, "galaxy token is nil")
 	require.NoErrorf(t, err, "login as groot into namespace %d failed", x.GalaxyNamespace)
 
@@ -284,7 +285,7 @@ func (msuite *MultitenancyTestSuite) TestTwoPermissionSetsInNameSpacesWithAcl() 
 	defer cleanup()
 	require.NoError(t, e)
 	require.NoError(t, gcli.LoginIntoNamespace(context.Background(),
-		dgraphtest.DefaultUser, dgraphtest.DefaultPassword, ns1))
+		dgraphapi.DefaultUser, dgraphapi.DefaultPassword, ns1))
 	msuite.AddData(gcli)
 
 	user1, user2 := "alice", "bob"
@@ -293,7 +294,7 @@ func (msuite *MultitenancyTestSuite) TestTwoPermissionSetsInNameSpacesWithAcl() 
 	// Create user alice in ns1
 	hcli, err := msuite.dc.HTTPClient()
 	require.NoError(t, err)
-	err = hcli.LoginIntoNamespace(dgraphtest.DefaultUser, dgraphtest.DefaultPassword, ns1)
+	err = hcli.LoginIntoNamespace(dgraphapi.DefaultUser, dgraphapi.DefaultPassword, ns1)
 	require.NoErrorf(t, err, "login as groot into namespace %d failed", ns1)
 	_, err = hcli.CreateUser(user1, user1passwd)
 	require.NoError(t, err)
@@ -309,13 +310,13 @@ func (msuite *MultitenancyTestSuite) TestTwoPermissionSetsInNameSpacesWithAcl() 
 	gcli, cleanup, err = msuite.dc.Client()
 	defer cleanup()
 	require.NoError(t, err)
-	require.NoError(t, gcli.LoginIntoNamespace(context.Background(), dgraphtest.DefaultUser, dgraphtest.DefaultPassword, ns2))
+	require.NoError(t, gcli.LoginIntoNamespace(context.Background(), dgraphapi.DefaultUser, dgraphapi.DefaultPassword, ns2))
 	msuite.AddData(gcli)
 
 	// Create user bob
 	hcli, err = msuite.dc.HTTPClient()
 	require.NoError(t, err)
-	err = hcli.LoginIntoNamespace(dgraphtest.DefaultUser, dgraphtest.DefaultPassword, ns2)
+	err = hcli.LoginIntoNamespace(dgraphapi.DefaultUser, dgraphapi.DefaultPassword, ns2)
 	require.NoErrorf(t, err, "login with namespace %d failed", ns2)
 	_, err = hcli.CreateUser(user2, user2passwd)
 	require.NoError(t, err)
@@ -331,14 +332,14 @@ func (msuite *MultitenancyTestSuite) TestTwoPermissionSetsInNameSpacesWithAcl() 
 	defer cleanup()
 	require.NoError(t, err)
 	require.NoError(t, gcli.LoginIntoNamespace(context.Background(), user1, user1passwd, ns1))
-	dgraphtest.PollTillPassOrTimeout(gcli, query, `{"me": [{"name":"guy2"}, {"name":"guy1"}]}`, aclQueryTimeout)
+	dgraphapi.PollTillPassOrTimeout(gcli, query, `{"me": [{"name":"guy2"}, {"name":"guy1"}]}`, aclQueryTimeout)
 
 	// Query via bob and check result
 	gcli, cleanup, err = msuite.dc.Client()
 	defer cleanup()
 	require.NoError(t, err)
 	require.NoError(t, gcli.LoginIntoNamespace(context.Background(), user2, user2passwd, ns2))
-	require.NoError(t, dgraphtest.PollTillPassOrTimeout(gcli, query, `{}`, aclQueryTimeout))
+	require.NoError(t, dgraphapi.PollTillPassOrTimeout(gcli, query, `{}`, aclQueryTimeout))
 
 	// Query namespace-1 via alice and check result to ensure it still works
 	gcli, cleanup, err = msuite.dc.Client()
@@ -347,22 +348,22 @@ func (msuite *MultitenancyTestSuite) TestTwoPermissionSetsInNameSpacesWithAcl() 
 	require.NoError(t, gcli.LoginIntoNamespace(context.Background(), user1, user1passwd, ns1))
 	resp, err := gcli.Query(query)
 	require.NoError(t, err)
-	require.NoError(t, dgraphtest.CompareJSON(`{"me": [{"name":"guy2"}, {"name":"guy1"}]}`, string(resp.Json)))
+	require.NoError(t, dgraphapi.CompareJSON(`{"me": [{"name":"guy2"}, {"name":"guy1"}]}`, string(resp.Json)))
 
 	// Change permissions in namespace-2
 	hcli, err = msuite.dc.HTTPClient()
 	require.NoError(t, err)
-	err = hcli.LoginIntoNamespace(dgraphtest.DefaultUser, dgraphtest.DefaultPassword, ns2)
+	err = hcli.LoginIntoNamespace(dgraphapi.DefaultUser, dgraphapi.DefaultPassword, ns2)
 	require.NoErrorf(t, err, "login as groot into namespace %d failed", ns2)
 	require.NoError(t, hcli.AddRulesToGroup("dev",
-		[]dgraphtest.AclRule{{Predicate: "name", Permission: acl.Read.Code}}, false))
+		[]dgraphapi.AclRule{{Predicate: "name", Permission: acl.Read.Code}}, false))
 
 	// Query namespace-2
 	gcli, cleanup, err = msuite.dc.Client()
 	defer cleanup()
 	require.NoError(t, err)
 	require.NoError(t, gcli.LoginIntoNamespace(context.Background(), user2, user2passwd, ns2))
-	require.NoError(t, dgraphtest.PollTillPassOrTimeout(gcli, query,
+	require.NoError(t, dgraphapi.PollTillPassOrTimeout(gcli, query,
 		`{"me": [{"name":"guy2", "nickname": "RG2"}, {"name":"guy1", "nickname": "RG"}]}`, aclQueryTimeout))
 
 	// Query namespace-1
@@ -372,7 +373,7 @@ func (msuite *MultitenancyTestSuite) TestTwoPermissionSetsInNameSpacesWithAcl() 
 	require.NoError(t, gcli.LoginIntoNamespace(context.Background(), user1, user1passwd, ns1))
 	resp, err = gcli.Query(query)
 	require.NoError(t, err)
-	require.NoError(t, dgraphtest.CompareJSON(`{"me": [{"name":"guy2"}, {"name":"guy1"}]}`, string(resp.Json)))
+	require.NoError(t, dgraphapi.CompareJSON(`{"me": [{"name":"guy2"}, {"name":"guy1"}]}`, string(resp.Json)))
 }
 
 func (msuite *MultitenancyTestSuite) TestCreateNamespace() {
@@ -381,7 +382,7 @@ func (msuite *MultitenancyTestSuite) TestCreateNamespace() {
 	// Galaxy Login
 	hcli, err := msuite.dc.HTTPClient()
 	require.NoError(t, err)
-	err = hcli.LoginIntoNamespace(dgraphtest.DefaultUser, dgraphtest.DefaultPassword, x.GalaxyNamespace)
+	err = hcli.LoginIntoNamespace(dgraphapi.DefaultUser, dgraphapi.DefaultPassword, x.GalaxyNamespace)
 	require.NotNil(t, hcli.AccessJwt, "Galaxy token is nil")
 	require.NoErrorf(t, err, "login failed")
 
@@ -395,7 +396,7 @@ func (msuite *MultitenancyTestSuite) TestCreateNamespace() {
 	// Log into the namespace as groot
 	hcli, err = msuite.dc.HTTPClient()
 	require.NoError(t, err)
-	err = hcli.LoginIntoNamespace(dgraphtest.DefaultUser, dgraphtest.DefaultPassword, ns)
+	err = hcli.LoginIntoNamespace(dgraphapi.DefaultUser, dgraphapi.DefaultPassword, ns)
 	require.NotNil(t, hcli.AccessJwt, "namespace token is nil")
 	require.NoErrorf(t, err, "login with namespace %d failed", ns)
 
@@ -411,7 +412,7 @@ func (msuite *MultitenancyTestSuite) TestResetPassword() {
 	// Galaxy Login
 	hcli1, err := msuite.dc.HTTPClient()
 	require.NoError(t, err)
-	err = hcli1.LoginIntoNamespace(dgraphtest.DefaultUser, dgraphtest.DefaultPassword, x.GalaxyNamespace)
+	err = hcli1.LoginIntoNamespace(dgraphapi.DefaultUser, dgraphapi.DefaultPassword, x.GalaxyNamespace)
 	require.NotNil(t, hcli1.HttpToken, "Galaxy token is nil")
 	require.NoErrorf(t, err, "login failed")
 
@@ -420,7 +421,7 @@ func (msuite *MultitenancyTestSuite) TestResetPassword() {
 	require.NoError(t, err)
 
 	// Reset Password
-	_, err = hcli1.ResetPassword(dgraphtest.DefaultUser, "newpassword", ns)
+	_, err = hcli1.ResetPassword(dgraphapi.DefaultUser, "newpassword", ns)
 	require.NoError(t, err)
 
 	// Upgrade
@@ -429,14 +430,14 @@ func (msuite *MultitenancyTestSuite) TestResetPassword() {
 	// Try and Fail with old password for groot
 	hcli2, err := msuite.dc.HTTPClient()
 	require.NoError(t, err)
-	err = hcli2.LoginIntoNamespace(dgraphtest.DefaultUser, dgraphtest.DefaultPassword, ns)
+	err = hcli2.LoginIntoNamespace(dgraphapi.DefaultUser, dgraphapi.DefaultPassword, ns)
 	require.Error(t, err, "expected error because incorrect login")
 	require.Empty(t, hcli2.AccessJwt, "nil token because incorrect login")
 
 	// Try and succeed with new password for groot
 	hcli3, err := msuite.dc.HTTPClient()
 	require.NoError(t, err)
-	err = hcli3.LoginIntoNamespace(dgraphtest.DefaultUser, "newpassword", ns)
+	err = hcli3.LoginIntoNamespace(dgraphapi.DefaultUser, "newpassword", ns)
 	require.NoError(t, err, "login failed")
 	require.Equal(t, hcli3.Password, "newpassword", "new password matches the reset password")
 }
@@ -447,15 +448,15 @@ func (msuite *MultitenancyTestSuite) TestDeleteNamespace() {
 	// Galaxy Login
 	hcli, err := msuite.dc.HTTPClient()
 	require.NoError(t, err)
-	err = hcli.LoginIntoNamespace(dgraphtest.DefaultUser, dgraphtest.DefaultPassword, x.GalaxyNamespace)
+	err = hcli.LoginIntoNamespace(dgraphapi.DefaultUser, dgraphapi.DefaultPassword, x.GalaxyNamespace)
 	require.NoErrorf(t, err, "login failed")
 
-	dg := make(map[uint64]*dgraphtest.GrpcClient)
+	dg := make(map[uint64]*dgraphapi.GrpcClient)
 	gcli, cleanup, e := msuite.dc.Client()
 	defer cleanup()
 	require.NoError(t, e)
 	require.NoError(t, gcli.LoginIntoNamespace(context.Background(),
-		dgraphtest.DefaultUser, dgraphtest.DefaultPassword, x.GalaxyNamespace))
+		dgraphapi.DefaultUser, dgraphapi.DefaultPassword, x.GalaxyNamespace))
 	dg[x.GalaxyNamespace] = gcli
 
 	// Create a new namespace
@@ -467,7 +468,7 @@ func (msuite *MultitenancyTestSuite) TestDeleteNamespace() {
 	defer cleanup()
 	require.NoError(t, err)
 	require.NoError(t, gcli.LoginIntoNamespace(context.Background(),
-		dgraphtest.DefaultUser, dgraphtest.DefaultPassword, ns))
+		dgraphapi.DefaultUser, dgraphapi.DefaultPassword, ns))
 	dg[ns] = gcli
 
 	addData := func(ns uint64) error {
@@ -490,7 +491,7 @@ func (msuite *MultitenancyTestSuite) TestDeleteNamespace() {
 	`
 		resp, err := dg[ns].Query(query)
 		require.NoError(t, err)
-		require.NoError(t, dgraphtest.CompareJSON(expected, string(resp.Json)))
+		require.NoError(t, dgraphapi.CompareJSON(expected, string(resp.Json)))
 	}
 
 	require.NoError(t, addData(x.GalaxyNamespace))
@@ -501,13 +502,13 @@ func (msuite *MultitenancyTestSuite) TestDeleteNamespace() {
 
 	// Upgrade
 	msuite.Upgrade()
-	dg = make(map[uint64]*dgraphtest.GrpcClient)
+	dg = make(map[uint64]*dgraphapi.GrpcClient)
 
 	gcli, cleanup, err = msuite.dc.Client()
 	defer cleanup()
 	require.NoError(t, err)
 	require.NoError(t, gcli.LoginIntoNamespace(context.Background(),
-		dgraphtest.DefaultUser, dgraphtest.DefaultPassword, x.GalaxyNamespace))
+		dgraphapi.DefaultUser, dgraphapi.DefaultPassword, x.GalaxyNamespace))
 	dg[x.GalaxyNamespace] = gcli
 
 	// Log into namespace as groot
@@ -515,13 +516,13 @@ func (msuite *MultitenancyTestSuite) TestDeleteNamespace() {
 	defer cleanup()
 	require.NoError(t, err)
 	require.NoError(t, gcli.LoginIntoNamespace(context.Background(),
-		dgraphtest.DefaultUser, dgraphtest.DefaultPassword, ns))
+		dgraphapi.DefaultUser, dgraphapi.DefaultPassword, ns))
 	dg[ns] = gcli
 
 	// Galaxy Login
 	hcli, err = msuite.dc.HTTPClient()
 	require.NoError(t, err)
-	err = hcli.LoginIntoNamespace(dgraphtest.DefaultUser, dgraphtest.DefaultPassword, x.GalaxyNamespace)
+	err = hcli.LoginIntoNamespace(dgraphapi.DefaultUser, dgraphapi.DefaultPassword, x.GalaxyNamespace)
 	require.NoError(t, err, "login failed")
 
 	// Delete namespace
@@ -554,7 +555,7 @@ func (msuite *MultitenancyTestSuite) TestDeleteNamespace() {
 	}
 }
 
-func (msuite *MultitenancyTestSuite) AddData(gcli *dgraphtest.GrpcClient) {
+func (msuite *MultitenancyTestSuite) AddData(gcli *dgraphapi.GrpcClient) {
 	rdfs := `
 		_:a <name> "guy1" .
 		_:a <nickname> "RG" .
@@ -566,7 +567,7 @@ func (msuite *MultitenancyTestSuite) AddData(gcli *dgraphtest.GrpcClient) {
 	require.NoError(msuite.T(), err)
 }
 
-func AddNumberOfTriples(gcli *dgraphtest.GrpcClient, start, end int) (*api.Response, error) {
+func AddNumberOfTriples(gcli *dgraphapi.GrpcClient, start, end int) (*api.Response, error) {
 	triples := strings.Builder{}
 	for i := start; i <= end; i++ {
 		triples.WriteString(fmt.Sprintf("_:person%[1]v <name> \"person%[1]v\" .\n", i))
@@ -579,12 +580,12 @@ func (msuite *MultitenancyTestSuite) createGroupAndSetPermissions(namespace uint
 	t := msuite.T()
 	hcli, err := msuite.dc.HTTPClient()
 	require.NoError(t, err)
-	require.NoError(t, hcli.LoginIntoNamespace(dgraphtest.DefaultUser, dgraphtest.DefaultPassword, namespace))
+	require.NoError(t, hcli.LoginIntoNamespace(dgraphapi.DefaultUser, dgraphapi.DefaultPassword, namespace))
 	require.NotNil(t, hcli.AccessJwt, "namespace token is nil")
 	require.NoErrorf(t, err, "login as groot into namespace %d failed", namespace)
 	_, err = hcli.CreateGroup(group)
 	require.NoError(t, err)
 	require.NoError(t, hcli.AddUserToGroup(user, group))
 	require.NoError(t, hcli.AddRulesToGroup(group,
-		[]dgraphtest.AclRule{{Predicate: predicate, Permission: acl.Read.Code}}, true))
+		[]dgraphapi.AclRule{{Predicate: predicate, Permission: acl.Read.Code}}, true))
 }

--- a/systest/multi-tenancy/integration_basic_helper_test.go
+++ b/systest/multi-tenancy/integration_basic_helper_test.go
@@ -27,7 +27,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/dgraph-io/dgraph/dgraphtest"
+	"github.com/dgraph-io/dgraph/dgraphapi"
 	"github.com/dgraph-io/dgraph/testutil"
 	"github.com/dgraph-io/dgraph/x"
 )
@@ -67,11 +67,11 @@ func (msuite *MultitenancyTestSuite) TestLiveLoadMulti() {
 	defer cleanup()
 	require.NoError(t, err)
 	require.NoError(t, gcli0.LoginIntoNamespace(context.Background(),
-		dgraphtest.DefaultUser, dgraphtest.DefaultPassword, x.GalaxyNamespace))
+		dgraphapi.DefaultUser, dgraphapi.DefaultPassword, x.GalaxyNamespace))
 
 	hcli, err := msuite.dc.HTTPClient()
 	require.NoError(t, err)
-	err = hcli.LoginIntoNamespace(dgraphtest.DefaultUser, dgraphtest.DefaultPassword, x.GalaxyNamespace)
+	err = hcli.LoginIntoNamespace(dgraphapi.DefaultUser, dgraphapi.DefaultPassword, x.GalaxyNamespace)
 	require.NoError(t, err, "login failed")
 
 	// Create a new namespace
@@ -81,11 +81,11 @@ func (msuite *MultitenancyTestSuite) TestLiveLoadMulti() {
 	defer cleanup()
 	require.NoError(t, err)
 	require.NoError(t, gcli1.LoginIntoNamespace(context.Background(),
-		dgraphtest.DefaultUser, dgraphtest.DefaultPassword, ns))
+		dgraphapi.DefaultUser, dgraphapi.DefaultPassword, ns))
 
 	// Load data.
-	galaxyCreds := &testutil.LoginParams{UserID: dgraphtest.DefaultUser,
-		Passwd: dgraphtest.DefaultPassword, Namespace: x.GalaxyNamespace}
+	galaxyCreds := &testutil.LoginParams{UserID: dgraphapi.DefaultUser,
+		Passwd: dgraphapi.DefaultPassword, Namespace: x.GalaxyNamespace}
 	require.NoError(t, msuite.liveLoadData(&liveOpts{
 		rdfs: fmt.Sprintf(`
 		_:a <name> "galaxy alice" .
@@ -184,7 +184,7 @@ func (msuite *MultitenancyTestSuite) TestLiveLoadMulti() {
 	err = msuite.liveLoadData(&liveOpts{
 		rdfs:    `_:c <name> "ns hola" .`,
 		schema:  `name: string @index(term) .`,
-		creds:   &testutil.LoginParams{UserID: dgraphtest.DefaultUser, Passwd: dgraphtest.DefaultPassword, Namespace: ns},
+		creds:   &testutil.LoginParams{UserID: dgraphapi.DefaultUser, Passwd: dgraphapi.DefaultPassword, Namespace: ns},
 		forceNs: -1,
 	})
 	require.Error(t, err)
@@ -193,7 +193,7 @@ func (msuite *MultitenancyTestSuite) TestLiveLoadMulti() {
 	err = msuite.liveLoadData(&liveOpts{
 		rdfs:    `_:c <name> "ns hola" .`,
 		schema:  `name: string @index(term) .`,
-		creds:   &testutil.LoginParams{UserID: dgraphtest.DefaultUser, Passwd: dgraphtest.DefaultPassword, Namespace: ns},
+		creds:   &testutil.LoginParams{UserID: dgraphapi.DefaultUser, Passwd: dgraphapi.DefaultPassword, Namespace: ns},
 		forceNs: 10,
 	})
 	require.Error(t, err)
@@ -205,7 +205,7 @@ func (msuite *MultitenancyTestSuite) TestLiveLoadMulti() {
 			_:b <name> "ns gary" <%#x> .
 			_:c <name> "ns hola" <%#x> .`, ns, 0x100),
 		schema: `name: string @index(term) .`,
-		creds:  &testutil.LoginParams{UserID: dgraphtest.DefaultUser, Passwd: dgraphtest.DefaultPassword, Namespace: ns},
+		creds:  &testutil.LoginParams{UserID: dgraphapi.DefaultUser, Passwd: dgraphapi.DefaultPassword, Namespace: ns},
 	}))
 
 	resp, err = gcli1.Query(query3)

--- a/systest/multi-tenancy/integration_test.go
+++ b/systest/multi-tenancy/integration_test.go
@@ -26,13 +26,14 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/dgraph-io/dgo/v230/protos/api"
+	"github.com/dgraph-io/dgraph/dgraphapi"
 	"github.com/dgraph-io/dgraph/dgraphtest"
 	"github.com/dgraph-io/dgraph/x"
 )
 
 type MultitenancyTestSuite struct {
 	suite.Suite
-	dc dgraphtest.Cluster
+	dc dgraphapi.Cluster
 }
 
 func (msuite *MultitenancyTestSuite) SetupTest() {
@@ -45,7 +46,7 @@ func (msuite *MultitenancyTestSuite) TearDownTest() {
 	defer cleanup()
 	require.NoError(t, err)
 	require.NoError(t, gcli.LoginIntoNamespace(context.Background(),
-		dgraphtest.DefaultUser, dgraphtest.DefaultPassword, x.GalaxyNamespace))
+		dgraphapi.DefaultUser, dgraphapi.DefaultPassword, x.GalaxyNamespace))
 	require.NoError(t, gcli.Alter(context.Background(), &api.Operation{DropAll: true}))
 }
 

--- a/systest/multi-tenancy/upgrade_test.go
+++ b/systest/multi-tenancy/upgrade_test.go
@@ -26,13 +26,14 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
+	"github.com/dgraph-io/dgraph/dgraphapi"
 	"github.com/dgraph-io/dgraph/dgraphtest"
 	"github.com/dgraph-io/dgraph/x"
 )
 
 type MultitenancyTestSuite struct {
 	suite.Suite
-	dc dgraphtest.Cluster
+	dc dgraphapi.Cluster
 	lc *dgraphtest.LocalCluster
 	uc dgraphtest.UpgradeCombo
 }

--- a/systest/mutations-and-queries/integration_test.go
+++ b/systest/mutations-and-queries/integration_test.go
@@ -24,12 +24,13 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
+	"github.com/dgraph-io/dgraph/dgraphapi"
 	"github.com/dgraph-io/dgraph/dgraphtest"
 )
 
 type SystestTestSuite struct {
 	suite.Suite
-	dc dgraphtest.Cluster
+	dc dgraphapi.Cluster
 }
 
 func (ssuite *SystestTestSuite) SetupTest() {

--- a/systest/mutations-and-queries/mutations_test.go
+++ b/systest/mutations-and-queries/mutations_test.go
@@ -36,6 +36,7 @@ import (
 
 	"github.com/dgraph-io/dgo/v230"
 	"github.com/dgraph-io/dgo/v230/protos/api"
+	"github.com/dgraph-io/dgraph/dgraphapi"
 	"github.com/dgraph-io/dgraph/dgraphtest"
 	"github.com/dgraph-io/dgraph/testutil"
 )
@@ -162,7 +163,7 @@ func (ssuite *SystestTestSuite) FacetJsonInputSupportsAnyOfTerms() {
 	require.NoError(t, err, "the query should have succeeded")
 
 	//var respUser User
-	dgraphtest.CompareJSON(fmt.Sprintf(`
+	dgraphapi.CompareJSON(fmt.Sprintf(`
 	{
 		"direct":[
 			{
@@ -246,7 +247,7 @@ func (ssuite *SystestTestSuite) NQuadMutationTest() {
 	txn = gcli.NewTxn()
 	resp, err := txn.Query(ctx, breakfastQuery)
 	require.NoError(t, err)
-	dgraphtest.CompareJSON(`{ "q": [ {
+	dgraphapi.CompareJSON(`{ "q": [ {
 		"fruit": [
 			{ "xid": "apple" },
 			{ "xid": "banana" }
@@ -275,7 +276,7 @@ func (ssuite *SystestTestSuite) NQuadMutationTest() {
 	txn = gcli.NewTxn()
 	resp, err = txn.Query(ctx, breakfastQuery)
 	require.NoError(t, err)
-	dgraphtest.CompareJSON(`{ "q": [ {
+	dgraphapi.CompareJSON(`{ "q": [ {
 		"fruit": [
 			{ "xid": "apple" }
 		]
@@ -328,7 +329,7 @@ func (ssuite *SystestTestSuite) DeleteAllReverseIndex() {
 	ctx = context.Background()
 	resp, err := gcli.NewTxn().Query(ctx, fmt.Sprintf("{ q(func: uid(%s)) { ~link { uid } }}", bId))
 	require.NoError(t, err)
-	dgraphtest.CompareJSON(`{"q":[]}`, string(resp.Json))
+	dgraphapi.CompareJSON(`{"q":[]}`, string(resp.Json))
 
 	assignedIds, err = gcli.NewTxn().Mutate(ctx, &api.Mutation{
 		CommitNow: true,
@@ -339,7 +340,7 @@ func (ssuite *SystestTestSuite) DeleteAllReverseIndex() {
 
 	resp, err = gcli.NewTxn().Query(ctx, fmt.Sprintf("{ q(func: uid(%s)) { ~link { uid } }}", cId))
 	require.NoError(t, err)
-	dgraphtest.CompareJSON(fmt.Sprintf(`{"q":[{"~link": [{"uid": "%s"}]}]}`, aId), string(resp.Json))
+	dgraphapi.CompareJSON(fmt.Sprintf(`{"q":[{"~link": [{"uid": "%s"}]}]}`, aId), string(resp.Json))
 }
 
 func (ssuite *SystestTestSuite) NormalizeEdgeCasesTest() {
@@ -478,7 +479,7 @@ func (ssuite *SystestTestSuite) FacetOrderTest() {
 	ctx = context.Background()
 	resp, err := txn.Query(ctx, friendQuery)
 	require.NoError(t, err)
-	dgraphtest.CompareJSON(`
+	dgraphapi.CompareJSON(`
 	{
 		"q":[
 			{
@@ -1188,7 +1189,7 @@ func (ssuite *SystestTestSuite) DeleteWithExpandAll() {
 	require.Equal(t, 0, len(r.Me))
 }
 
-func testTimeValue(t *testing.T, c *dgraphtest.GrpcClient, timeBytes []byte) {
+func testTimeValue(t *testing.T, c *dgraphapi.GrpcClient, timeBytes []byte) {
 	nquads := []*api.NQuad{
 		{
 			Subject:   "0x01",
@@ -1264,7 +1265,7 @@ func (ssuite *SystestTestSuite) SkipEmptyPLForHas() {
 		}`
 	resp, err := gcli.NewTxn().Query(ctx, q)
 	require.NoError(t, err)
-	dgraphtest.CompareJSON(`{"users":[{"name":"u"},{"name":"u1"}]}`, string(resp.Json))
+	dgraphapi.CompareJSON(`{"users":[{"name":"u"},{"name":"u1"}]}`, string(resp.Json))
 
 	op := &api.Operation{DropAll: true}
 	require.NoError(t, gcli.Alter(ctx, op))
@@ -1331,7 +1332,7 @@ func (ssuite *SystestTestSuite) HasWithDash() {
 	txn = gcli.NewTxn()
 	resp, err := txn.Query(ctx, friendQuery)
 	require.NoError(t, err)
-	dgraphtest.CompareJSON(`{"q":[{"new-friend":[{"name":"Bob"},{"name":"Charlie"}]}]}`, string(resp.Json))
+	dgraphapi.CompareJSON(`{"q":[{"new-friend":[{"name":"Bob"},{"name":"Charlie"}]}]}`, string(resp.Json))
 }
 
 func (ssuite *SystestTestSuite) ListGeoFilterTest() {
@@ -1378,7 +1379,7 @@ func (ssuite *SystestTestSuite) ListGeoFilterTest() {
 		}
 	}`)
 	require.NoError(t, err)
-	dgraphtest.CompareJSON(`
+	dgraphapi.CompareJSON(`
 	{
 		"q": [
 			{
@@ -1436,7 +1437,7 @@ func (ssuite *SystestTestSuite) ListRegexFilterTest() {
 		}
 	}`)
 	require.NoError(t, err)
-	dgraphtest.CompareJSON(`
+	dgraphapi.CompareJSON(`
 	{
 		"q": [
 			{
@@ -1485,7 +1486,7 @@ func (ssuite *SystestTestSuite) RegexQueryWithVarsWithSlash() {
 		}
 	}`)
 	require.NoError(t, err)
-	dgraphtest.CompareJSON(`
+	dgraphapi.CompareJSON(`
 	{
 		"q": [
 			{
@@ -1503,7 +1504,7 @@ func (ssuite *SystestTestSuite) RegexQueryWithVarsWithSlash() {
 		}
 	}`, map[string]string{"$rex": "/\\/def/"})
 	require.NoError(t, err)
-	dgraphtest.CompareJSON(`
+	dgraphapi.CompareJSON(`
 	{
 		"q": [
 			{
@@ -1559,7 +1560,7 @@ func (ssuite *SystestTestSuite) RegexQueryWithVars() {
 			}
 		}`, map[string]string{"$term": "/^rea.*$/"})
 	require.NoError(t, err)
-	dgraphtest.CompareJSON(`
+	dgraphapi.CompareJSON(`
 	{
 		"q": [
 			{
@@ -1616,7 +1617,7 @@ func (ssuite *SystestTestSuite) GraphQLVarChild() {
 		}
 	}`, map[string]string{"$alice": a})
 	require.NoError(t, err)
-	dgraphtest.CompareJSON(`
+	dgraphapi.CompareJSON(`
 	{
 		"q": [
 			{
@@ -1637,7 +1638,7 @@ func (ssuite *SystestTestSuite) GraphQLVarChild() {
 		}
 	}`, map[string]string{"$bob": b})
 	require.NoError(t, err)
-	dgraphtest.CompareJSON(`
+	dgraphapi.CompareJSON(`
 	{
 		"q": [
 			{
@@ -1664,7 +1665,7 @@ func (ssuite *SystestTestSuite) GraphQLVarChild() {
 		}
 	}`, map[string]string{"$friends": friends})
 	require.NoError(t, err)
-	dgraphtest.CompareJSON(`
+	dgraphapi.CompareJSON(`
 	{
 		"q": [
 			{
@@ -1721,7 +1722,7 @@ func (ssuite *SystestTestSuite) MathGe() {
 		}
 	}`)
 	require.NoError(t, err)
-	dgraphtest.CompareJSON(`
+	dgraphapi.CompareJSON(`
 		{
 		  "q": [
 		    {
@@ -1958,7 +1959,7 @@ func (ssuite *SystestTestSuite) RestoreReservedPreds() {
 	query := `schema(preds: dgraph.type) {predicate}`
 	resp, err := gcli.NewReadOnlyTxn().Query(ctx, query)
 	require.NoError(t, err)
-	dgraphtest.CompareJSON(`{"schema": [{"predicate":"dgraph.type"}]}`, string(resp.Json))
+	dgraphapi.CompareJSON(`{"schema": [{"predicate":"dgraph.type"}]}`, string(resp.Json))
 }
 
 func (ssuite *SystestTestSuite) DropData() {
@@ -2005,7 +2006,7 @@ func (ssuite *SystestTestSuite) DropData() {
 	query := `schema(preds: [name, follow]) {predicate}`
 	resp, err := gcli.NewReadOnlyTxn().Query(ctx, query)
 	require.NoError(t, err)
-	dgraphtest.CompareJSON(`{"schema": [{"predicate":"name"}, {"predicate":"follow"}]}`, string(resp.Json))
+	dgraphapi.CompareJSON(`{"schema": [{"predicate":"name"}, {"predicate":"follow"}]}`, string(resp.Json))
 
 	// Check data is gone.
 	resp, err = gcli.NewTxn().Query(ctx, `{
@@ -2015,7 +2016,7 @@ func (ssuite *SystestTestSuite) DropData() {
 		}
 	}`)
 	require.NoError(t, err)
-	dgraphtest.CompareJSON(`{"q": []}`, string(resp.GetJson()))
+	dgraphapi.CompareJSON(`{"q": []}`, string(resp.GetJson()))
 }
 
 func (ssuite *SystestTestSuite) DropDataAndDropAll() {
@@ -2061,7 +2062,7 @@ func (ssuite *SystestTestSuite) DropType() {
 	query := `schema(type: Person) {}`
 	resp, err := gcli.NewReadOnlyTxn().Query(ctx, query)
 	require.NoError(t, err)
-	dgraphtest.CompareJSON(`{"types":[{"name":"Person", "fields":[{"name":"name"}]}]}`,
+	dgraphapi.CompareJSON(`{"types":[{"name":"Person", "fields":[{"name":"name"}]}]}`,
 		string(resp.Json))
 
 	require.NoError(t, gcli.Alter(ctx, &api.Operation{
@@ -2072,7 +2073,7 @@ func (ssuite *SystestTestSuite) DropType() {
 	// Check type is gone.
 	resp, err = gcli.NewReadOnlyTxn().Query(ctx, query)
 	require.NoError(t, err)
-	dgraphtest.CompareJSON("{}", string(resp.Json))
+	dgraphapi.CompareJSON("{}", string(resp.Json))
 }
 
 func (ssuite *SystestTestSuite) DropTypeNoValue() {
@@ -2111,7 +2112,7 @@ func (ssuite *SystestTestSuite) CountIndexConcurrentSetDelUIDList() {
 	var wg sync.WaitGroup
 	wg.Add(numRoutines)
 	for i := 0; i < numRoutines; i++ {
-		go func(dg *dgraphtest.GrpcClient, wg *sync.WaitGroup) {
+		go func(dg *dgraphapi.GrpcClient, wg *sync.WaitGroup) {
 			defer wg.Done()
 			for {
 				if atomic.AddUint64(&txnCur, 1) > txnTotal {
@@ -2146,7 +2147,7 @@ func (ssuite *SystestTestSuite) CountIndexConcurrentSetDelUIDList() {
 	}`, len(insertedMap))
 	resp, err := gcli.NewReadOnlyTxn().Query(ctx, q)
 	require.NoError(t, err, "the query should have succeeded")
-	dgraphtest.CompareJSON(`{"me":[{"uid": "0x1"}]}`, string(resp.GetJson()))
+	dgraphapi.CompareJSON(`{"me":[{"uid": "0x1"}]}`, string(resp.GetJson()))
 
 	// Now start deleting UIDs.
 	var insertedUids []int
@@ -2162,7 +2163,7 @@ func (ssuite *SystestTestSuite) CountIndexConcurrentSetDelUIDList() {
 
 	wg.Add(numRoutines)
 	for i := 0; i < numRoutines; i++ {
-		go func(dg *dgraphtest.GrpcClient, wg *sync.WaitGroup) {
+		go func(dg *dgraphapi.GrpcClient, wg *sync.WaitGroup) {
 			defer wg.Done()
 			for {
 				if atomic.AddUint64(&txnCur, 1) > txnTotal {
@@ -2197,7 +2198,7 @@ func (ssuite *SystestTestSuite) CountIndexConcurrentSetDelUIDList() {
 	}`, insertedCount-len(deletedMap))
 	resp, err = gcli.NewReadOnlyTxn().Query(ctx, q)
 	require.NoError(t, err, "the query should have succeeded")
-	dgraphtest.CompareJSON(`{"me":[{"uid": "0x1"}]}`, string(resp.GetJson()))
+	dgraphapi.CompareJSON(`{"me":[{"uid": "0x1"}]}`, string(resp.GetJson()))
 
 	// Delete all friends now.
 	mu := &api.Mutation{
@@ -2216,7 +2217,7 @@ func (ssuite *SystestTestSuite) CountIndexConcurrentSetDelUIDList() {
 	ctx = context.Background()
 	resp, err = gcli.NewReadOnlyTxn().Query(ctx, q)
 	require.NoError(t, err, "the query should have succeeded")
-	dgraphtest.CompareJSON(`{"me":[]}`, string(resp.GetJson()))
+	dgraphapi.CompareJSON(`{"me":[]}`, string(resp.GetJson()))
 }
 
 func (ssuite *SystestTestSuite) CountIndexConcurrentSetDelScalarPredicate() {
@@ -2238,7 +2239,7 @@ func (ssuite *SystestTestSuite) CountIndexConcurrentSetDelScalarPredicate() {
 	var wg sync.WaitGroup
 	wg.Add(numRoutines)
 	for i := 0; i < numRoutines; i++ {
-		go func(dg *dgraphtest.GrpcClient, wg *sync.WaitGroup) {
+		go func(dg *dgraphapi.GrpcClient, wg *sync.WaitGroup) {
 			defer wg.Done()
 			for {
 				if atomic.AddUint64(&txnCur, 1) > txnTotal {
@@ -2293,7 +2294,7 @@ func (ssuite *SystestTestSuite) CountIndexConcurrentSetDelScalarPredicate() {
 	ctx = context.Background()
 	resp, err = gcli.NewReadOnlyTxn().Query(ctx, q)
 	require.NoError(t, err, "the query should have succeeded")
-	dgraphtest.CompareJSON(`{"q":[]}`, string(resp.GetJson()))
+	dgraphapi.CompareJSON(`{"q":[]}`, string(resp.GetJson()))
 }
 
 func (ssuite *SystestTestSuite) CountIndexNonlistPredicateDelete() {
@@ -2324,7 +2325,7 @@ func (ssuite *SystestTestSuite) CountIndexNonlistPredicateDelete() {
 	}`
 	resp, err := gcli.NewReadOnlyTxn().Query(ctx, q)
 	require.NoError(t, err, "the query should have succeeded")
-	dgraphtest.CompareJSON(`{"q": [{"uid": "0x1"}]}`, string(resp.GetJson()))
+	dgraphapi.CompareJSON(`{"q": [{"uid": "0x1"}]}`, string(resp.GetJson()))
 
 	// Upgrade
 	ssuite.Upgrade()
@@ -2345,7 +2346,7 @@ func (ssuite *SystestTestSuite) CountIndexNonlistPredicateDelete() {
 	// Query it using count index.
 	resp, err = gcli.NewReadOnlyTxn().Query(ctx, q)
 	require.NoError(t, err, "the query should have succeeded")
-	dgraphtest.CompareJSON(`{"q": [{"uid": "0x1"}]}`, string(resp.GetJson()))
+	dgraphapi.CompareJSON(`{"q": [{"uid": "0x1"}]}`, string(resp.GetJson()))
 }
 
 func (ssuite *SystestTestSuite) ReverseCountIndexDelete() {
@@ -2375,7 +2376,7 @@ func (ssuite *SystestTestSuite) ReverseCountIndexDelete() {
 	}`
 	resp, err := gcli.NewReadOnlyTxn().Query(ctx, q)
 	require.NoError(t, err, "the query should have succeeded")
-	dgraphtest.CompareJSON(`{"me":[{"uid": "0x2"}, {"uid": "0x3"}]}`, string(resp.GetJson()))
+	dgraphapi.CompareJSON(`{"me":[{"uid": "0x2"}, {"uid": "0x3"}]}`, string(resp.GetJson()))
 
 	// Upgrade
 	ssuite.Upgrade()
@@ -2394,7 +2395,7 @@ func (ssuite *SystestTestSuite) ReverseCountIndexDelete() {
 
 	resp, err = gcli.NewReadOnlyTxn().Query(ctx, q)
 	require.NoError(t, err, "the query should have succeeded")
-	dgraphtest.CompareJSON(`{"me":[{"uid": "0x3"}]}`, string(resp.GetJson()))
+	dgraphapi.CompareJSON(`{"me":[{"uid": "0x3"}]}`, string(resp.GetJson()))
 
 }
 
@@ -2428,7 +2429,7 @@ func (ssuite *SystestTestSuite) ReverseCountIndex() {
 	var wg sync.WaitGroup
 	wg.Add(numRoutines)
 	for i := 0; i < numRoutines; i++ {
-		go func(dg *dgraphtest.GrpcClient, id string, wg *sync.WaitGroup) {
+		go func(dg *dgraphapi.GrpcClient, id string, wg *sync.WaitGroup) {
 			defer wg.Done()
 			mu := &api.Mutation{
 				CommitNow: true,
@@ -2461,7 +2462,7 @@ func (ssuite *SystestTestSuite) ReverseCountIndex() {
 	ctx = context.Background()
 	resp, err := gcli.NewReadOnlyTxn().Query(ctx, q)
 	require.NoError(t, err, "the query should have succeeded")
-	dgraphtest.CompareJSON(`{"me":[{"name":"Alice","count(~friend)":10}]}`, string(resp.GetJson()))
+	dgraphapi.CompareJSON(`{"me":[{"name":"Alice","count(~friend)":10}]}`, string(resp.GetJson()))
 }
 
 func (ssuite *SystestTestSuite) TypePredicateCheck() {
@@ -2566,7 +2567,7 @@ func (ssuite *SystestTestSuite) InferSchemaAsList() {
 	require.NoError(t, err)
 	resp, err := gcli.NewReadOnlyTxn().Query(context.Background(), query)
 	require.NoError(t, err)
-	dgraphtest.CompareJSON(`{"schema": [{"predicate":"name", "list":true},
+	dgraphapi.CompareJSON(`{"schema": [{"predicate":"name", "list":true},
 		{"predicate":"nickname"}]}`, string(resp.Json))
 }
 
@@ -2594,7 +2595,7 @@ func (ssuite *SystestTestSuite) InferSchemaAsListJSON() {
 	require.NoError(t, err)
 	resp, err := gcli.NewReadOnlyTxn().Query(context.Background(), query)
 	require.NoError(t, err)
-	dgraphtest.CompareJSON(`{"schema": [{"predicate":"name", "list":true},
+	dgraphapi.CompareJSON(`{"schema": [{"predicate":"name", "list":true},
 		{"predicate":"nickname"}]}`, string(resp.Json))
 }
 
@@ -2623,7 +2624,7 @@ func (ssuite *SystestTestSuite) ForceSchemaAsListJSON() {
 	require.NoError(t, err)
 	resp, err := gcli.NewReadOnlyTxn().Query(context.Background(), query)
 	require.NoError(t, err)
-	dgraphtest.CompareJSON(`{"schema": [{"predicate":"name", "list":true},
+	dgraphapi.CompareJSON(`{"schema": [{"predicate":"name", "list":true},
 		{"predicate":"nickname"}]}`, string(resp.Json))
 }
 
@@ -2652,7 +2653,7 @@ func (ssuite *SystestTestSuite) ForceSchemaAsSingleJSON() {
 	require.NoError(t, err)
 	resp, err := gcli.NewReadOnlyTxn().Query(context.Background(), query)
 	require.NoError(t, err)
-	dgraphtest.CompareJSON(`{"schema": [{"predicate":"person"}, {"predicate":"nickname"}]}`,
+	dgraphapi.CompareJSON(`{"schema": [{"predicate":"person"}, {"predicate":"nickname"}]}`,
 		string(resp.Json))
 }
 
@@ -2692,7 +2693,7 @@ func (ssuite *SystestTestSuite) OverwriteUidPredicates() {
 }`
 	resp, err := gcli.NewReadOnlyTxn().Query(ctx, q)
 	require.NoError(t, err)
-	dgraphtest.CompareJSON(`{"me":[{"name":"Alice","best_friend": {"name": "Bob"}}]}`,
+	dgraphapi.CompareJSON(`{"me":[{"name":"Alice","best_friend": {"name": "Bob"}}]}`,
 		string(resp.GetJson()))
 
 	upsertQuery := `query { alice as var(func: eq(name, Alice)) }`
@@ -2717,7 +2718,7 @@ func (ssuite *SystestTestSuite) OverwriteUidPredicates() {
 	require.NoError(t, err)
 	resp, err = gcli.NewReadOnlyTxn().Query(context.Background(), q)
 	require.NoError(t, err)
-	dgraphtest.CompareJSON(`{"me":[{"name":"Alice","best_friend": {"name": "Carol"}}]}`,
+	dgraphapi.CompareJSON(`{"me":[{"name":"Alice","best_friend": {"name": "Carol"}}]}`,
 		string(resp.GetJson()))
 }
 
@@ -2757,7 +2758,7 @@ func (ssuite *SystestTestSuite) OverwriteUidPredicatesReverse() {
 }`
 	resp, err := gcli.NewReadOnlyTxn().Query(ctx, q)
 	require.NoError(t, err)
-	dgraphtest.CompareJSON(`{"me":[{"name":"Alice","best_friend": {"name": "Bob"}}]}`,
+	dgraphapi.CompareJSON(`{"me":[{"name":"Alice","best_friend": {"name": "Bob"}}]}`,
 		string(resp.GetJson()))
 
 	reverseQuery := `{
@@ -2769,7 +2770,7 @@ func (ssuite *SystestTestSuite) OverwriteUidPredicatesReverse() {
 		}}`
 	resp, err = gcli.NewReadOnlyTxn().Query(ctx, reverseQuery)
 	require.NoError(t, err)
-	dgraphtest.CompareJSON(`{"reverse":[{"name":"Bob","~best_friend": [{"name": "Alice"}]}]}`,
+	dgraphapi.CompareJSON(`{"reverse":[{"name":"Bob","~best_friend": [{"name": "Alice"}]}]}`,
 		string(resp.GetJson()))
 
 	upsertQuery := `query { alice as var(func: eq(name, Alice)) }`
@@ -2788,7 +2789,7 @@ func (ssuite *SystestTestSuite) OverwriteUidPredicatesReverse() {
 
 	resp, err = gcli.NewReadOnlyTxn().Query(ctx, reverseQuery)
 	require.NoError(t, err)
-	dgraphtest.CompareJSON(`{"reverse":[{"name":"Carol","~best_friend": [{"name": "Alice"}]}]}`,
+	dgraphapi.CompareJSON(`{"reverse":[{"name":"Carol","~best_friend": [{"name": "Alice"}]}]}`,
 		string(resp.GetJson()))
 
 	// Delete the triples and verify the reverse edge is gone.
@@ -2816,12 +2817,12 @@ func (ssuite *SystestTestSuite) OverwriteUidPredicatesReverse() {
 	ctx = context.Background()
 	resp, err = gcli.NewReadOnlyTxn().Query(ctx, reverseQuery)
 	require.NoError(t, err)
-	dgraphtest.CompareJSON(`{"reverse":[]}`,
+	dgraphapi.CompareJSON(`{"reverse":[]}`,
 		string(resp.GetJson()))
 
 	resp, err = gcli.NewReadOnlyTxn().Query(ctx, q)
 	require.NoError(t, err)
-	dgraphtest.CompareJSON(`{"me":[{"name":"Alice"}]}`,
+	dgraphapi.CompareJSON(`{"me":[{"name":"Alice"}]}`,
 		string(resp.GetJson()))
 }
 
@@ -2883,7 +2884,7 @@ func (ssuite *SystestTestSuite) OverwriteUidPredicatesMultipleTxn() {
 	require.NoError(t, err)
 	resp, err = gcli.NewReadOnlyTxn().Query(context.Background(), query)
 	require.NoError(t, err)
-	dgraphtest.CompareJSON(`{"me":[{"name":"Alice","best_friend": {"name": "Carl"}}]}`,
+	dgraphapi.CompareJSON(`{"me":[{"name":"Alice","best_friend": {"name": "Carl"}}]}`,
 		string(resp.GetJson()))
 }
 
@@ -2927,7 +2928,7 @@ func (ssuite *SystestTestSuite) DeleteAndQuerySameTxn() {
 	q := `{ me(func: has(name)) { name } }`
 	resp, err := txn2.Query(ctx, q)
 	require.NoError(t, err)
-	dgraphtest.CompareJSON(`{"me":[{"name":"Alice"}]}`,
+	dgraphapi.CompareJSON(`{"me":[{"name":"Alice"}]}`,
 		string(resp.GetJson()))
 	require.NoError(t, txn2.Commit(ctx))
 
@@ -2940,7 +2941,7 @@ func (ssuite *SystestTestSuite) DeleteAndQuerySameTxn() {
 	// Verify that changes are reflected after the transaction is committed.
 	resp, err = gcli.NewReadOnlyTxn().Query(context.Background(), q)
 	require.NoError(t, err)
-	dgraphtest.CompareJSON(`{"me":[{"name":"Alice"}]}`,
+	dgraphapi.CompareJSON(`{"me":[{"name":"Alice"}]}`,
 		string(resp.GetJson()))
 }
 
@@ -2980,7 +2981,7 @@ func (ssuite *SystestTestSuite) AddAndQueryZeroTimeValue() {
 	txn = gcli.NewTxn()
 	resp, err := txn.Query(ctx, datetimeQuery)
 	require.NoError(t, err)
-	dgraphtest.CompareJSON(`{
+	dgraphapi.CompareJSON(`{
 		"q": [
 		  {
 			"val": "0000-01-01T00:00:00Z"

--- a/systest/mutations-and-queries/queries_test.go
+++ b/systest/mutations-and-queries/queries_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/dgraph-io/dgo/v230/protos/api"
-	"github.com/dgraph-io/dgraph/dgraphtest"
+	"github.com/dgraph-io/dgraph/dgraphapi"
 	"github.com/dgraph-io/dgraph/testutil"
 	"github.com/dgraph-io/dgraph/x"
 )
@@ -226,7 +226,7 @@ func (ssuite *SystestTestSuite) MultipleBlockEval() {
 	for _, tc := range tests {
 		resp, err := txn.Query(ctx, fmt.Sprintf(queryFmt, tc.in))
 		require.NoError(t, err)
-		dgraphtest.CompareJSON(tc.out, string(resp.Json))
+		dgraphapi.CompareJSON(tc.out, string(resp.Json))
 	}
 }
 
@@ -328,7 +328,7 @@ func (ssuite *SystestTestSuite) UnmatchedVarEval() {
 	for _, tc := range tests {
 		resp, err := txn.Query(ctx, tc.in)
 		require.NoError(t, err)
-		dgraphtest.CompareJSON(tc.out, string(resp.Json))
+		dgraphapi.CompareJSON(tc.out, string(resp.Json))
 	}
 }
 
@@ -453,7 +453,7 @@ func (ssuite *SystestTestSuite) SchemaQueryTestPredicate1() {
 	"types": [` + testutil.GetInternalTypes(false) + `
 	]
   }`
-	dgraphtest.CompareJSON(js, string(resp.Json))
+	dgraphapi.CompareJSON(js, string(resp.Json))
 }
 
 func (ssuite *SystestTestSuite) SchemaQueryTestPredicate2() {
@@ -496,7 +496,7 @@ func (ssuite *SystestTestSuite) SchemaQueryTestPredicate2() {
       }
     ]
   }`
-	dgraphtest.CompareJSON(js, string(resp.Json))
+	dgraphapi.CompareJSON(js, string(resp.Json))
 }
 
 func (ssuite *SystestTestSuite) SchemaQueryTestPredicate3() {
@@ -548,7 +548,7 @@ func (ssuite *SystestTestSuite) SchemaQueryTestPredicate3() {
       }
     ]
   }`
-	dgraphtest.CompareJSON(js, string(resp.Json))
+	dgraphapi.CompareJSON(js, string(resp.Json))
 }
 
 func (ssuite *SystestTestSuite) SchemaQueryTestHTTP() {
@@ -573,7 +573,7 @@ func (ssuite *SystestTestSuite) SchemaQueryTestHTTP() {
 
 	hcli, err := ssuite.dc.HTTPClient()
 	require.NoError(t, err)
-	err = hcli.LoginIntoNamespace(dgraphtest.DefaultUser, dgraphtest.DefaultPassword, x.GalaxyNamespace)
+	err = hcli.LoginIntoNamespace(dgraphapi.DefaultUser, dgraphapi.DefaultPassword, x.GalaxyNamespace)
 	require.NotNil(t, hcli.AccessJwt, "token is nil")
 	require.NoError(t, err)
 
@@ -584,7 +584,7 @@ func (ssuite *SystestTestSuite) SchemaQueryTestHTTP() {
 	var m map[string]json.RawMessage
 	require.NoError(t, json.Unmarshal(res, &m))
 	require.NotNil(t, m["extensions"])
-	dgraphtest.CompareJSON(testutil.GetFullSchemaJSON(testutil.SchemaOptions{UserPreds: `
+	dgraphapi.CompareJSON(testutil.GetFullSchemaJSON(testutil.SchemaOptions{UserPreds: `
 	  {
         "predicate": "name",
         "type": "string",
@@ -747,7 +747,7 @@ func (ssuite *SystestTestSuite) FuzzyMatch() {
 			continue
 		}
 		require.NoError(t, err)
-		dgraphtest.CompareJSON(tc.out, string(resp.Json))
+		dgraphapi.CompareJSON(tc.out, string(resp.Json))
 	}
 }
 
@@ -1218,7 +1218,7 @@ func (ssuite *SystestTestSuite) CascadeParams() {
 	for _, tc := range tests {
 		resp, err := gcli.NewTxn().Query(ctx, tc.in)
 		require.NoError(t, err)
-		dgraphtest.CompareJSON(tc.out, string(resp.Json))
+		dgraphapi.CompareJSON(tc.out, string(resp.Json))
 	}
 }
 
@@ -1339,7 +1339,7 @@ func (ssuite *SystestTestSuite) QueryHashIndex() {
 	for _, tc := range tests {
 		resp, err := gcli.NewTxn().Query(ctx, tc.in)
 		require.NoError(t, err)
-		dgraphtest.CompareJSON(tc.out, string(resp.Json))
+		dgraphapi.CompareJSON(tc.out, string(resp.Json))
 	}
 }
 
@@ -1396,7 +1396,7 @@ func (ssuite *SystestTestSuite) RegexpToggleTrigramIndex() {
 	for _, tc := range tests {
 		resp, err := gcli.NewTxn().Query(ctx, tc.in)
 		require.NoError(t, err)
-		dgraphtest.CompareJSON(tc.out, string(resp.Json))
+		dgraphapi.CompareJSON(tc.out, string(resp.Json))
 	}
 
 	op = &api.Operation{Schema: `name: string @index(trigram) @lang .`}
@@ -1406,7 +1406,7 @@ func (ssuite *SystestTestSuite) RegexpToggleTrigramIndex() {
 	for _, tc := range tests {
 		resp, err := gcli.NewTxn().Query(ctx, tc.in)
 		require.NoError(t, err)
-		dgraphtest.CompareJSON(tc.out, string(resp.Json))
+		dgraphapi.CompareJSON(tc.out, string(resp.Json))
 	}
 
 	require.NoError(t, gcli.Alter(ctx, &api.Operation{
@@ -1455,7 +1455,7 @@ func (ssuite *SystestTestSuite) EqWithAlteredIndexOrder() {
 	expectedResult := `{"q":[{"name":"Alice"}]}`
 	resp, err := gcli.NewReadOnlyTxn().Query(ctx, q)
 	require.NoError(t, err)
-	dgraphtest.CompareJSON(expectedResult, string(resp.Json))
+	dgraphapi.CompareJSON(expectedResult, string(resp.Json))
 
 	// now, let's set the schema with trigram before term
 	op = &api.Operation{Schema: `name: string @index(trigram, term) .`}
@@ -1464,7 +1464,7 @@ func (ssuite *SystestTestSuite) EqWithAlteredIndexOrder() {
 	// querying with eq should still work
 	resp, err = gcli.NewReadOnlyTxn().Query(ctx, q)
 	require.NoError(t, err)
-	dgraphtest.CompareJSON(expectedResult, string(resp.Json))
+	dgraphapi.CompareJSON(expectedResult, string(resp.Json))
 }
 
 func (ssuite *SystestTestSuite) GroupByUidWorks() {
@@ -1519,17 +1519,17 @@ func (ssuite *SystestTestSuite) GroupByUidWorks() {
 	for _, tc := range tests {
 		resp, err := gcli.NewTxn().Query(ctx, tc.in)
 		require.NoError(t, err)
-		dgraphtest.CompareJSON(tc.out, string(resp.Json))
+		dgraphapi.CompareJSON(tc.out, string(resp.Json))
 	}
 }
 
-func doGrpcLogin(ssuite *SystestTestSuite) (*dgraphtest.GrpcClient, func(), error) {
+func doGrpcLogin(ssuite *SystestTestSuite) (*dgraphapi.GrpcClient, func(), error) {
 	gcli, cleanup, err := ssuite.dc.Client()
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "error creating grpc client")
 	}
 	err = gcli.LoginIntoNamespace(context.Background(),
-		dgraphtest.DefaultUser, dgraphtest.DefaultPassword, x.GalaxyNamespace)
+		dgraphapi.DefaultUser, dgraphapi.DefaultPassword, x.GalaxyNamespace)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "groot login into galaxy namespace failed")
 	}

--- a/systest/mutations-and-queries/upgrade_test.go
+++ b/systest/mutations-and-queries/upgrade_test.go
@@ -27,13 +27,14 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
+	"github.com/dgraph-io/dgraph/dgraphapi"
 	"github.com/dgraph-io/dgraph/dgraphtest"
 	"github.com/dgraph-io/dgraph/x"
 )
 
 type SystestTestSuite struct {
 	suite.Suite
-	dc dgraphtest.Cluster
+	dc dgraphapi.Cluster
 	lc *dgraphtest.LocalCluster
 	uc dgraphtest.UpgradeCombo
 }

--- a/systest/plugin/integration_test.go
+++ b/systest/plugin/integration_test.go
@@ -24,12 +24,13 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
+	"github.com/dgraph-io/dgraph/dgraphapi"
 	"github.com/dgraph-io/dgraph/dgraphtest"
 )
 
 type PluginTestSuite struct {
 	suite.Suite
-	dc  dgraphtest.Cluster
+	dc dgraphapi.Cluster
 }
 
 func (psuite *PluginTestSuite) SetupTest() {

--- a/systest/plugin/plugin_test.go
+++ b/systest/plugin/plugin_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/dgraph-io/dgo/v230/protos/api"
-	"github.com/dgraph-io/dgraph/dgraphtest"
+	"github.com/dgraph-io/dgraph/dgraphapi"
 )
 
 type testCase struct {
@@ -329,7 +329,7 @@ func (psuite *PluginTestSuite) TestPlugins() {
 			for _, test := range testInp[i].cases {
 				reply, err := gcli.Query(test.query)
 				require.NoError(t, err)
-				dgraphtest.CompareJSON(test.wantResult, string(reply.GetJson()))
+				dgraphapi.CompareJSON(test.wantResult, string(reply.GetJson()))
 			}
 		})
 	}

--- a/systest/plugin/upgrade_test.go
+++ b/systest/plugin/upgrade_test.go
@@ -26,15 +26,16 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
+	"github.com/dgraph-io/dgraph/dgraphapi"
 	"github.com/dgraph-io/dgraph/dgraphtest"
 	"github.com/dgraph-io/dgraph/x"
 )
 
 type PluginTestSuite struct {
 	suite.Suite
-	dc  dgraphtest.Cluster
-	lc  *dgraphtest.LocalCluster
-	uc  dgraphtest.UpgradeCombo
+	dc dgraphapi.Cluster
+	lc *dgraphtest.LocalCluster
+	uc dgraphtest.UpgradeCombo
 }
 
 func (psuite *PluginTestSuite) SetupSubTest() {

--- a/systest/unique_test.go
+++ b/systest/unique_test.go
@@ -33,6 +33,7 @@ import (
 
 	"github.com/dgraph-io/dgo/v230/protos/api"
 	"github.com/dgraph-io/dgraph/dgraph/cmd/live"
+	"github.com/dgraph-io/dgraph/dgraphapi"
 	"github.com/dgraph-io/dgraph/dgraphtest"
 )
 
@@ -49,7 +50,7 @@ const emailQueryWithUid = `{
 	    }
 	}`
 
-func setUpDgraph(t *testing.T) *dgraphtest.GrpcClient {
+func setUpDgraph(t *testing.T) *dgraphapi.GrpcClient {
 	c := dgraphtest.ComposeCluster{}
 	dg, close, err := c.Client()
 	require.NoError(t, err)
@@ -126,7 +127,7 @@ func TestUniqueTwoMutationSingleBlankNode(t *testing.T) {
 	require.NoError(t, err)
 	resp, err := dg.Query(emailQuery)
 	require.NoError(t, err)
-	require.NoError(t, dgraphtest.CompareJSON(`{ "q": [{"email": "example@email.com"}]}`, string(resp.Json)))
+	require.NoError(t, dgraphapi.CompareJSON(`{ "q": [{"email": "example@email.com"}]}`, string(resp.Json)))
 	_, err = dg.Mutate(&api.Mutation{
 		SetNquads: []byte(rdf),
 		CommitNow: true,
@@ -150,7 +151,7 @@ func TestUniqueOneMutationSameValueTwoBlankNode(t *testing.T) {
 
 	resp, err := dg.Query(emailQuery)
 	require.NoError(t, err)
-	require.NoError(t, dgraphtest.CompareJSON(`{ "q": [ ]}`, string(resp.Json)))
+	require.NoError(t, dgraphapi.CompareJSON(`{ "q": [ ]}`, string(resp.Json)))
 }
 
 func TestUniqueOneMutationSameValueSingleBlankNode(t *testing.T) {
@@ -166,7 +167,7 @@ func TestUniqueOneMutationSameValueSingleBlankNode(t *testing.T) {
 	require.NoError(t, err)
 	resp, err := dg.Query(emailQuery)
 	require.NoError(t, err)
-	require.NoError(t, dgraphtest.CompareJSON(`{ "q": [ {	"email": "example@email.com"}]}`,
+	require.NoError(t, dgraphapi.CompareJSON(`{ "q": [ {	"email": "example@email.com"}]}`,
 		string(resp.Json)))
 }
 
@@ -183,7 +184,7 @@ func TestUniqueTwoMutattionsTwoHardCodedUIDs(t *testing.T) {
 
 	resp, err := dg.Query(emailQueryWithUid)
 	require.NoError(t, err)
-	require.NoError(t, dgraphtest.CompareJSON(`{ "q": [ {"email": "example@email.com","uid" :"0x5"}]}`,
+	require.NoError(t, dgraphapi.CompareJSON(`{ "q": [ {"email": "example@email.com","uid" :"0x5"}]}`,
 		string(resp.Json)))
 
 	rdf = `<0x6> <email> "example@email.com" .	`
@@ -208,7 +209,7 @@ func TestUniqueHardCodedUidsWithDiffrentNotation(t *testing.T) {
 
 	resp, err := dg.Query(emailQueryWithUid)
 	require.NoError(t, err)
-	require.NoError(t, dgraphtest.CompareJSON(`{ "q": [ {"email": "example@email.com","uid" :"0xad"}]}`,
+	require.NoError(t, dgraphapi.CompareJSON(`{ "q": [ {"email": "example@email.com","uid" :"0xad"}]}`,
 		string(resp.Json)))
 
 	rdf = `<0o255> <email> "example@email.com" .	`
@@ -219,7 +220,7 @@ func TestUniqueHardCodedUidsWithDiffrentNotation(t *testing.T) {
 	require.NoError(t, err)
 	resp, err = dg.Query(emailQueryWithUid)
 	require.NoError(t, err)
-	require.NoError(t, dgraphtest.CompareJSON(`{ "q": [ {"email": "example@email.com","uid" :"0xad"}]}`,
+	require.NoError(t, dgraphapi.CompareJSON(`{ "q": [ {"email": "example@email.com","uid" :"0xad"}]}`,
 		string(resp.Json)))
 
 	rdf = `<0b10101101> <email> "example@email.com" .	`
@@ -230,7 +231,7 @@ func TestUniqueHardCodedUidsWithDiffrentNotation(t *testing.T) {
 	require.NoError(t, err)
 	resp, err = dg.Query(emailQueryWithUid)
 	require.NoError(t, err)
-	require.NoError(t, dgraphtest.CompareJSON(`{ "q": [ {"email": "example@email.com","uid" :"0xad"}]}`,
+	require.NoError(t, dgraphapi.CompareJSON(`{ "q": [ {"email": "example@email.com","uid" :"0xad"}]}`,
 		string(resp.Json)))
 
 	rdf = `<173> <email> "example@email.com" .	`
@@ -241,7 +242,7 @@ func TestUniqueHardCodedUidsWithDiffrentNotation(t *testing.T) {
 	require.NoError(t, err)
 	resp, err = dg.Query(emailQueryWithUid)
 	require.NoError(t, err)
-	require.NoError(t, dgraphtest.CompareJSON(`{ "q": [ {"email": "example@email.com","uid" :"0xad"}]}`,
+	require.NoError(t, dgraphapi.CompareJSON(`{ "q": [ {"email": "example@email.com","uid" :"0xad"}]}`,
 		string(resp.Json)))
 
 }
@@ -259,7 +260,7 @@ func TestUniqueSingleMutattionsOneHardCodedUIDSameValue(t *testing.T) {
 	require.NoError(t, err)
 	resp, err := dg.Query(emailQueryWithUid)
 	require.NoError(t, err)
-	require.NoError(t, dgraphtest.CompareJSON(`{ "q": [ {	
+	require.NoError(t, dgraphapi.CompareJSON(`{ "q": [ {	
 		"email": "example@email.com",
 		"uid":"0x5"
 	}]}`, string(resp.Json)))
@@ -280,7 +281,7 @@ func TestUniqueOneMutattionsTwoHardCodedUIDsDiffValue(t *testing.T) {
 
 	resp, err := dg.Query(emailQuery)
 	require.NoError(t, err)
-	require.NoError(t, dgraphtest.CompareJSON(`{ "q": [ ]}`, string(resp.Json)))
+	require.NoError(t, dgraphapi.CompareJSON(`{ "q": [ ]}`, string(resp.Json)))
 }
 
 func TestUniqueUpsertMutation(t *testing.T) {
@@ -306,7 +307,7 @@ func TestUniqueUpsertMutation(t *testing.T) {
 	require.NoError(t, err)
 	resp, err := dg.Query(emailQuery)
 	require.NoError(t, err)
-	require.NoError(t, dgraphtest.CompareJSON(`{ "q": [{"email": "example@email.com"} ]}`, string(resp.Json)))
+	require.NoError(t, dgraphapi.CompareJSON(`{ "q": [{"email": "example@email.com"} ]}`, string(resp.Json)))
 
 	mu = &api.Mutation{
 		SetNquads: []byte(` uid(v) <email> "example1@email.com" .`),
@@ -328,7 +329,7 @@ func TestUniqueWithConditionalUpsertMutation(t *testing.T) {
 	require.NoError(t, err)
 	resp, err := dg.Query(emailQuery)
 	require.NoError(t, err)
-	require.NoError(t, dgraphtest.CompareJSON(`{ "q": [{"email": "example@email.com"} ]}`, string(resp.Json)))
+	require.NoError(t, dgraphapi.CompareJSON(`{ "q": [{"email": "example@email.com"} ]}`, string(resp.Json)))
 
 	query := `query{
 		         v as person(func: eq(email, "example@email.com")) {
@@ -505,7 +506,7 @@ func TestUniqueForInt(t *testing.T) {
     }`
 	resp, err := dg.Query(query)
 	require.NoError(t, err)
-	require.NoError(t, dgraphtest.CompareJSON(`{ "q": [ {	"mobile": 1234567890}]}`, string(resp.Json)))
+	require.NoError(t, dgraphapi.CompareJSON(`{ "q": [ {	"mobile": 1234567890}]}`, string(resp.Json)))
 }
 
 func TestUniqueForLangDirective(t *testing.T) {
@@ -657,7 +658,7 @@ func TestConcurrencyMutationsDiffrentValuesForDiffrentBlankNode(t *testing.T) {
 	resp, err := dg.Query(query)
 	require.NoError(t, err)
 	// there should be 1000 emails in DB.
-	require.NoError(t, dgraphtest.CompareJSON(`{"allMails":[{"count":1000}]}`, string(resp.Json)))
+	require.NoError(t, dgraphapi.CompareJSON(`{"allMails":[{"count":1000}]}`, string(resp.Json)))
 }
 
 func TestUniqueTwoTxnWithoutCommit(t *testing.T) {
@@ -682,7 +683,7 @@ func TestUniqueTwoTxnWithoutCommit(t *testing.T) {
 	resp, err := dg.Query(emailQuery)
 	require.NoError(t, err)
 	// there should be only one email data as expected.
-	require.NoError(t, dgraphtest.CompareJSON(`{"q":[{"email":"example@email.com"}]}`, string(resp.Json)))
+	require.NoError(t, dgraphapi.CompareJSON(`{"q":[{"email":"example@email.com"}]}`, string(resp.Json)))
 }
 
 func TestUniqueSingelTxnDuplicteValuesWithoutCommit(t *testing.T) {
@@ -751,8 +752,8 @@ func TestConcurrency2(t *testing.T) {
 		}`, i)
 		resp, err := dg.Query(emailQuery)
 		require.NoError(t, err)
-		err1 := dgraphtest.CompareJSON(fmt.Sprintf(`{"q":[{"email":"example%v@email.com"}]}`, i), string(resp.Json))
-		err2 := dgraphtest.CompareJSON(fmt.Sprintf(`{ "q": [ ]}`), string(resp.Json))
+		err1 := dgraphapi.CompareJSON(fmt.Sprintf(`{"q":[{"email":"example%v@email.com"}]}`, i), string(resp.Json))
+		err2 := dgraphapi.CompareJSON(fmt.Sprintf(`{ "q": [ ]}`), string(resp.Json))
 		if err1 != nil && err2 != nil {
 			t.Fatal()
 		}

--- a/systest/vector/backup_test.go
+++ b/systest/vector/backup_test.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	"github.com/dgraph-io/dgo/v230/protos/api"
+	"github.com/dgraph-io/dgraph/dgraphapi"
 	"github.com/dgraph-io/dgraph/dgraphtest"
 	"github.com/dgraph-io/dgraph/x"
 	"github.com/stretchr/testify/require"
@@ -43,12 +44,12 @@ func TestVectorIncrBackupRestore(t *testing.T) {
 	require.NoError(t, err)
 	defer cleanup()
 	require.NoError(t, gc.LoginIntoNamespace(context.Background(),
-		dgraphtest.DefaultUser, dgraphtest.DefaultPassword, x.GalaxyNamespace))
+		dgraphapi.DefaultUser, dgraphapi.DefaultPassword, x.GalaxyNamespace))
 
 	hc, err := c.HTTPClient()
 	require.NoError(t, err)
-	require.NoError(t, hc.LoginIntoNamespace(dgraphtest.DefaultUser,
-		dgraphtest.DefaultPassword, x.GalaxyNamespace))
+	require.NoError(t, hc.LoginIntoNamespace(dgraphapi.DefaultUser,
+		dgraphapi.DefaultPassword, x.GalaxyNamespace))
 
 	require.NoError(t, gc.SetupSchema(testSchema))
 
@@ -59,7 +60,7 @@ func TestVectorIncrBackupRestore(t *testing.T) {
 	for i := 1; i <= 5; i++ {
 		var rdfs string
 		var vectors [][]float32
-		rdfs, vectors = dgraphtest.GenerateRandomVectors(numVectors*(i-1), numVectors*i, 1, pred)
+		rdfs, vectors = dgraphapi.GenerateRandomVectors(numVectors*(i-1), numVectors*i, 1, pred)
 		allVectors = append(allVectors, vectors)
 		allRdfs = append(allRdfs, rdfs)
 		mu := &api.Mutation{SetNquads: []byte(rdfs), CommitNow: true}
@@ -75,7 +76,7 @@ func TestVectorIncrBackupRestore(t *testing.T) {
 
 		incrFrom := i - 1
 		require.NoError(t, hc.Restore(c, dgraphtest.DefaultBackupDir, "", incrFrom, i))
-		require.NoError(t, dgraphtest.WaitForRestore(c))
+		require.NoError(t, dgraphapi.WaitForRestore(c))
 		query := `{
 			vector(func: has(project_discription_v)) {
 				   count(uid)
@@ -120,18 +121,18 @@ func TestVectorBackupRestore(t *testing.T) {
 	require.NoError(t, err)
 	defer cleanup()
 	require.NoError(t, gc.LoginIntoNamespace(context.Background(),
-		dgraphtest.DefaultUser, dgraphtest.DefaultPassword, x.GalaxyNamespace))
+		dgraphapi.DefaultUser, dgraphapi.DefaultPassword, x.GalaxyNamespace))
 
 	hc, err := c.HTTPClient()
 	require.NoError(t, err)
-	require.NoError(t, hc.LoginIntoNamespace(dgraphtest.DefaultUser,
-		dgraphtest.DefaultPassword, x.GalaxyNamespace))
+	require.NoError(t, hc.LoginIntoNamespace(dgraphapi.DefaultUser,
+		dgraphapi.DefaultPassword, x.GalaxyNamespace))
 
 	require.NoError(t, gc.SetupSchema(testSchema))
 
 	numVectors := 1000
 	pred := "project_discription_v"
-	rdfs, vectors := dgraphtest.GenerateRandomVectors(0, numVectors, 10, pred)
+	rdfs, vectors := dgraphapi.GenerateRandomVectors(0, numVectors, 10, pred)
 
 	mu := &api.Mutation{SetNquads: []byte(rdfs), CommitNow: true}
 	_, err = gc.Mutate(mu)
@@ -142,7 +143,7 @@ func TestVectorBackupRestore(t *testing.T) {
 
 	t.Log("restoring backup \n")
 	require.NoError(t, hc.Restore(c, dgraphtest.DefaultBackupDir, "", 0, 0))
-	require.NoError(t, dgraphtest.WaitForRestore(c))
+	require.NoError(t, dgraphapi.WaitForRestore(c))
 
 	testVectorQuery(t, gc, vectors, rdfs, pred, numVectors)
 }
@@ -159,19 +160,19 @@ func TestVectorBackupRestoreDropIndex(t *testing.T) {
 	require.NoError(t, err)
 	defer cleanup()
 	require.NoError(t, gc.LoginIntoNamespace(context.Background(),
-		dgraphtest.DefaultUser, dgraphtest.DefaultPassword, x.GalaxyNamespace))
+		dgraphapi.DefaultUser, dgraphapi.DefaultPassword, x.GalaxyNamespace))
 
 	hc, err := c.HTTPClient()
 	require.NoError(t, err)
-	require.NoError(t, hc.LoginIntoNamespace(dgraphtest.DefaultUser,
-		dgraphtest.DefaultPassword, x.GalaxyNamespace))
+	require.NoError(t, hc.LoginIntoNamespace(dgraphapi.DefaultUser,
+		dgraphapi.DefaultPassword, x.GalaxyNamespace))
 
 	// add vector predicate + index
 	require.NoError(t, gc.SetupSchema(testSchema))
 	// add data to the vector predicate
 	numVectors := 3
 	pred := "project_discription_v"
-	rdfs, vectors := dgraphtest.GenerateRandomVectors(0, numVectors, 1, pred)
+	rdfs, vectors := dgraphapi.GenerateRandomVectors(0, numVectors, 1, pred)
 	mu := &api.Mutation{SetNquads: []byte(rdfs), CommitNow: true}
 	_, err = gc.Mutate(mu)
 	require.NoError(t, err)
@@ -183,7 +184,7 @@ func TestVectorBackupRestoreDropIndex(t *testing.T) {
 	require.NoError(t, gc.SetupSchema(testSchemaWithoutIndex))
 
 	// add more data to the vector predicate
-	rdfs, vectors2 := dgraphtest.GenerateRandomVectors(3, numVectors+3, 1, pred)
+	rdfs, vectors2 := dgraphapi.GenerateRandomVectors(3, numVectors+3, 1, pred)
 	mu = &api.Mutation{SetNquads: []byte(rdfs), CommitNow: true}
 	_, err = gc.Mutate(mu)
 	require.NoError(t, err)
@@ -212,7 +213,7 @@ func TestVectorBackupRestoreDropIndex(t *testing.T) {
 	// restore backup
 	t.Log("restoring backup \n")
 	require.NoError(t, hc.Restore(c, dgraphtest.DefaultBackupDir, "", 0, 0))
-	require.NoError(t, dgraphtest.WaitForRestore(c))
+	require.NoError(t, dgraphapi.WaitForRestore(c))
 
 	query := ` {
 		vectors(func: has(project_discription_v)) {
@@ -247,18 +248,18 @@ func TestVectorBackupRestoreReIndexing(t *testing.T) {
 	require.NoError(t, err)
 	defer cleanup()
 	require.NoError(t, gc.LoginIntoNamespace(context.Background(),
-		dgraphtest.DefaultUser, dgraphtest.DefaultPassword, x.GalaxyNamespace))
+		dgraphapi.DefaultUser, dgraphapi.DefaultPassword, x.GalaxyNamespace))
 
 	hc, err := c.HTTPClient()
 	require.NoError(t, err)
-	require.NoError(t, hc.LoginIntoNamespace(dgraphtest.DefaultUser,
-		dgraphtest.DefaultPassword, x.GalaxyNamespace))
+	require.NoError(t, hc.LoginIntoNamespace(dgraphapi.DefaultUser,
+		dgraphapi.DefaultPassword, x.GalaxyNamespace))
 
 	require.NoError(t, gc.SetupSchema(testSchema))
 
 	numVectors := 1000
 	pred := "project_discription_v"
-	rdfs, vectors := dgraphtest.GenerateRandomVectors(0, numVectors, 10, pred)
+	rdfs, vectors := dgraphapi.GenerateRandomVectors(0, numVectors, 10, pred)
 
 	mu := &api.Mutation{SetNquads: []byte(rdfs), CommitNow: true}
 	_, err = gc.Mutate(mu)
@@ -267,14 +268,14 @@ func TestVectorBackupRestoreReIndexing(t *testing.T) {
 	t.Log("taking backup \n")
 	require.NoError(t, hc.Backup(c, false, dgraphtest.DefaultBackupDir))
 
-	rdfs2, vectors2 := dgraphtest.GenerateRandomVectors(numVectors, numVectors+300, 10, pred)
+	rdfs2, vectors2 := dgraphapi.GenerateRandomVectors(numVectors, numVectors+300, 10, pred)
 
 	mu = &api.Mutation{SetNquads: []byte(rdfs2), CommitNow: true}
 	_, err = gc.Mutate(mu)
 	require.NoError(t, err)
 	t.Log("restoring backup \n")
 	require.NoError(t, hc.Restore(c, dgraphtest.DefaultBackupDir, "", 2, 1))
-	require.NoError(t, dgraphtest.WaitForRestore(c))
+	require.NoError(t, dgraphapi.WaitForRestore(c))
 
 	for i := 0; i < 5; i++ {
 		// drop index

--- a/systest/vector/load_test.go
+++ b/systest/vector/load_test.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/dgraph-io/dgo/v230/protos/api"
+	"github.com/dgraph-io/dgraph/dgraphapi"
 	"github.com/dgraph-io/dgraph/dgraphtest"
 	"github.com/dgraph-io/dgraph/x"
 	"github.com/stretchr/testify/require"
@@ -51,18 +52,18 @@ func testExportAndLiveLoad(t *testing.T, c *dgraphtest.LocalCluster, exportForma
 	require.NoError(t, err)
 	defer cleanup()
 	require.NoError(t, gc.LoginIntoNamespace(context.Background(),
-		dgraphtest.DefaultUser, dgraphtest.DefaultPassword, x.GalaxyNamespace))
+		dgraphapi.DefaultUser, dgraphapi.DefaultPassword, x.GalaxyNamespace))
 
 	hc, err := c.HTTPClient()
 	require.NoError(t, err)
-	require.NoError(t, hc.LoginIntoNamespace(dgraphtest.DefaultUser,
-		dgraphtest.DefaultPassword, x.GalaxyNamespace))
+	require.NoError(t, hc.LoginIntoNamespace(dgraphapi.DefaultUser,
+		dgraphapi.DefaultPassword, x.GalaxyNamespace))
 
 	require.NoError(t, gc.SetupSchema(testSchema))
 
 	numVectors := 100
 	pred := "project_discription_v"
-	rdfs, vectors := dgraphtest.GenerateRandomVectors(0, numVectors, 10, pred)
+	rdfs, vectors := dgraphapi.GenerateRandomVectors(0, numVectors, 10, pred)
 
 	mu := &api.Mutation{SetNquads: []byte(rdfs), CommitNow: true}
 	_, err = gc.Mutate(mu)
@@ -87,7 +88,7 @@ func testExportAndLiveLoad(t *testing.T, c *dgraphtest.LocalCluster, exportForma
 	require.NoError(t, c.LiveLoadFromExport(dgraphtest.DefaultExportDir))
 
 	require.NoError(t, gc.LoginIntoNamespace(context.Background(),
-		dgraphtest.DefaultUser, dgraphtest.DefaultPassword, x.GalaxyNamespace))
+		dgraphapi.DefaultUser, dgraphapi.DefaultPassword, x.GalaxyNamespace))
 
 	result, err = gc.Query(query)
 	require.NoError(t, err)

--- a/systest/vector/vector_test.go
+++ b/systest/vector/vector_test.go
@@ -301,12 +301,12 @@ func TestVectorIndexOnVectorPredWithoutData(t *testing.T) {
 	require.NoError(t, err)
 	defer cleanup()
 	require.NoError(t, gc.LoginIntoNamespace(context.Background(),
-		dgraphtest.DefaultUser, dgraphtest.DefaultPassword, x.GalaxyNamespace))
+		dgraphapi.DefaultUser, dgraphapi.DefaultPassword, x.GalaxyNamespace))
 
 	hc, err := c.HTTPClient()
 	require.NoError(t, err)
-	require.NoError(t, hc.LoginIntoNamespace(dgraphtest.DefaultUser,
-		dgraphtest.DefaultPassword, x.GalaxyNamespace))
+	require.NoError(t, hc.LoginIntoNamespace(dgraphapi.DefaultUser,
+		dgraphapi.DefaultPassword, x.GalaxyNamespace))
 
 	require.NoError(t, gc.SetupSchema(testSchema))
 	pred := "project_discription_v"

--- a/systest/vector/vector_test.go
+++ b/systest/vector/vector_test.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/dgraph-io/dgo/v230/protos/api"
+	"github.com/dgraph-io/dgraph/dgraphapi"
 	"github.com/dgraph-io/dgraph/dgraphtest"
 	"github.com/dgraph-io/dgraph/x"
 	"github.com/stretchr/testify/require"
@@ -38,7 +39,7 @@ const (
 	testSchemaWithoutIndex = `project_discription_v: float32vector .`
 )
 
-func testVectorQuery(t *testing.T, gc *dgraphtest.GrpcClient, vectors [][]float32, rdfs, pred string, topk int) {
+func testVectorQuery(t *testing.T, gc *dgraphapi.GrpcClient, vectors [][]float32, rdfs, pred string, topk int) {
 	for i, vector := range vectors {
 		triple := strings.Split(rdfs, "\n")[i]
 		uid := strings.Split(triple, " ")[0]
@@ -65,12 +66,12 @@ func TestVectorDropAll(t *testing.T) {
 	require.NoError(t, err)
 	defer cleanup()
 	require.NoError(t, gc.LoginIntoNamespace(context.Background(),
-		dgraphtest.DefaultUser, dgraphtest.DefaultPassword, x.GalaxyNamespace))
+		dgraphapi.DefaultUser, dgraphapi.DefaultPassword, x.GalaxyNamespace))
 
 	hc, err := c.HTTPClient()
 	require.NoError(t, err)
-	require.NoError(t, hc.LoginIntoNamespace(dgraphtest.DefaultUser,
-		dgraphtest.DefaultPassword, x.GalaxyNamespace))
+	require.NoError(t, hc.LoginIntoNamespace(dgraphapi.DefaultUser,
+		dgraphapi.DefaultPassword, x.GalaxyNamespace))
 
 	numVectors := 100
 	pred := "project_discription_v"
@@ -85,7 +86,7 @@ func TestVectorDropAll(t *testing.T) {
 
 	for i := 0; i < 10; i++ {
 		require.NoError(t, gc.SetupSchema(testSchema))
-		rdfs, vectors := dgraphtest.GenerateRandomVectors(0, numVectors, 100, pred)
+		rdfs, vectors := dgraphapi.GenerateRandomVectors(0, numVectors, 100, pred)
 		mu := &api.Mutation{SetNquads: []byte(rdfs), CommitNow: true}
 		_, err = gc.Mutate(mu)
 		require.NoError(t, err)
@@ -122,25 +123,25 @@ func TestVectorSnapshot(t *testing.T) {
 	require.NoError(t, err)
 	defer cleanup()
 	require.NoError(t, gc.LoginIntoNamespace(context.Background(),
-		dgraphtest.DefaultUser, dgraphtest.DefaultPassword, x.GalaxyNamespace))
+		dgraphapi.DefaultUser, dgraphapi.DefaultPassword, x.GalaxyNamespace))
 
 	hc, err := c.HTTPClient()
 	require.NoError(t, err)
-	require.NoError(t, hc.LoginIntoNamespace(dgraphtest.DefaultUser,
-		dgraphtest.DefaultPassword, x.GalaxyNamespace))
+	require.NoError(t, hc.LoginIntoNamespace(dgraphapi.DefaultUser,
+		dgraphapi.DefaultPassword, x.GalaxyNamespace))
 
 	require.NoError(t, c.KillAlpha(1))
 
 	hc, err = c.HTTPClient()
 	require.NoError(t, err)
-	require.NoError(t, hc.LoginIntoNamespace(dgraphtest.DefaultUser,
-		dgraphtest.DefaultPassword, x.GalaxyNamespace))
+	require.NoError(t, hc.LoginIntoNamespace(dgraphapi.DefaultUser,
+		dgraphapi.DefaultPassword, x.GalaxyNamespace))
 
 	gc, cleanup, err = c.AlphaClient(0)
 	require.NoError(t, err)
 	defer cleanup()
 	require.NoError(t, gc.LoginIntoNamespace(context.Background(),
-		dgraphtest.DefaultUser, dgraphtest.DefaultPassword, x.GalaxyNamespace))
+		dgraphapi.DefaultUser, dgraphapi.DefaultPassword, x.GalaxyNamespace))
 
 	require.NoError(t, gc.SetupSchema(testSchema))
 
@@ -149,7 +150,7 @@ func TestVectorSnapshot(t *testing.T) {
 
 	numVectors := 500
 	pred := "project_discription_v"
-	rdfs, vectors := dgraphtest.GenerateRandomVectors(0, numVectors, 100, pred)
+	rdfs, vectors := dgraphapi.GenerateRandomVectors(0, numVectors, 100, pred)
 	mu := &api.Mutation{SetNquads: []byte(rdfs), CommitNow: true}
 	_, err = gc.Mutate(mu)
 	require.NoError(t, err)
@@ -175,8 +176,8 @@ func TestVectorSnapshot(t *testing.T) {
 	gc, cleanup, err = c.AlphaClient(1)
 	require.NoError(t, err)
 	defer cleanup()
-	require.NoError(t, gc.Login(context.Background(), dgraphtest.DefaultUser,
-		dgraphtest.DefaultPassword))
+	require.NoError(t, gc.Login(context.Background(), dgraphapi.DefaultUser,
+		dgraphapi.DefaultPassword))
 
 	result, err = gc.Query(query)
 	require.NoError(t, err)
@@ -196,12 +197,12 @@ func TestVectorDropNamespace(t *testing.T) {
 	require.NoError(t, err)
 	defer cleanup()
 	require.NoError(t, gc.LoginIntoNamespace(context.Background(),
-		dgraphtest.DefaultUser, dgraphtest.DefaultPassword, x.GalaxyNamespace))
+		dgraphapi.DefaultUser, dgraphapi.DefaultPassword, x.GalaxyNamespace))
 
 	hc, err := c.HTTPClient()
 	require.NoError(t, err)
-	require.NoError(t, hc.LoginIntoNamespace(dgraphtest.DefaultUser,
-		dgraphtest.DefaultPassword, x.GalaxyNamespace))
+	require.NoError(t, hc.LoginIntoNamespace(dgraphapi.DefaultUser,
+		dgraphapi.DefaultPassword, x.GalaxyNamespace))
 
 	numVectors := 500
 	pred := "project_discription_v"
@@ -209,7 +210,7 @@ func TestVectorDropNamespace(t *testing.T) {
 		ns, err := hc.AddNamespace()
 		require.NoError(t, err)
 		require.NoError(t, gc.SetupSchema(testSchema))
-		rdfs, vectors := dgraphtest.GenerateRandomVectors(0, numVectors, 100, pred)
+		rdfs, vectors := dgraphapi.GenerateRandomVectors(0, numVectors, 100, pred)
 		mu := &api.Mutation{SetNquads: []byte(rdfs), CommitNow: true}
 		_, err = gc.Mutate(mu)
 		require.NoError(t, err)
@@ -247,18 +248,18 @@ func TestVectorIndexRebuilding(t *testing.T) {
 	require.NoError(t, err)
 	defer cleanup()
 	require.NoError(t, gc.LoginIntoNamespace(context.Background(),
-		dgraphtest.DefaultUser, dgraphtest.DefaultPassword, x.GalaxyNamespace))
+		dgraphapi.DefaultUser, dgraphapi.DefaultPassword, x.GalaxyNamespace))
 
 	hc, err := c.HTTPClient()
 	require.NoError(t, err)
-	require.NoError(t, hc.LoginIntoNamespace(dgraphtest.DefaultUser,
-		dgraphtest.DefaultPassword, x.GalaxyNamespace))
+	require.NoError(t, hc.LoginIntoNamespace(dgraphapi.DefaultUser,
+		dgraphapi.DefaultPassword, x.GalaxyNamespace))
 
 	require.NoError(t, gc.SetupSchema(testSchema))
 
 	pred := "project_discription_v"
 	numVectors := 1000
-	rdfs, vectors := dgraphtest.GenerateRandomVectors(0, numVectors, 100, pred)
+	rdfs, vectors := dgraphapi.GenerateRandomVectors(0, numVectors, 100, pred)
 	mu := &api.Mutation{SetNquads: []byte(rdfs), CommitNow: true}
 	_, err = gc.Mutate(mu)
 	require.NoError(t, err)

--- a/testutil/schema.go
+++ b/testutil/schema.go
@@ -32,7 +32,7 @@ import (
 
 const (
 	aclPreds = `
-{"predicate":"dgraph.xid","type":"string", "index":true, "tokenizer":["exact"], "upsert":true},
+{"predicate":"dgraph.xid","type":"string", "index":true, "tokenizer":["exact"], "unique": true, "upsert":true},
 {"predicate":"dgraph.password","type":"password"},
 {"predicate":"dgraph.user.group","list":true, "reverse":true, "type":"uid"},
 {"predicate":"dgraph.acl.rule","type":"uid","list":true},

--- a/worker/export.go
+++ b/worker/export.go
@@ -329,6 +329,9 @@ func toSchema(attr string, update *pb.SchemaUpdate) *bpb.KV {
 	if update.GetUpsert() {
 		x.Check2(buf.WriteString(" @upsert"))
 	}
+	if update.GetUnique() {
+		x.Check2(buf.WriteString(" @unique"))
+	}
 	x.Check2(buf.WriteString(" . \n"))
 	//TODO(Naman): We don't need the version anymore.
 	return &bpb.KV{


### PR DESCRIPTION
This PR adds the unique directive to the 'dgraph.xid' predicate. Prior to this change, users could create duplicate users leading to misconfiguration of ACL.