### PR TITLE
fix(vector): fix index rebuild when options change

### DIFF
--- a/query/vector/vector_graphql_test.go
+++ b/query/vector/vector_graphql_test.go
@@ -170,7 +170,7 @@ func TestVectorGraphQLAddVectorPredicate(t *testing.T) {
 	require.NoError(t, err)
 	hc.LoginIntoNamespace("groot", "password", 0)
 	// add schema
-	require.NoError(t, hc.UpdateGQLSchema(fmt.Sprintf(graphQLVectorSchema, "euclidean")))
+	require.NoError(t, hc.UpdateGQLSchema(fmt.Sprintf(graphQLVectorSchema, "euclidian")))
 }
 
 func TestVectorSchema(t *testing.T) {
@@ -188,7 +188,7 @@ func TestVectorSchema(t *testing.T) {
 
 	// add schema
 	require.NoError(t, hc.UpdateGQLSchema(schema))
-	require.Error(t, hc.UpdateGQLSchema(fmt.Sprintf(graphQLVectorSchema, "euclidean")))
+	require.Error(t, hc.UpdateGQLSchema(fmt.Sprintf(graphQLVectorSchema, "euclidian")))
 }
 
 func TestVectorGraphQlEuclidianIndexMutationAndQuery(t *testing.T) {
@@ -197,7 +197,7 @@ func TestVectorGraphQlEuclidianIndexMutationAndQuery(t *testing.T) {
 	require.NoError(t, err)
 	hc.LoginIntoNamespace("groot", "password", 0)
 
-	schema := fmt.Sprintf(graphQLVectorSchema, "euclidean")
+	schema := fmt.Sprintf(graphQLVectorSchema, "euclidian")
 	// add schema
 	require.NoError(t, hc.UpdateGQLSchema(schema))
 	testVectorGraphQlMutationAndQuery(t, hc)

--- a/tok/hnsw/persistent_factory.go
+++ b/tok/hnsw/persistent_factory.go
@@ -19,6 +19,7 @@
 package hnsw
 
 import (
+	"fmt"
 	"sync"
 
 	c "github.com/dgraph-io/dgraph/v24/tok/constraints"
@@ -80,6 +81,9 @@ func (hf *persistentIndexFactory[T]) AllowedOptions() opt.AllowedOptions {
 		AddIntOption(EfConstructionOpt).
 		AddIntOption(EfSearchOpt)
 	getSimFunc := func(optValue string) (any, error) {
+		if optValue != Euclidian && optValue != Cosine && optValue != DotProd {
+			return nil, errors.New(fmt.Sprintf("Can't create a vector index for %s", optValue))
+		}
 		return GetSimType[T](optValue, hf.floatBits), nil
 	}
 


### PR DESCRIPTION
Currently when we rebuild vector index, it only works if you drop it and then add again. With this change, you will be able to rebuild index by changing parameters.
We are also restricting vector index to only work with proper distance metric. 