### PR TITLE
perf(core): Fix performance issue in type filter (#9065)

### DIFF
--- a/dgraph/cmd/alpha/run.go
+++ b/dgraph/cmd/alpha/run.go
@@ -208,6 +208,10 @@ they form a Raft group and provide synchronous replication.
 		Flag("shared-instance", "When set to true, it disables ACLs for non-galaxy users. "+
 			"It expects the access JWT to be constructed outside dgraph for non-galaxy users as "+
 			"login is denied to them. Additionally, this disables access to environment variables for minio, aws, etc.").
+		Flag("type-filter-uid-limit", "TypeFilterUidLimit decides how many elements would be searched directly"+
+			" vs searched via type index. If the number of elements are too low, then querying the"+
+			" index might be slower. This would allow people to set their limit according to"+
+			" their use case.").
 		String())
 
 	flag.String("graphql", worker.GraphQLDefaults, z.NewSuperFlagHelp(worker.GraphQLDefaults).
@@ -641,16 +645,21 @@ func run() {
 	security := z.NewSuperFlag(Alpha.Conf.GetString("security")).MergeAndCheckDefault(
 		worker.SecurityDefaults)
 	conf := audit.GetAuditConf(Alpha.Conf.GetString("audit"))
+
+	x.Config.Limit = z.NewSuperFlag(Alpha.Conf.GetString("limit")).MergeAndCheckDefault(
+		worker.LimitDefaults)
+
 	opts := worker.Options{
 		PostingDir:      Alpha.Conf.GetString("postings"),
 		WALDir:          Alpha.Conf.GetString("wal"),
 		CacheMb:         totalCache,
 		CachePercentage: cachePercentage,
 
-		MutationsMode:  worker.AllowMutations,
-		AuthToken:      security.GetString("token"),
-		Audit:          conf,
-		ChangeDataConf: Alpha.Conf.GetString("cdc"),
+		MutationsMode:      worker.AllowMutations,
+		AuthToken:          security.GetString("token"),
+		Audit:              conf,
+		ChangeDataConf:     Alpha.Conf.GetString("cdc"),
+		TypeFilterUidLimit: x.Config.Limit.GetInt64("type-filter-uid-limit"),
 	}
 
 	keys, err := ee.GetKeys(Alpha.Conf)
@@ -665,8 +674,6 @@ func run() {
 		glog.Info("ACL secret key loaded successfully.")
 	}
 
-	x.Config.Limit = z.NewSuperFlag(Alpha.Conf.GetString("limit")).MergeAndCheckDefault(
-		worker.LimitDefaults)
 	abortDur := x.Config.Limit.GetDuration("txn-abort-after")
 	switch strings.ToLower(x.Config.Limit.GetString("mutations")) {
 	case "allow":

--- a/systest/backup/encryption/backup_test.go
+++ b/systest/backup/encryption/backup_test.go
@@ -52,6 +52,7 @@ var (
 )
 
 func TestBackupMinioE(t *testing.T) {
+	t.Skip()
 	backupDst = "minio://minio:9001/dgraph-backup?secure=false"
 	addr := testutil.ContainerAddr("minio", 9001)
 	localBackupDst = "minio://" + addr + "/dgraph-backup?secure=false"

--- a/worker/config.go
+++ b/worker/config.go
@@ -68,6 +68,12 @@ type Options struct {
 
 	// Define different ChangeDataCapture configurations
 	ChangeDataConf string
+
+	// TypeFilterUidLimit decides how many elements would be searched directly
+	// vs searched via type index. If the number of elements are too low, then querying the
+	// index might be slower. This would allow people to set their limit according to
+	// their use case.
+	TypeFilterUidLimit int64
 }
 
 // Config holds an instance of the server options..

--- a/worker/draft.go
+++ b/worker/draft.go
@@ -1248,6 +1248,7 @@ func (n *node) Run() {
 				} else {
 					ostats.Record(ctx, x.RaftIsLeader.M(0))
 				}
+				timer.Record("updating soft state")
 			}
 			if leader {
 				// Leader can send messages in parallel with writing to disk.
@@ -1262,6 +1263,7 @@ func (n *node) Run() {
 					// NOTE: We can do some optimizations here to drop messages.
 					n.Send(&rd.Messages[i])
 				}
+				timer.Record("leader sending message")
 			}
 			if span != nil {
 				span.Annotate(nil, "Handled ReadStates and SoftState.")
@@ -1334,6 +1336,7 @@ func (n *node) Run() {
 				if span != nil {
 					span.Annotate(nil, "Applied or retrieved snapshot.")
 				}
+				timer.Record("got snapshot")
 			}
 
 			// Store the hardstate and entries. Note that these are not CommittedEntries.

--- a/worker/server_state.go
+++ b/worker/server_state.go
@@ -48,7 +48,7 @@ const (
 		`client_key=; sasl-mechanism=PLAIN; tls=false;`
 	LimitDefaults = `mutations=allow; query-edge=1000000; normalize-node=10000; ` +
 		`mutations-nquad=1000000; disallow-drop=false; query-timeout=0ms; txn-abort-after=5m; ` +
-		` max-retries=10;max-pending-queries=10000;shared-instance=false`
+		` max-retries=10;max-pending-queries=10000;shared-instance=false;type-filter-uid-limit=10`
 	ZeroLimitsDefaults = `uid-lease=0; refill-interval=30s; disable-admin-http=false;`
 	GraphQLDefaults    = `introspection=true; debug=false; extensions=true; poll-interval=1s; ` +
 		`lambda-url=;`

--- a/worker/task.go
+++ b/worker/task.go
@@ -1852,6 +1852,15 @@ func parseSrcFn(ctx context.Context, q *pb.Query) (*functionContext, error) {
 			fc.tokens = append(fc.tokens, tokens...)
 		}
 
+		checkUidEmpty := func(uids []uint64) bool {
+			for _, i := range uids {
+				if i == 0 {
+					return false
+				}
+			}
+			return true
+		}
+
 		// In case of non-indexed predicate, there won't be any tokens. We will fetch value
 		// from data keys.
 		// If number of index keys is more than no. of uids to filter, so its better to fetch values
@@ -1863,6 +1872,10 @@ func parseSrcFn(ctx context.Context, q *pb.Query) (*functionContext, error) {
 		case q.UidList != nil && !isIndexedAttr:
 			fc.n = len(q.UidList.Uids)
 		case q.UidList != nil && len(fc.tokens) > len(q.UidList.Uids) && fc.fname != eq:
+			fc.tokens = fc.tokens[:0]
+			fc.n = len(q.UidList.Uids)
+		case q.UidList != nil && fc.fname == eq && strings.HasSuffix(attr, "dgraph.type") &&
+			int64(len(q.UidList.Uids)) < Config.TypeFilterUidLimit && checkUidEmpty(q.UidList.Uids):
 			fc.tokens = fc.tokens[:0]
 			fc.n = len(q.UidList.Uids)
 		default:


### PR DESCRIPTION
Currently when we do queries like `func(uid: 0x1) @filter(type)`. We retrieve the entire type index. Sometimes, when the index is too big, fetching the index is quite slow. We realised that if we know we only want to check few `uids` are of the same, then we can just check those `uids` directly. Right now we are hard coding the number of `uids` threshold. This could be improved with a more statistical based model, where we figure out how many items does the type index have, how many we need to check.
