### PR TITLE
Update ci-golang-lint.yml

### DIFF
--- a/.github/workflows/ci-golang-lint.yml
+++ b/.github/workflows/ci-golang-lint.yml
@@ -31,7 +31,7 @@ jobs:
   golang-lint:
     if: github.event.pull_request.draft == false
     name: lint
-    runs-on: warp-ubuntu-latest-x64-4x
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Get Go Version


### PR DESCRIPTION
Moving this job back to GitHub runners, as there is an incompatibility with Warp runners. It's likely caused by a dated Actions dependency since this Action is quite behind on its dependencies. Will revisit linting strategy in the future.