### PR TITLE
fix(core): Fix namespace used by unique query generator

### DIFF
--- a/ee/acl/acl_integration_test.go
+++ b/ee/acl/acl_integration_test.go
@@ -482,7 +482,7 @@ func (asuite *AclTestSuite) TestACLDuplicateGrootUser() {
 	         _:a <dgraph.type> "dgraph.type.User"  .`
 
 	mu := &api.Mutation{SetNquads: []byte(rdfs), CommitNow: true}
-	_, err := gc.Mutate(mu)
+	_, err = gc.Mutate(mu)
 	require.Error(t, err)
 	require.ErrorContains(t, err, "could not insert duplicate value [groot] for predicate [dgraph.xid]")
 }


### PR DESCRIPTION
Currently namespace used by unique generator uses edge predicate to validate. This shouldn't be the case, we should use the namespace provided in context. 