### PR TITLE
fix(core): Fix regression in parsing json empty string

### DIFF
--- a/chunker/json_parser.go
+++ b/chunker/json_parser.go
@@ -230,7 +230,7 @@ func handleBasicType(k string, v interface{}, op int, nq *api.NQuad) error {
 			return nil
 		}
 
-		if vf, err := types.ParseVFloat(v); err == nil {
+		if vf, err := types.ParseVFloat(v); err == nil && len(vf) != 0 {
 			nq.ObjectValue = &api.Value{Val: &api.Value_Vfloat32Val{Vfloat32Val: types.FloatArrayAsBytes(vf)}}
 			return nil
 		}


### PR DESCRIPTION
Currently when we parse an empty string, a json empty array is returned. This is a regression. This diff fixes it. We disallow any vector of empty length. 