### PR TITLE
fix(query): fix has function in filter

### DIFF
--- a/query/query0_test.go
+++ b/query/query0_test.go
@@ -52,6 +52,52 @@ func TestGetUID(t *testing.T) {
 		js)
 }
 
+func TestFilterHas(t *testing.T) {
+	// Query untagged values
+	query := `
+		{
+			me(func: has(alias)) @filter(has(alias_lang)) {
+				uid
+			}
+		}
+	`
+	js := processQueryNoErr(t, query)
+	require.JSONEq(t, `{"data":{"me":[]}}`, js)
+
+	// Query all tagged values
+	query = `
+		{
+			me(func: has(alias)) @filter(has(alias_lang@.)) {
+				alias_lang@.
+			}
+		}
+	`
+	js = processQueryNoErr(t, query)
+	require.JSONEq(t, `{"data":{"me":[{"alias_lang@.":"Zambo Alice"},{"alias_lang@.":"John Alice"},{"alias_lang@.":"Bob Joe"},{"alias_lang@.":"Allan Matt"},{"alias_lang@.":"John Oliver"}]}}`, js)
+
+	// All tagged values in root function
+	query = `
+		{
+			me(func: has(lossy@.)){
+				lossy@.
+			}
+		}
+	`
+	js = processQueryNoErr(t, query)
+	require.JSONEq(t, `{"data":{"me":[{"lossy@.":"Badger"},{"lossy@.":"Honey badger"}]}}`, js)
+
+	// Query specific language
+	query = `
+		{
+			me(func: has(lossy@.)) @filter(has(lossy@fr)) {
+				lossy@fr
+			}
+		}
+	`
+	js = processQueryNoErr(t, query)
+	require.JSONEq(t, `{"data":{"me":[{"lossy@fr":"Blaireau européen"}]}}`, js)
+}
+
 func TestQueryEmptyDefaultNames(t *testing.T) {
 	query := `{
 	  people(func: eq(name, "")) {

--- a/worker/task.go
+++ b/worker/task.go
@@ -718,6 +718,10 @@ func (qs *queryState) handleUidPostings(
 	x.AssertTrue(width > 0)
 	span.Annotatef(nil, "Width: %d. NumGo: %d", width, numGo)
 
+	lang := langForFunc(q.Langs)
+	needFiltering := needsStringFiltering(srcFn, q.Langs, q.Attr)
+	isList := schema.State().IsList(q.Attr)
+
 	errCh := make(chan error, numGo)
 	outputs := make([]*pb.Result, numGo)
 
@@ -784,7 +788,32 @@ func (qs *queryState) handleUidPostings(
 				if i == 0 {
 					span.Annotate(nil, "HasFn")
 				}
-				empty, err := pl.IsEmpty(args.q.ReadTs, 0)
+				// We figure out if need to filter on bases of lang attribute or not.
+				// If we don't need to do so, we can just check if the posting list
+				// is empty. If we need to filter on basis of lang, we need to check
+				// the value with its tag. if lang == "", in that case, we need to
+				// return if there are any untagged values. If lang != "", in that
+				// case we need to check exact value.
+				empty := false
+				var err error
+				if !needFiltering {
+					empty, err = pl.IsEmpty(args.q.ReadTs, 0)
+				} else {
+					if lang == "" {
+						if isList {
+							_, err = pl.AllValues(args.q.ReadTs)
+						} else {
+							_, err = pl.Value(args.q.ReadTs)
+						}
+					} else {
+						_, err = pl.ValueForTag(args.q.ReadTs, lang)
+					}
+
+					if err == posting.ErrNoValue {
+						empty = true
+						err = nil
+					}
+				}
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
Currently when we have a language tagged predicate (example: name). Querying name should return only untagged values. name@. should return any language.

Consider dataset
<1> <name> "first user" .
<2> <name@en> "second user" .

query (func: uid(1,2)) { uid name} would return "{uid: 1, name: first user}".
query (func: uid(1,2)) { uid name@.} would return "{{uid: 1, name@.: "first user"}, {uid: 2, name@.: "second user"}}".

However due to a bug, we are not enforcing this in @filter(has(name)). So this results in

query (func: has(dgraph.type)) @filter(has(name)) { uid name} results in
"{{uid: 1, name: "first user'}, {uid: 2}}"

Fix: We update @filter(has(name)) to filter on basis of language.