### PR TITLE
fix(core): Update error msg for txn too old to give more context

### DIFF
--- a/posting/index.go
+++ b/posting/index.go
@@ -243,7 +243,7 @@ func (txn *Txn) addReverseMutationHelper(ctx context.Context, plist *List,
 	if hasCountIndex {
 		countBefore, found, _ = plist.getPostingAndLengthNoSort(txn.StartTs, 0, edge.ValueId)
 		if countBefore == -1 {
-			return emptyCountParams, ErrTsTooOld
+			return emptyCountParams, errors.Wrapf(ErrTsTooOld, "Adding reverse mutation helper count")
 		}
 	}
 	if err := plist.addMutationInternal(ctx, txn, edge); err != nil {
@@ -505,7 +505,7 @@ func (txn *Txn) addMutationHelper(ctx context.Context, l *List, doUpdateIndex bo
 	case hasCountIndex:
 		countBefore, found, currPost = l.getPostingAndLength(txn.StartTs, 0, getUID(t))
 		if countBefore == -1 {
-			return val, false, emptyCountParams, ErrTsTooOld
+			return val, false, emptyCountParams, errors.Wrapf(ErrTsTooOld, "Add mutation count index")
 		}
 	case doUpdateIndex || delNonListPredicate:
 		found, currPost, err = l.findPosting(txn.StartTs, fingerprintEdge(t))

--- a/posting/list.go
+++ b/posting/list.go
@@ -1278,7 +1278,7 @@ func (l *List) Uids(opt ListOptions) (*pb.List, error) {
 	if len(l.mutationMap) == 0 && opt.Intersect != nil && len(l.plist.Splits) == 0 {
 		if opt.ReadTs < l.minTs {
 			l.RUnlock()
-			return out, ErrTsTooOld
+			return out, errors.Wrapf(ErrTsTooOld, "While reading UIDs")
 		}
 		algo.IntersectCompressedWith(l.plist.Pack, opt.AfterUid, opt.Intersect, out)
 		l.RUnlock()

--- a/posting/mvcc.go
+++ b/posting/mvcc.go
@@ -195,7 +195,7 @@ func (ir *incrRollupi) Process(closer *z.Closer, getNewTs func(bool) uint64) {
 		currTs := time.Now().Unix()
 		for _, key := range *batch {
 			hash := z.MemHash(key)
-			if elem := m[hash]; currTs-elem >= 2 {
+			if elem := m[hash]; currTs-elem >= 10 {
 				// Key not present or Key present but last roll up was more than 2 sec ago.
 				// Add/Update map and rollup.
 				m[hash] = currTs

--- a/worker/task.go
+++ b/worker/task.go
@@ -854,7 +854,7 @@ func (qs *queryState) handleUidPostings(
 				}
 				len := pl.Length(args.q.ReadTs, 0)
 				if len == -1 {
-					return posting.ErrTsTooOld
+					return error.Wrapf(posting.ErrTsTooOld, "While reading posting list length")
 				}
 				count := int64(len)
 				if evalCompare(srcFn.fname, count, srcFn.threshold[0]) {

--- a/worker/task.go
+++ b/worker/task.go
@@ -854,7 +854,7 @@ func (qs *queryState) handleUidPostings(
 				}
 				len := pl.Length(args.q.ReadTs, 0)
 				if len == -1 {
-					return error.Wrapf(posting.ErrTsTooOld, "While reading posting list length")
+					return errors.Wrapf(posting.ErrTsTooOld, "While reading posting list length")
 				}
 				count := int64(len)
 				if evalCompare(srcFn.fname, count, srcFn.threshold[0]) {


### PR DESCRIPTION
Update rollup frequency so that txn too old error doesn't happen too frequently. 
Also added more context to the error to see where it's coming from. 