### PR TITLE
Fix(debug): Close file correctly before exiting on error

### DIFF
--- a/dgraph/cmd/debuginfo/debugging.go
+++ b/dgraph/cmd/debuginfo/debugging.go
@@ -87,7 +87,6 @@ func saveDebug(sourceURL, filePath string, duration time.Duration) error {
 		out.Close()
 	}()
 	_, err = io.Copy(out, resp)
-	out.Close()
 	return err
 }
 

--- a/dgraph/cmd/debuginfo/debugging.go
+++ b/dgraph/cmd/debuginfo/debugging.go
@@ -79,12 +79,15 @@ func saveDebug(sourceURL, filePath string, duration time.Duration) error {
 			glog.Warningf("error closing resp reader: %v", err)
 		}
 	}()
-
 	out, err := os.Create(filePath)
 	if err != nil {
 		return fmt.Errorf("error while creating debug file: %s", err)
 	}
+	defer func() {
+		out.Close()
+	}()
 	_, err = io.Copy(out, resp)
+	out.Close()
 	return err
 }
 


### PR DESCRIPTION
 Improving on #9070. A file must be closed if the function exits on an error.
