### PR TITLE
Fix(graphql): issue with local variable squashing intended JWK index

### DIFF
--- a/graphql/authorization/auth.go
+++ b/graphql/authorization/auth.go
@@ -513,7 +513,7 @@ func (a *AuthMeta) FetchJWK(i int) error {
 
 func (a *AuthMeta) refreshJWK(i int) error {
 	var err error
-	for i := 0; i < 3; i++ {
+	for n := 0; n < 3; n++ {
 		err = a.FetchJWK(i)
 		if err == nil {
 			return nil


### PR DESCRIPTION
A logic error (redeclaring `i` in the loop) in this method disabled the intension of the method: try 3 times to fetch the *i-th* JWK
