### PR TITLE
chore(): add Dependabot version bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "wednesday"
+      time: "16:00"
+    rebase-strategy: "disabled"
+    groups:
+      patch:
+        update-types: ["patch"]
+      minor:
+        update-types: ["minor"]
+
+  - package-ecosystem: "github-actions"
+    # Workflow files stored in the default location of `.github/workflows`. (You don't need to specify `/.github/workflows` for `directory`. You can use `directory: "/"`.)
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: wednesday
+      time: "16:00"


### PR DESCRIPTION
add Dependabot automated version bumps; behavior is configured as:
- group all patch version bumps into one PR
- group all minor version bumps into one PR
- open individual PRs for all major version bumps
