### PR TITLE
build: Fix OSS build

### DIFF
--- a/ee/keys.go
+++ b/ee/keys.go
@@ -20,15 +20,12 @@
 package ee
 
 import (
-	"fmt"
-
 	"github.com/spf13/viper"
 )
 
 // GetKeys returns the ACL and encryption keys as configured by the user
 // through the --acl, --encryption, and --vault flags. On OSS builds,
-// this function always returns an error.
+// this function always returns an empty struct.
 func GetKeys(config *viper.Viper) (*Keys, error) {
-	return nil, fmt.Errorf(
-		"flags: acl / encryption is an enterprise-only feature")
+	return &Keys{}, nil
 }


### PR DESCRIPTION
Perhaps my misunderstanding, but running "make install_oss" fails on the main repo, as e.g. on line 665 of dgraph/cmd/alpha/run.go calls ee.GetKeys, which will always return an error in OSS mode.  This change returns an empty struct instead of an error, allowing the build to complete.