### PR TITLE
fix(multi-tenancy): upsert groot for namespace after drop data

### DIFF
--- a/edgraph/access_ee.go
+++ b/edgraph/access_ee.go
@@ -440,6 +440,26 @@ func InitializeAcl(closer *z.Closer) {
 	upsertGuardianAndGroot(closer, x.GalaxyNamespace)
 }
 
+func RestoreGuardianAndGroot(ctx context.Context, passwd string) {
+	for ctx.Err() == nil {
+		if err := upsertGuardian(ctx); err != nil {
+			glog.Infof("Unable to upsert the guardian group. Error: %v", err)
+			time.Sleep(100 * time.Millisecond)
+			continue
+		}
+		break
+	}
+
+	for ctx.Err() == nil {
+		if err := upsertGroot(ctx, passwd); err != nil {
+			glog.Infof("Unable to upsert the groot account. Error: %v", err)
+			time.Sleep(100 * time.Millisecond)
+			continue
+		}
+		break
+	}
+}
+
 // Note: The handling of closer should be done by caller.
 func upsertGuardianAndGroot(closer *z.Closer, ns uint64) {
 	if worker.Config.AclSecretKey == nil {

--- a/edgraph/server.go
+++ b/edgraph/server.go
@@ -428,7 +428,8 @@ func (s *Server) Alter(ctx context.Context, op *api.Operation) (*api.Payload, er
 		// reset their in-memory GraphQL schema
 		_, err = UpdateGQLSchema(ctx, "", "")
 		// recreate the admin account after a drop all operation
-		InitializeAcl(nil)
+		// InitializeAcl(nil)
+		RestoreGuardianAndGroot(ctx, "password")
 		return empty, err
 	}
 
@@ -459,7 +460,8 @@ func (s *Server) Alter(ctx context.Context, op *api.Operation) (*api.Payload, er
 		// just reinsert the GraphQL schema, no need to alter dgraph schema as this was drop_data
 		_, err = UpdateGQLSchema(ctx, graphQLSchema, "")
 		// recreate the admin account after a drop data operation
-		InitializeAcl(nil)
+		// InitializeAcl(nil)
+		RestoreGuardianAndGroot(ctx, "password")
 		return empty, err
 	}
 


### PR DESCRIPTION
Description: After executing drop data in a namespace, the namespace cannot be logged in anymore

1. drop data of a namespace

```bash
curl --location 'http://localhost:8080/alter' \
--header 'X-Dgraph-AccessToken: accesstoken' \
--header 'Content-Type: text/plain' \
--data '{"drop_op": "DATA"}
'
```

2. login the namespace again

```bash
curl --location 'http://127.0.0.1:8080/login' \
--header 'Content-Type: application/json' \
--data '{
    "userid": "groot",
    "password": "password",
    "namespace": 1
}'
```

3. get error message `Authentication from address10.42.0.1:55404 failed: unable to authenticate: invalidi credentials`

function `InitializeAcl` only upsert groot for namespace 0