### PR TITLE
Fix(core): Fix deadlock in runMutation and error handling

### DIFF
--- a/query/vector/vector_test.go
+++ b/query/vector/vector_test.go
@@ -434,6 +434,7 @@ func TestVectorsMutateFixedLengthWithDiffrentIndexes(t *testing.T) {
 }
 
 func TestVectorDeadlockwithTimeout(t *testing.T) {
+	pred := "vtest1"
 	dc = dgraphtest.NewComposeCluster()
 	var cleanup func()
 	client, cleanup, err := dc.Client()
@@ -449,14 +450,14 @@ func TestVectorDeadlockwithTimeout(t *testing.T) {
 		require.NoError(t, err)
 
 		err = client.Alter(context.Background(), &api.Operation{
-			DropAttr: "vtest",
+			DropAttr: pred,
 		})
-		dropPredicate("vtest")
-		setSchema(fmt.Sprintf(vectorSchemaWithIndex, "vtest", "4", "euclidian"))
+		dropPredicate(pred)
+		setSchema(fmt.Sprintf(vectorSchemaWithIndex, pred, "4", "euclidian"))
 		numVectors := 1000
 		vectorSize := 10
 
-		randomVectors, _ := generateRandomVectors(numVectors, vectorSize, "vtest")
+		randomVectors, _ := generateRandomVectors(numVectors, vectorSize, pred)
 
 		txn := client.NewTxn()
 		ctx, cancel := context.WithTimeout(context.Background(), time.Second)

--- a/query/vector/vector_test.go
+++ b/query/vector/vector_test.go
@@ -441,6 +441,7 @@ func TestVectorDeadlockwithTimeout(t *testing.T) {
 	defer cleanup()
 
 	for i := 0; i < 5; i++ {
+		fmt.Println("Testing iteration: ", i)
 		ctx, cancel2 := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel2()
 		err = client.LoginIntoNamespace(ctx, dgraphtest.DefaultUser,
@@ -458,7 +459,7 @@ func TestVectorDeadlockwithTimeout(t *testing.T) {
 		randomVectors, _ := generateRandomVectors(numVectors, vectorSize, "vtest")
 
 		txn := client.NewTxn()
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 		defer func() { _ = txn.Discard(ctx) }()
 		defer cancel()
 

--- a/query/vector/vector_test.go
+++ b/query/vector/vector_test.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/dgraph-io/dgo/v230/protos/api"
 	"github.com/dgraph-io/dgraph/dgraphtest"
+	"github.com/dgraph-io/dgraph/x"
 	"github.com/stretchr/testify/require"
 )
 
@@ -430,6 +431,46 @@ func TestVectorsMutateFixedLengthWithDiffrentIndexes(t *testing.T) {
 	setSchema(fmt.Sprintf(vectorSchemaWithIndex, "vtest", "4", "dot_product"))
 	testVectorMutationSameLength(t)
 	dropPredicate("vtest")
+}
+
+func TestVectorDeadlockwithTimeout(t *testing.T) {
+	dc = dgraphtest.NewComposeCluster()
+	var cleanup func()
+	client, cleanup, err := dc.Client()
+	x.Panic(err)
+	defer cleanup()
+
+	for i := 0; i < 5; i++ {
+		ctx, cancel2 := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel2()
+		err = client.LoginIntoNamespace(ctx, dgraphtest.DefaultUser,
+			dgraphtest.DefaultPassword, x.GalaxyNamespace)
+		require.NoError(t, err)
+
+		err = client.Alter(context.Background(), &api.Operation{
+			DropAttr: "vtest",
+		})
+		dropPredicate("vtest")
+		setSchema(fmt.Sprintf(vectorSchemaWithIndex, "vtest", "4", "euclidian"))
+		numVectors := 1000
+		vectorSize := 10
+
+		randomVectors, _ := generateRandomVectors(numVectors, vectorSize, "vtest")
+
+		txn := client.NewTxn()
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer func() { _ = txn.Discard(ctx) }()
+		defer cancel()
+
+		_, err = txn.Mutate(ctx, &api.Mutation{
+			SetNquads: []byte(randomVectors),
+			CommitNow: true,
+		})
+		require.Error(t, err)
+
+		err = txn.Commit(ctx)
+		require.Contains(t, err.Error(), "Transaction has already been committed or discarded")
+	}
 }
 
 func TestVectorMutateDiffrentLengthWithDiffrentIndexes(t *testing.T) {

--- a/tok/hnsw/helper.go
+++ b/tok/hnsw/helper.go
@@ -433,9 +433,10 @@ func (ph *persistentHNSW[T]) createEntryAndStartNodes(
 	err := ph.getVecFromUid(entry, c, vec)
 	if err != nil || len(*vec) == 0 {
 		// The entry vector has been deleted. We have to create a new entry vector.
-		entry, err := ph.PickStartNode(ctx, c, vec)
+		entry, err := ph.calculateNewEntryVec(ctx, c, vec)
 		if err != nil {
-			return 0, []*index.KeyValue{}, err
+			// No other node exists, go with the new node that has come
+			return create_edges(inUuid)
 		}
 		return create_edges(entry)
 	}

--- a/worker/draft.go
+++ b/worker/draft.go
@@ -549,12 +549,16 @@ func (n *node) applyMutations(ctx context.Context, proposal *pb.Proposal) (rerr 
 			errCh <- process(m.Edges[start:end])
 		}(start, end)
 	}
+	var errs error
 	for i := 0; i < numGo; i++ {
 		if err := <-errCh; err != nil {
-			return err
+			if errs == nil {
+				errs = errors.New("Got error while running mutation")
+			}
+			errs = errors.Wrapf(err, errs.Error())
 		}
 	}
-	return nil
+	return errs
 }
 
 func (n *node) applyCommitted(proposal *pb.Proposal, key uint64) error {

--- a/worker/draft.go
+++ b/worker/draft.go
@@ -843,7 +843,9 @@ func (n *node) commitOrAbort(pkey uint64, delta *pb.OracleDelta) error {
 		if txn == nil {
 			return
 		}
-		txn.Update()
+		if commit != 0 {
+			txn.Update()
+		}
 		// We start with 20 ms, so that we end up waiting 5 mins by the end.
 		// If there is any transient issue, it should get fixed within that timeframe.
 		err := x.ExponentialRetry(int(x.Config.MaxRetries),

--- a/worker/mutation.go
+++ b/worker/mutation.go
@@ -950,7 +950,9 @@ func (w *grpcWorker) proposeAndWait(ctx context.Context, txnCtx *api.TxnContext,
 
 	node := groups().Node
 	err := node.proposeAndWait(ctx, &pb.Proposal{Mutations: m})
-	fillTxnContext(txnCtx, m.StartTs)
+	if err == nil {
+		fillTxnContext(txnCtx, m.StartTs)
+	}
 	return err
 }
 

--- a/worker/mutation.go
+++ b/worker/mutation.go
@@ -642,9 +642,9 @@ func Timestamps(ctx context.Context, num *pb.Num) (*pb.AssignedIds, error) {
 	return c.Timestamps(ctx, num)
 }
 
-func fillTxnContext(tctx *api.TxnContext, startTs uint64) {
+func fillTxnContext(tctx *api.TxnContext, startTs uint64, isErrored bool) {
 	if txn := posting.Oracle().GetTxn(startTs); txn != nil {
-		txn.FillContext(tctx, groups().groupId())
+		txn.FillContext(tctx, groups().groupId(), isErrored)
 	}
 	// We do not need to fill linread mechanism anymore, because transaction
 	// start ts is sufficient to wait for, to achieve lin reads.
@@ -950,9 +950,8 @@ func (w *grpcWorker) proposeAndWait(ctx context.Context, txnCtx *api.TxnContext,
 
 	node := groups().Node
 	err := node.proposeAndWait(ctx, &pb.Proposal{Mutations: m})
-	if err == nil {
-		fillTxnContext(txnCtx, m.StartTs)
-	}
+	// When we are filling txn context, we don't need to update latest delta if the transaction has failed.
+	fillTxnContext(txnCtx, m.StartTs, err != nil)
 	return err
 }
 


### PR DESCRIPTION
We call txn.Update() once the transaction has finished. This moves all the uncommited posting lists to a delta map in the txn. This can cause a deadlock with runMutation. Mostly we have seen it when a transaction has a timeout. RunMutation keeps on going, while txn.Update() gets triggered. This PR fixes it by not calling txn.Update() if the transaction has failed. We would futher look into cancelling runMutation at that time too. 

Fixes: https://linear.app/hypermode/issue/DGR-477/dgraph-v24-alpha-2-hangs
