### PR TITLE
chore(repo): use go 1.22 int range loop

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -37,3 +37,4 @@ linters:
     - staticcheck
     - unconvert
     - unused
+    - intrange

--- a/algo/packed.go
+++ b/algo/packed.go
@@ -333,7 +333,7 @@ func IndexOfPacked(u *pb.UidPack, uid uint64) int {
 	}
 
 	index += uidx
-	for i := 0; i < decoder.BlockIdx(); i++ {
+	for i := range decoder.BlockIdx() {
 		index += int(u.Blocks[i].GetNumUids())
 	}
 

--- a/algo/packed_test.go
+++ b/algo/packed_test.go
@@ -320,12 +320,12 @@ func TestSubSorted6Packed(t *testing.T) {
 
 func TestIndexOfPacked1(t *testing.T) {
 	encoder := codec.Encoder{BlockSize: 10}
-	for i := 0; i < 1000; i++ {
+	for i := range 1000 {
 		encoder.Add(uint64(i))
 	}
 	pack := encoder.Done()
 
-	for i := 0; i < 1000; i++ {
+	for i := range 1000 {
 		require.Equal(t, i, IndexOfPacked(pack, uint64(i)))
 	}
 	require.Equal(t, -1, IndexOfPacked(pack, 1000))
@@ -333,7 +333,7 @@ func TestIndexOfPacked1(t *testing.T) {
 
 func TestIndexOfPacked2(t *testing.T) {
 	encoder := codec.Encoder{BlockSize: 10}
-	for i := 0; i < 100; i++ {
+	for i := range 100 {
 		encoder.Add(uint64(i))
 	}
 	pack := encoder.Done()

--- a/algo/uidlist_test.go
+++ b/algo/uidlist_test.go
@@ -316,7 +316,7 @@ func BenchmarkListIntersectRandom(b *testing.B) {
 	randomTests := func(arrSz int, overlap float64) {
 		limit := int64(float64(arrSz) / overlap)
 		u1, v1 := make([]uint64, arrSz), make([]uint64, arrSz)
-		for i := 0; i < arrSz; i++ {
+		for i := range arrSz {
 			u1[i] = uint64(rand.Int63n(limit))
 			v1[i] = uint64(rand.Int63n(limit))
 		}
@@ -379,10 +379,10 @@ func BenchmarkListIntersectCompressBin(b *testing.B) {
 
 			u1, v1 := make([]uint64, sz1), make([]uint64, sz2)
 			limit := int64(float64(sz) / overlap)
-			for i := 0; i < sz1; i++ {
+			for i := range sz1 {
 				u1[i] = uint64(rand.Int63n(limit))
 			}
-			for i := 0; i < sz2; i++ {
+			for i := range sz2 {
 				v1[i] = uint64(rand.Int63n(limit))
 			}
 			sort.Slice(u1, func(i, j int) bool { return u1[i] < u1[j] })
@@ -434,10 +434,10 @@ func BenchmarkListIntersectRatio(b *testing.B) {
 
 			u1, v1 := make([]uint64, sz1), make([]uint64, sz2)
 			limit := int64(float64(sz) / overlap)
-			for i := 0; i < sz1; i++ {
+			for i := range sz1 {
 				u1[i] = uint64(rand.Int63n(limit))
 			}
-			for i := 0; i < sz2; i++ {
+			for i := range sz2 {
 				v1[i] = uint64(rand.Int63n(limit))
 			}
 			sort.Slice(u1, func(i, j int) bool { return u1[i] < u1[j] })
@@ -510,7 +510,7 @@ func fillNumsDiff(N1, N2, N3 int) ([]uint64, []uint64, []uint64) {
 	otherNums := make([]uint64, N1+N3)
 	allC := make(map[uint64]bool)
 
-	for i := 0; i < N1; i++ {
+	for i := range N1 {
 		val := rand.Uint64() % 1000
 		commonNums[i] = val
 		blockNums[i] = val
@@ -546,7 +546,7 @@ func fillNums(N1, N2 int) ([]uint64, []uint64, []uint64) {
 	blockNums := make([]uint64, N1+N2)
 	otherNums := make([]uint64, N1+N2)
 
-	for i := 0; i < N1; i++ {
+	for i := range N1 {
 		val := rand.Uint64()
 		commonNums[i] = val
 		blockNums[i] = val

--- a/chunker/chunk.go
+++ b/chunker/chunk.go
@@ -97,7 +97,7 @@ func NewChunker(inputFormat InputFormat, batchSize int) Chunker {
 func (*rdfChunker) Chunk(r *bufio.Reader) (*bytes.Buffer, error) {
 	batch := new(bytes.Buffer)
 	batch.Grow(1 << 20)
-	for lineCount := 0; lineCount < 1e5; lineCount++ {
+	for range 100000 {
 		slc, err := r.ReadSlice('\n')
 		if err == io.EOF {
 			if _, err := batch.Write(slc); err != nil {

--- a/codec/benchmark/benchmark.go
+++ b/codec/benchmark/benchmark.go
@@ -156,7 +156,7 @@ func benchmarkUnpack(trials int, chunks *chunks) int {
 	for i, c := range chunks.data {
 		out := codec.Decode(packed[i], 0)
 
-		for j := 0; j < len(c); j++ {
+		for j := range c {
 			if c[j] != out[j] {
 				x.Fatalf("Something wrong %+v \n%+v\n %+v\n", len(c), len(out), j)
 			}

--- a/codec/codec.go
+++ b/codec/codec.go
@@ -85,7 +85,7 @@ func (e *Encoder) packBlock() {
 	buf := make([]byte, 17)
 	tmpUids := make([]uint32, 4)
 	for {
-		for i := 0; i < 4; i++ {
+		for i := range 4 {
 			if i >= len(e.uids) {
 				// Padding with '0' because Encode4 encodes only in batch of 4.
 				tmpUids[i] = 0
@@ -199,7 +199,7 @@ func (d *Decoder) UnpackBlock() []uint64 {
 
 		groupvarint.Decode4(tmpUids, encData)
 		encData = encData[groupvarint.BytesUsed[encData[0]]:]
-		for i := 0; i < 4; i++ {
+		for i := range 4 {
 			sum = last + uint64(tmpUids[i])
 			d.uids = append(d.uids, sum)
 			last = sum

--- a/codec/codec_test.go
+++ b/codec/codec_test.go
@@ -54,7 +54,7 @@ func TestUidPack(t *testing.T) {
 	require.Equal(t, 0, ApproxLen(&pb.UidPack{}))
 	require.Equal(t, 0, len(Decode(&pb.UidPack{}, 0)))
 
-	for i := 0; i < 13; i++ {
+	for range 13 {
 		size := rand.Intn(10e6)
 		if size < 0 {
 			size = 1e6
@@ -86,7 +86,7 @@ func TestBufferUidPack(t *testing.T) {
 	require.Equal(t, 0, buf.LenNoPadding())
 	require.NoError(t, buf.Release())
 
-	for i := 0; i < 13; i++ {
+	for range 13 {
 		size := rand.Intn(10e6)
 		if size < 0 {
 			size = 1e6
@@ -335,7 +335,7 @@ func TestEncoding(t *testing.T) {
 	rand.Seed(time.Now().UnixNano())
 	var lengths = []int{0, 1, 2, 3, 5, 13, 18, 100, 99, 98}
 
-	for tc := 0; tc < len(lengths); tc++ {
+	for tc := range lengths {
 		ints := make([]uint64, lengths[tc])
 
 		for i := 0; i < 50 && i < lengths[tc]; i++ {

--- a/conn/node_test.go
+++ b/conn/node_test.go
@@ -75,7 +75,7 @@ func TestProposal(t *testing.T) {
 	wg.Add(loop)
 	go n.run(&wg)
 
-	for i := 0; i < loop; i++ {
+	for i := range loop {
 		data := []byte(fmt.Sprintf("hey-%d", i))
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()

--- a/contrib/integration/acctupsert/main.go
+++ b/contrib/integration/acctupsert/main.go
@@ -100,7 +100,7 @@ func doUpserts(c *dgo.Dgraph) {
 	var wg sync.WaitGroup
 	wg.Add(len(accounts) * *concurr)
 	for _, acct := range accounts {
-		for i := 0; i < *concurr; i++ {
+		for range *concurr {
 			go func(acct account) {
 				upsert(c, acct)
 				wg.Done()

--- a/contrib/integration/bank/main.go
+++ b/contrib/integration/bank/main.go
@@ -374,7 +374,7 @@ func main() {
 	s.createAccounts(clients[0])
 
 	var wg sync.WaitGroup
-	for i := 0; i < *conc; i++ {
+	for range *conc {
 		for _, dg := range clients {
 			wg.Add(1)
 			go s.loop(dg, &wg)

--- a/contrib/integration/bigdata/main.go
+++ b/contrib/integration/bigdata/main.go
@@ -74,7 +74,7 @@ func main() {
 	case "mutate":
 		var errCount int64
 		var mutateCount int64
-		for i := 0; i < *conc; i++ {
+		for range *conc {
 			go func() {
 				for {
 					err := mutate(c)
@@ -94,7 +94,7 @@ func main() {
 	case "query":
 		var errCount int64
 		var queryCount int64
-		for i := 0; i < *conc; i++ {
+		for range *conc {
 			go func() {
 				for {
 					err := showNode(c)

--- a/contrib/integration/swap/main.go
+++ b/contrib/integration/swap/main.go
@@ -104,7 +104,7 @@ func main() {
 	done := make(chan struct{})
 	go func() {
 		pending := make(chan struct{}, *concurr)
-		for i := 0; i < *numSwaps; i++ {
+		for range *numSwaps {
 			pending <- struct{}{}
 			go func() {
 				swapSentences(c,
@@ -114,7 +114,7 @@ func main() {
 				<-pending
 			}()
 		}
-		for i := 0; i < *concurr; i++ {
+		for range *concurr {
 			pending <- struct{}{}
 		}
 		close(done)
@@ -343,7 +343,7 @@ func checkInvariants(c *dgo.Dgraph, uids []string, sentences []string) error {
 		}
 	}
 	sort.Strings(gotSentences)
-	for i := 0; i < len(sentences); i++ {
+	for i := range sentences {
 		if sentences[i] != gotSentences[i] {
 			fmt.Printf("Sentence doesn't match. Wanted: %q. Got: %q\n", sentences[i], gotSentences[i])
 			fmt.Printf("All sentences: %v\n", sentences)

--- a/dgraph/cmd/bulk/loader.go
+++ b/dgraph/cmd/bulk/loader.go
@@ -144,7 +144,7 @@ func newLoader(opt *options) *loader {
 		mappers: make([]*mapper, opt.NumGoroutines),
 		zero:    zero,
 	}
-	for i := 0; i < opt.NumGoroutines; i++ {
+	for i := range opt.NumGoroutines {
 		ld.mappers[i] = newMapper(st)
 	}
 	go ld.prog.report()

--- a/dgraph/cmd/bulk/merge_shards.go
+++ b/dgraph/cmd/bulk/merge_shards.go
@@ -52,7 +52,7 @@ func mergeMapShardsIntoReduceShards(opt *options) {
 	sortBySize(shardDirs)
 
 	var reduceShards []string
-	for i := 0; i < opt.ReduceShards; i++ {
+	for i := range opt.ReduceShards {
 		shardDir := filepath.Join(opt.TmpDir, reduceShardDir, fmt.Sprintf("shard_%d", i))
 		x.Check(os.MkdirAll(shardDir, 0750))
 		reduceShards = append(reduceShards, shardDir)

--- a/dgraph/cmd/bulk/reduce.go
+++ b/dgraph/cmd/bulk/reduce.go
@@ -61,7 +61,7 @@ func (r *reducer) run() error {
 	x.AssertTrue(len(r.opt.shardOutputDirs) == r.opt.ReduceShards)
 
 	thr := y.NewThrottle(r.opt.NumReducers)
-	for i := 0; i < r.opt.ReduceShards; i++ {
+	for i := range r.opt.ReduceShards {
 		if err := thr.Do(); err != nil {
 			return err
 		}
@@ -465,7 +465,7 @@ func (r *reducer) reduce(partitionKeys [][]byte, mapItrs []*mapIterator, ci *cou
 	encoderCh := make(chan *encodeRequest, 2*cpu)
 	writerCh := make(chan *encodeRequest, 2*cpu)
 	encoderCloser := z.NewCloser(cpu)
-	for i := 0; i < cpu; i++ {
+	for range cpu {
 		// Start listening to encode entries
 		// For time being let's lease 100 stream id for each encoder.
 		go r.encode(encoderCh, encoderCloser)
@@ -500,7 +500,7 @@ func (r *reducer) reduce(partitionKeys [][]byte, mapItrs []*mapIterator, ci *cou
 		// Append nil for the last entries.
 		partitionKeys = append(partitionKeys, nil)
 
-		for i := 0; i < len(partitionKeys); i++ {
+		for i := range partitionKeys {
 			pkey := partitionKeys[i]
 			for _, itr := range mapItrs {
 				itr.Next(cbuf, pkey)

--- a/dgraph/cmd/bulk/run.go
+++ b/dgraph/cmd/bulk/run.go
@@ -289,7 +289,7 @@ func run() {
 
 	// Delete and recreate the output dirs to ensure they are empty.
 	x.Check(os.RemoveAll(opt.OutDir))
-	for i := 0; i < opt.ReduceShards; i++ {
+	for i := range opt.ReduceShards {
 		dir := filepath.Join(opt.OutDir, strconv.Itoa(i), "p")
 		x.Check(os.MkdirAll(dir, 0700))
 		opt.shardOutputDirs = append(opt.shardOutputDirs, dir)

--- a/dgraph/cmd/cert/create.go
+++ b/dgraph/cmd/cert/create.go
@@ -175,7 +175,7 @@ func createCAPair(opt *options) error {
 // which case the path must already exist and be writable.
 // Returns nil on success, or an error otherwise.
 func createNodePair(opt *options) error {
-	if opt.nodes == nil || len(opt.nodes) == 0 {
+	if len(opt.nodes) == 0 {
 		return nil
 	}
 

--- a/dgraph/cmd/debug/run.go
+++ b/dgraph/cmd/debug/run.go
@@ -365,7 +365,7 @@ func jepsen(db *badger.DB) {
 	showAllPostingsAt(db, ts)
 	seekTotal(db, ts-1)
 
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		// Get a few previous commits.
 		_, ts = getMinMax(db, ts-1)
 		showAllPostingsAt(db, ts)

--- a/dgraph/cmd/increment/increment.go
+++ b/dgraph/cmd/increment/increment.go
@@ -218,7 +218,7 @@ func run(conf *viper.Viper) {
 
 	// Run things serially first, if conc > 1.
 	if conc > 1 {
-		for i := 0; i < conc; i++ {
+		for range conc {
 			err := processOne(0)
 			x.Check(err)
 			num--
@@ -241,7 +241,7 @@ func run(conf *viper.Viper) {
 		}
 	}
 
-	for i := 0; i < conc; i++ {
+	for i := range conc {
 		wg.Add(1)
 		go f(i + 1)
 	}

--- a/dgraph/cmd/live/run.go
+++ b/dgraph/cmd/live/run.go
@@ -654,7 +654,7 @@ func setup(opts batchMutationOptions, dc *dgo.Dgraph, conf *viper.Viper) *loader
 	}
 
 	l.requestsWg.Add(opts.Pending)
-	for i := 0; i < opts.Pending; i++ {
+	for range opts.Pending {
 		go l.makeRequests()
 	}
 
@@ -850,7 +850,7 @@ func run() error {
 		go l.printCounters()
 	}
 
-	for i := 0; i < totalFiles; i++ {
+	for range totalFiles {
 		if err := <-errCh; err != nil {
 			fmt.Printf("Error while processing data file %s\n", err)
 			return err

--- a/dgraph/cmd/migrate/utils.go
+++ b/dgraph/cmd/migrate/utils.go
@@ -110,7 +110,7 @@ func getColumnValues(columns []string, dataTypes []dataType,
 	}
 
 	valuePtrs := make([]interface{}, 0, len(columns))
-	for i := 0; i < len(columns); i++ {
+	for i := range columns {
 		switch dataTypes[i] {
 		case stringType:
 			valuePtrs = append(valuePtrs, new([]byte)) // the value can be nil

--- a/dgraph/cmd/zero/raft.go
+++ b/dgraph/cmd/zero/raft.go
@@ -451,7 +451,7 @@ func (n *node) applyProposal(e raftpb.Entry) (uint64, error) {
 		}
 	}
 
-	if p.Tablets != nil && len(p.Tablets) > 0 {
+	if len(p.Tablets) > 0 {
 		if err := n.handleBulkTabletProposal(p.Tablets); err != nil {
 			span.Annotatef(nil, "While applying bulk tablet proposal: %v", err)
 			glog.Errorf("While applying bulk tablet proposal: %v", err)

--- a/dgraphapi/cluster.go
+++ b/dgraphapi/cluster.go
@@ -548,7 +548,7 @@ loop:
 	// and the "loop" will not be able to detect this case. The "loop2" below ensures
 	// by looking into the logs that the restore process has in fact been started and completed.
 loop2:
-	for i := 0; i < 60; i++ {
+	for range 60 {
 		time.Sleep(waitDurBeforeRetry)
 
 		alphasLogs, err := c.AlphasLogs()

--- a/dgraphapi/vector.go
+++ b/dgraphapi/vector.go
@@ -27,7 +27,7 @@ import (
 
 func GenerateRandomVector(size int) []float32 {
 	vector := make([]float32, size)
-	for i := 0; i < size; i++ {
+	for i := range size {
 		vector[i] = rand.Float32() * 10
 	}
 	return vector

--- a/dgraphtest/dcloud_cluster.go
+++ b/dgraphtest/dcloud_cluster.go
@@ -108,7 +108,7 @@ func (c1 *DCloudCluster) AssignUids(client *dgo.Dgraph, num uint64) error {
 	genData := func() []byte {
 		var rdfs bytes.Buffer
 		_, _ = rdfs.WriteString("_:root <test_cloud> \"root\" .\n")
-		for i := 0; i < 1000; i++ {
+		for i := range 1000 {
 			rdfs.WriteString(fmt.Sprintf("_:%v <test_cloud> \"0\" .\n", i))
 		}
 		return rdfs.Bytes()

--- a/dgraphtest/local_cluster.go
+++ b/dgraphtest/local_cluster.go
@@ -143,7 +143,7 @@ func (c *LocalCluster) init() error {
 	}
 
 	c.zeros = c.zeros[:0]
-	for i := 0; i < c.conf.numZeros; i++ {
+	for i := range c.conf.numZeros {
 		zo := &zero{id: i}
 		zo.containerName = fmt.Sprintf(zeroNameFmt, c.conf.prefix, zo.id)
 		zo.aliasName = fmt.Sprintf(zeroAliasNameFmt, zo.id)
@@ -151,7 +151,7 @@ func (c *LocalCluster) init() error {
 	}
 
 	c.alphas = c.alphas[:0]
-	for i := 0; i < c.conf.numAlphas; i++ {
+	for i := range c.conf.numAlphas {
 		aa := &alpha{id: i}
 		aa.containerName = fmt.Sprintf(alphaNameFmt, c.conf.prefix, aa.id)
 		aa.aliasName = fmt.Sprintf(alphaLNameFmt, aa.id)
@@ -380,12 +380,12 @@ func (c *LocalCluster) cleanupDocker() error {
 func (c *LocalCluster) Start() error {
 	log.Printf("[INFO] starting cluster with prefix [%v]", c.conf.prefix)
 	startAll := func() error {
-		for i := 0; i < c.conf.numZeros; i++ {
+		for i := range c.conf.numZeros {
 			if err := c.StartZero(i); err != nil {
 				return err
 			}
 		}
-		for i := 0; i < c.conf.numAlphas; i++ {
+		for i := range c.conf.numAlphas {
 			if err := c.StartAlpha(i); err != nil {
 				return err
 			}
@@ -553,7 +553,7 @@ func (c *LocalCluster) containerHealthCheck(url func(c *LocalCluster) (string, e
 		return errors.Wrap(err, "error getting health URL")
 	}
 
-	for i := 0; i < 60; i++ {
+	for range 60 {
 		time.Sleep(waitDurBeforeRetry)
 
 		endpoint, err = url(c)
@@ -610,7 +610,7 @@ func (c *LocalCluster) waitUntilLogin() error {
 
 	ctx, cancel := context.WithTimeout(context.Background(), requestTimeout)
 	defer cancel()
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		err := client.Login(ctx, dgraphapi.DefaultUser, dgraphapi.DefaultPassword)
 		if err == nil {
 			log.Printf("[INFO] login succeeded")
@@ -633,7 +633,7 @@ func (c *LocalCluster) waitUntilGraphqlHealthCheck() error {
 		}
 	}
 
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		// we do this because before v21, we used to propose the initial schema to the cluster.
 		// This results in schema being applied and indexes being built which could delay alpha
 		// starting to serve graphql schema.

--- a/dql/parser.go
+++ b/dql/parser.go
@@ -712,7 +712,7 @@ func ParseWithNeedVars(r Request, needVars []string) (res Result, rerr error) {
 
 	if len(res.Query) != 0 {
 		res.QueryVars = make([]*Vars, 0, len(res.Query))
-		for i := 0; i < len(res.Query); i++ {
+		for i := range res.Query {
 			qu := res.Query[i]
 			// Try expanding fragments using fragment map.
 			if err := qu.expandFragments(fmap); err != nil {
@@ -790,7 +790,7 @@ func checkDependency(vl []*Vars) error {
 			defines, needs)
 	}
 
-	for i := 0; i < len(defines); i++ {
+	for i := range defines {
 		if defines[i] != needs[i] {
 			return errors.Errorf("Variables are not used properly. \nDefined:%v\nUsed:%v\n",
 				defines, needs)
@@ -3038,7 +3038,7 @@ func godeep(it *lex.ItemIterator, gq *GraphQuery) error {
 		case itemPeriod:
 			// looking for ...
 			dots := 1
-			for i := 0; i < 2; i++ {
+			for range 2 {
 				if it.Next() && it.Item().Typ == itemPeriod {
 					dots++
 				}

--- a/graphql/authorization/auth.go
+++ b/graphql/authorization/auth.go
@@ -292,7 +292,7 @@ func (c *CustomClaims) UnmarshalJSON(data []byte) error {
 
 func (c *CustomClaims) validateAudience() error {
 	// If there's no audience claim, ignore
-	if c.Audience == nil || len(c.Audience) == 0 {
+	if len(c.Audience) == 0 {
 		return nil
 	}
 
@@ -353,7 +353,7 @@ func GetJwtToken(ctx context.Context) string {
 func (a *AuthMeta) validateThroughJWKUrl(jwtStr string) (*jwt.Token, error) {
 	var err error
 	var token *jwt.Token
-	for i := 0; i < len(a.JWKUrls); i++ {
+	for i := range a.JWKUrls {
 		if a.isExpired(i) {
 			err = a.refreshJWK(i)
 			if err != nil {
@@ -441,7 +441,7 @@ func (a *AuthMeta) FetchJWKs() error {
 		return errors.Errorf("No JWKUrl supplied")
 	}
 
-	for i := 0; i < len(a.JWKUrls); i++ {
+	for i := range a.JWKUrls {
 		err := a.FetchJWK(i)
 		if err != nil {
 			return err
@@ -513,7 +513,7 @@ func (a *AuthMeta) FetchJWK(i int) error {
 
 func (a *AuthMeta) refreshJWK(i int) error {
 	var err error
-	for n := 0; n < 3; n++ {
+	for range 3 {
 		err = a.FetchJWK(i)
 		if err == nil {
 			return nil

--- a/graphql/bench/auth_test.go
+++ b/graphql/bench/auth_test.go
@@ -356,7 +356,7 @@ func BenchmarkOneLevelMutation(b *testing.B) {
 
 	items := 10000
 	var cusines Cuisines
-	for i := 0; i < items; i++ {
+	for i := range items {
 		r := Cuisine{
 			Name:   fmt.Sprintf("Test_Cuisine_%d", i),
 			Type:   "TypeCuisineAuth",

--- a/graphql/e2e/common/common.go
+++ b/graphql/e2e/common/common.go
@@ -280,7 +280,7 @@ func probeGraphQL(authority string, header http.Header) (*ProbeGraphQLResp, erro
 }
 
 func retryProbeGraphQL(authority string, header http.Header) *ProbeGraphQLResp {
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		resp, err := probeGraphQL(authority, header)
 		if err == nil && resp.Healthy {
 			return resp
@@ -304,7 +304,7 @@ func RetryProbeGraphQL(t *testing.T, authority string, header http.Header) *Prob
 // If it can't make the assertion with enough retries, it fails the test.
 func AssertSchemaUpdateCounterIncrement(t *testing.T, authority string, oldCounter uint64, header http.Header) {
 	var newCounter uint64
-	for i := 0; i < 20; i++ {
+	for range 20 {
 		if newCounter = RetryProbeGraphQL(t, authority,
 			header).SchemaUpdateCounter; newCounter == oldCounter+1 {
 			return
@@ -1295,7 +1295,7 @@ func CheckGraphQLStarted(url string) error {
 	// Because of how GraphQL starts (it needs to read the schema from Dgraph),
 	// there's no guarantee that GraphQL is available by now.  So we
 	// need to try and connect and potentially retry a few times.
-	for i := 0; i < 60; i++ {
+	for range 60 {
 		_, err = hasCurrentGraphQLSchema(url)
 		if err == nil {
 			return nil

--- a/graphql/e2e/common/error.go
+++ b/graphql/e2e/common/error.go
@@ -109,7 +109,7 @@ func graphQLCompletionOn(t *testing.T) {
 				return result.QueryCountry[i].Name < result.QueryCountry[j].Name
 			})
 
-			for i := 0; i < 4; i++ {
+			for i := range 4 {
 				require.NotNil(t, result.QueryCountry[i])
 				require.Equal(t, result.QueryCountry[i].Name, expected.QueryCountry[i].Name)
 			}

--- a/graphql/e2e/common/mutation.go
+++ b/graphql/e2e/common/mutation.go
@@ -1321,7 +1321,7 @@ func updateCountry(t *testing.T, filter map[string]interface{}, newName string, 
 
 func filterInUpdate(t *testing.T) {
 	countries := make([]country, 0, 4)
-	for i := 0; i < 4; i++ {
+	for range 4 {
 		country := addCountry(t, postExecutor)
 		country.Name = "updatedValue"
 		countries = append(countries, *country)
@@ -1395,7 +1395,7 @@ func filterInUpdate(t *testing.T) {
 			require.NoError(t, err)
 
 			require.Equal(t, len(result.UpdateCountry.Country), test.Expected)
-			for i := 0; i < test.Expected; i++ {
+			for i := range test.Expected {
 				require.Equal(t, result.UpdateCountry.Country[i].Name, "updatedValue")
 			}
 
@@ -3395,7 +3395,7 @@ func parallelMutations(t *testing.T) {
 	// Each goroutine adds num different new nodes.
 	executeMutation := func(wg *sync.WaitGroup, num int) {
 		defer wg.Done()
-		for i := 0; i < num; i++ {
+		for i := range num {
 			addStateParams := &GraphQLParams{
 				Query: fmt.Sprintf(`mutation {
             			addState(input: [{xcode: "NewS%d", name: "State%d"}]) {
@@ -3414,13 +3414,13 @@ func parallelMutations(t *testing.T) {
 
 	// Nodes to be added per each goroutine
 	num := 5
-	for i := 0; i < 20; i++ {
+	for range 20 {
 		wg.Add(1)
 		go executeMutation(&wg, num)
 	}
 	wg.Wait()
 
-	for i := 0; i < num; i++ {
+	for i := range num {
 		getStateParams := &GraphQLParams{
 			Query: fmt.Sprintf(`query {
 					queryState(filter: { xcode: { eq: "NewS%d"}}) {

--- a/graphql/schema/rules.go
+++ b/graphql/schema/rules.go
@@ -130,7 +130,7 @@ func dgraphDirectivePredicateValidation(gqlSch *ast.Schema, definitions []string
 		fieldsToReport := make(map[string][]string)
 		interfaces := typ.Interfaces
 
-		for i := 0; i < len(interfaces); i++ {
+		for i := range interfaces {
 			intr1 := interfaces[i]
 			interfacePreds1 := interfacePreds[intr1]
 			for j := i + 1; j < len(interfaces); j++ {

--- a/graphql/schema/wrappers.go
+++ b/graphql/schema/wrappers.go
@@ -2833,7 +2833,7 @@ func getAsPathParamValue(val interface{}) string {
 func getAsInterfaceSliceInPath(slice []interface{}) string {
 	var b strings.Builder
 	size := len(slice)
-	for i := 0; i < size; i++ {
+	for i := range size {
 		b.WriteString(getAsPathParamValue(slice[i]))
 		if i != size-1 {
 			b.WriteString(",")
@@ -3177,7 +3177,7 @@ func buildGraphqlRequestFields(writer *bytes.Buffer, field *ast.Field) {
 		return
 	}
 	writer.WriteString("{\n")
-	for i := 0; i < len(field.SelectionSet); i++ {
+	for i := range field.SelectionSet {
 		castedField := field.SelectionSet[i].(*ast.Field)
 		writer.WriteString(castedField.Name)
 

--- a/posting/index.go
+++ b/posting/index.go
@@ -790,7 +790,7 @@ func printTreeStats(txn *Txn) {
 				fmt.Println("Error while decoding", err)
 			}
 
-			for i := 0; i < len(temp); i++ {
+			for i := range temp {
 				if len(temp[i]) > 0 {
 					numNodes[i] += 1
 				}
@@ -800,15 +800,15 @@ func printTreeStats(txn *Txn) {
 		}
 	}
 
-	for i := 0; i < numLevels; i++ {
+	for i := range numLevels {
 		fmt.Printf("%d, ", numNodes[i])
 	}
 	fmt.Println("")
-	for i := 0; i < numLevels; i++ {
+	for i := range numLevels {
 		fmt.Printf("%d, ", numConnections[i])
 	}
 	fmt.Println("")
-	for i := 0; i < numLevels; i++ {
+	for i := range numLevels {
 		if numNodes[i] == 0 {
 			fmt.Printf("0, ")
 			continue
@@ -832,13 +832,13 @@ func decodeUint64MatrixUnsafe(data []byte, matrix *[][]uint64) error {
 
 	*matrix = make([][]uint64, rows)
 
-	for i := 0; i < int(rows); i++ {
+	for i := range rows {
 		// Read row length
 		rowLen := *(*uint64)(unsafe.Pointer(&data[offset]))
 		offset += 8
 
 		(*matrix)[i] = make([]uint64, rowLen)
-		for j := 0; j < int(rowLen); j++ {
+		for j := range rowLen {
 			(*matrix)[i][j] = *(*uint64)(unsafe.Pointer(&data[offset]))
 			offset += 8
 		}
@@ -1589,7 +1589,7 @@ func prefixesToDropVectorIndexEdges(ctx context.Context, rb *IndexRebuild) [][]b
 	prefixes = append(prefixes, x.PredicatePrefix(hnsw.ConcatStrings(rb.Attr, hnsw.VecDead)))
 	prefixes = append(prefixes, x.PredicatePrefix(hnsw.ConcatStrings(rb.Attr, hnsw.VecKeyword)))
 
-	for i := 0; i < hnsw.VectorIndexMaxLevels; i++ {
+	for i := range hnsw.VectorIndexMaxLevels {
 		prefixes = append(prefixes, x.PredicatePrefix(hnsw.ConcatStrings(rb.Attr, hnsw.VecKeyword, fmt.Sprint(i))))
 	}
 

--- a/posting/list_test.go
+++ b/posting/list_test.go
@@ -1150,7 +1150,7 @@ func TestLargePlistSplit(t *testing.T) {
 	require.NoError(t, err)
 	b = make([]byte, 10<<20)
 	_, _ = rand.Read(b)
-	for i := 0; i < 63; i++ {
+	for i := range 63 {
 		edge := &pb.DirectedEdge{
 			Entity:  uint64(1 << uint32(i)),
 			ValueId: uint64(i),

--- a/posting/writer_test.go
+++ b/posting/writer_test.go
@@ -34,7 +34,7 @@ var val = make([]byte, 128)
 func BenchmarkWriter(b *testing.B) {
 	createKVList := func() bpb.KVList {
 		var KVList bpb.KVList
-		for i := 0; i < 5000000; i++ {
+		for i := range 5000000 {
 			n := &bpb.KV{Key: []byte(fmt.Sprint(i)), Value: val, Version: 5}
 			KVList.Kv = append(KVList.Kv, n)
 		}

--- a/query/aggregator.go
+++ b/query/aggregator.go
@@ -142,7 +142,7 @@ func applyAdd(a, b, c *types.Val) error {
 			return ErrorVectorsNotMatch
 		}
 		cVal := make([]float32, len(aVal))
-		for i := 0; i < len(aVal); i++ {
+		for i := range aVal {
 			cVal[i] = aVal[i] + bVal[i]
 		}
 		c.Value = cVal
@@ -185,7 +185,7 @@ func applySub(a, b, c *types.Val) error {
 			return ErrorVectorsNotMatch
 		}
 		cVal := make([]float32, len(aVal))
-		for i := 0; i < len(aVal); i++ {
+		for i := range aVal {
 			cVal[i] = aVal[i] - bVal[i]
 		}
 		c.Value = cVal
@@ -233,7 +233,7 @@ func applyMul(a, b, c *types.Val) error {
 		case VFLOAT:
 			bVal := b.Value.([]float32)
 			cVal := make([]float32, len(bVal))
-			for i := 0; i < len(bVal); i++ {
+			for i := range bVal {
 				cVal[i] = float32(aVal) * bVal[i]
 			}
 			c.Value = cVal
@@ -255,7 +255,7 @@ func applyMul(a, b, c *types.Val) error {
 		if math.IsInf(float64(float32(bVal)), 0) {
 			return ErrorFloat32Overflow
 		}
-		for i := 0; i < len(aVal); i++ {
+		for i := range aVal {
 			cVal[i] = aVal[i] * float32(bVal)
 		}
 		c.Tid = types.VFloatID
@@ -304,7 +304,7 @@ func applyDiv(a, b, c *types.Val) error {
 		}
 		aVal := a.Value.([]float32)
 		cVal := make([]float32, len(aVal))
-		for i := 0; i < len(aVal); i++ {
+		for i := range aVal {
 			cVal[i] = aVal[i] / float32(denom)
 		}
 		c.Value = cVal
@@ -428,7 +428,7 @@ func applyDot(a, b, c *types.Val) error {
 	}
 	c.Tid = types.FloatID
 	var cVal float64
-	for i := 0; i < len(aVal); i++ {
+	for i := range aVal {
 		cVal += (float64)(aVal[i]) * (float64)(bVal[i])
 	}
 	c.Value = cVal
@@ -847,7 +847,7 @@ func (ag *aggregator) Apply(val types.Val) error {
 			if len(bVal) != len(accumVal) {
 				return ErrorVectorsNotMatch
 			}
-			for i := 0; i < len(bVal); i++ {
+			for i := range bVal {
 				accumVal[i] += bVal[i]
 			}
 		case va.Tid == types.BigFloatID && vb.Tid == types.BigFloatID:
@@ -902,7 +902,7 @@ func (ag *aggregator) divideByCount() {
 	case types.VFloatID:
 		arr := ag.result.Value.([]float32)
 		res := make([]float32, len(arr))
-		for i := 0; i < len(arr); i++ {
+		for i := range arr {
 			res[i] = arr[i] / float32(ag.count)
 		}
 		ag.result.Value = res

--- a/query/groupby.go
+++ b/query/groupby.go
@@ -218,7 +218,7 @@ func (sg *SubGraph) formResult(ul *pb.List) (*groupResults, error) {
 		}
 		if len(child.DestUIDs.GetUids()) > 0 {
 			// It's a UID node.
-			for i := 0; i < len(child.uidMatrix); i++ {
+			for i := range child.uidMatrix {
 				srcUid := child.SrcUIDs.Uids[i]
 				// Ignore uids which are not part of srcUid.
 				if algo.IndexOf(ul, srcUid) < 0 {
@@ -300,7 +300,7 @@ func (sg *SubGraph) fillGroupedVars(doneVars map[string]varValue, path []*SubGra
 		}
 		if len(child.DestUIDs.GetUids()) > 0 {
 			// It's a UID node.
-			for i := 0; i < len(child.uidMatrix); i++ {
+			for i := range child.uidMatrix {
 				srcUid := child.SrcUIDs.Uids[i]
 				ul := child.uidMatrix[i]
 				for _, uid := range ul.Uids {

--- a/query/outputnode.go
+++ b/query/outputnode.go
@@ -1129,7 +1129,7 @@ func processNodeUids(fj fastJsonNode, enc *encoder, sg *SubGraph) error {
 	}
 
 	lenList := len(sg.uidMatrix[0].Uids)
-	for i := 0; i < lenList; i++ {
+	for i := range lenList {
 		uid := sg.uidMatrix[0].Uids[i]
 		if algo.IndexOf(sg.DestUIDs, uid) < 0 {
 			// This UID was filtered. So Ignore it.

--- a/query/outputnode_test.go
+++ b/query/outputnode_test.go
@@ -40,11 +40,11 @@ func TestEncodeMemory(t *testing.T) {
 	//	}
 	var wg sync.WaitGroup
 
-	for i := 0; i < runtime.NumCPU(); i++ {
+	for range runtime.NumCPU() {
 		enc := newEncoder()
 		n := enc.newNode(0)
 		require.NotNil(t, n)
-		for i := 0; i < 15000; i++ {
+		for i := range 15000 {
 			require.NoError(t, enc.AddValue(n, enc.idForAttr(fmt.Sprintf("very long attr name %06d", i)),
 				types.ValueForType(types.StringID)))
 			enc.AddListChild(n,
@@ -53,7 +53,7 @@ func TestEncodeMemory(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			for j := 0; j < 1000; j++ {
+			for range 1000 {
 				enc.buf.Reset()
 				require.NoError(t, enc.encode(n))
 			}
@@ -74,24 +74,24 @@ func TestNormalizeJSONLimit(t *testing.T) {
 	enc := newEncoder()
 	n := enc.newNode(enc.idForAttr("root"))
 	require.NotNil(t, n)
-	for i := 0; i < 1000; i++ {
+	for i := range 1000 {
 		require.NoError(t, enc.AddValue(n, enc.idForAttr(fmt.Sprintf("very long attr name %06d", i)),
 			types.ValueForType(types.StringID)))
 		child1 := enc.newNode(enc.idForAttr("child1"))
 		enc.AddListChild(n, child1)
-		for j := 0; j < 100; j++ {
+		for j := range 100 {
 			require.NoError(t, enc.AddValue(child1, enc.idForAttr(fmt.Sprintf("long child1 attr %06d", j)),
 				types.ValueForType(types.StringID)))
 		}
 		child2 := enc.newNode(enc.idForAttr("child2"))
 		enc.AddListChild(n, child2)
-		for j := 0; j < 100; j++ {
+		for j := range 100 {
 			require.NoError(t, enc.AddValue(child2, enc.idForAttr(fmt.Sprintf("long child2 attr %06d", j)),
 				types.ValueForType(types.StringID)))
 		}
 		child3 := enc.newNode(enc.idForAttr("child3"))
 		enc.AddListChild(n, child3)
-		for j := 0; j < 100; j++ {
+		for j := range 100 {
 			require.NoError(t, enc.AddValue(child3, enc.idForAttr(fmt.Sprintf("long child3 attr %06d", j)),
 				types.ValueForType(types.StringID)))
 		}
@@ -181,7 +181,7 @@ func BenchmarkFastJsonNodeEmpty(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		enc := newEncoder()
 		var fj fastJsonNode
-		for i := 0; i < 2e6; i++ {
+		for range 2000000 {
 			fj = enc.newNode(0)
 		}
 		_ = fj
@@ -199,7 +199,7 @@ func buildTestTree(b *testing.B, enc *encoder, level, maxlevel int, fj fastJsonN
 	}
 
 	// Add only two children for now.
-	for i := 0; i < 2; i++ {
+	for range 2 {
 		var ch fastJsonNode
 		if level == maxlevel-1 {
 			val, err := valToBytes(testVal)

--- a/query/query.go
+++ b/query/query.go
@@ -1136,7 +1136,7 @@ func (fromNode *varValue) transformTo(toPath []*SubGraph) (map[uint64]types.Val,
 			continue
 		}
 
-		for i := 0; i < len(curNode.uidMatrix); i++ {
+		for i := range curNode.uidMatrix {
 			ul := curNode.uidMatrix[i]
 			srcUid := curNode.SrcUIDs.Uids[i]
 			curVal, ok := newMap[srcUid]
@@ -1146,7 +1146,7 @@ func (fromNode *varValue) transformTo(toPath []*SubGraph) (map[uint64]types.Val,
 			if curVal.Tid != types.IntID && curVal.Tid != types.FloatID {
 				return nil, errors.Errorf("Encountered non int/float type for summing")
 			}
-			for j := 0; j < len(ul.Uids); j++ {
+			for j := range ul.Uids {
 				dstUid := ul.Uids[j]
 				ag := aggregator{name: "sum"}
 				if err := ag.Apply(curVal); err != nil {
@@ -1171,7 +1171,7 @@ func (fromNode *varValue) transformTo(toPath []*SubGraph) (map[uint64]types.Val,
 func (sg *SubGraph) transformVars(doneVars map[string]varValue, path []*SubGraph) error {
 	mNode := sg.MathExp
 	mvarList := mNode.extractVarNodes()
-	for i := 0; i < len(mvarList); i++ {
+	for i := range mvarList {
 		mt := mvarList[i]
 		curNode := doneVars[mt.Var]
 		newMap, err := curNode.transformTo(path)
@@ -1302,7 +1302,7 @@ func (sg *SubGraph) valueVarAggregation(doneVars map[string]varValue, path []*Su
 
 func (sg *SubGraph) populatePostAggregation(doneVars map[string]varValue, path []*SubGraph,
 	parent *SubGraph) error {
-	for idx := 0; idx < len(sg.Children); idx++ {
+	for idx := range sg.Children {
 		child := sg.Children[idx]
 		path = append(path, sg)
 		err := child.populatePostAggregation(doneVars, path, sg)
@@ -1403,7 +1403,7 @@ func (sg *SubGraph) populateVarMap(doneVars map[string]varValue, sgPath []*SubGr
 		if len(child.Params.Cascade.Fields) > 0 &&
 			(child.Params.Cascade.First != 0 || child.Params.Cascade.Offset != 0) {
 
-			for i := 0; i < len(child.uidMatrix); i++ {
+			for i := range child.uidMatrix {
 				start, end := x.PageRange(child.Params.Cascade.First,
 					child.Params.Cascade.Offset, len(child.uidMatrix[i].Uids))
 				child.uidMatrix[i].Uids = child.uidMatrix[i].Uids[start:end]
@@ -1955,7 +1955,7 @@ func expandSubgraph(ctx context.Context, sg *SubGraph) ([]*SubGraph, error) {
 		return nil, errors.Wrapf(err, "While expanding subgraph")
 	}
 	out := make([]*SubGraph, 0, len(sg.Children))
-	for i := 0; i < len(sg.Children); i++ {
+	for i := range sg.Children {
 		child := sg.Children[i]
 
 		if child.Params.Expand == "" {
@@ -2355,7 +2355,7 @@ func ProcessGraph(ctx context.Context, sg, parent *SubGraph, rch chan error) {
 	}
 
 	childChan := make(chan error, len(sg.Children))
-	for i := 0; i < len(sg.Children); i++ {
+	for i := range sg.Children {
 		child := sg.Children[i]
 		child.Params.ParentVars = make(map[string]varValue)
 		for k, v := range sg.Params.ParentVars {
@@ -2408,7 +2408,7 @@ func (sg *SubGraph) applyPagination(ctx context.Context) error {
 	}
 
 	sg.updateUidMatrix()
-	for i := 0; i < len(sg.uidMatrix); i++ {
+	for i := range sg.uidMatrix {
 		// Apply the offsets.
 		start, end := x.PageRange(sg.Params.Count, sg.Params.Offset, len(sg.uidMatrix[i].Uids))
 		sg.uidMatrix[i].Uids = sg.uidMatrix[i].Uids[start:end]
@@ -2547,7 +2547,7 @@ func (sg *SubGraph) sortAndPaginateUsingFacet(ctx context.Context) error {
 			values[i] = make([]types.Val, len(sg.Params.FacetsOrder))
 		}
 
-		for j := 0; j < len(ul.Uids); j++ {
+		for j := range ul.Uids {
 			uid := ul.Uids[j]
 			f := fl.FacetsList[j]
 			uids = append(uids, uid)
@@ -2593,7 +2593,7 @@ func (sg *SubGraph) sortAndPaginateUsingFacet(ctx context.Context) error {
 
 	if sg.Params.Count != 0 || sg.Params.Offset != 0 {
 		// Apply the pagination.
-		for i := 0; i < len(sg.uidMatrix); i++ {
+		for i := range sg.uidMatrix {
 			start, end := x.PageRange(sg.Params.Count, sg.Params.Offset, len(sg.uidMatrix[i].Uids))
 			sg.uidMatrix[i].Uids = sg.uidMatrix[i].Uids[start:end]
 			// We also have to paginate the facetsMatrix for safety.
@@ -2614,7 +2614,7 @@ func (sg *SubGraph) sortAndPaginateUsingVar(ctx context.Context) error {
 		return errors.Errorf("Variable: [%s] used before definition.", sg.Params.Order[0].Attr)
 	}
 
-	for i := 0; i < len(sg.uidMatrix); i++ {
+	for i := range sg.uidMatrix {
 		ul := sg.uidMatrix[i]
 		uids := make([]uint64, 0, len(ul.Uids))
 		values := make([][]types.Val, 0, len(ul.Uids))
@@ -2638,7 +2638,7 @@ func (sg *SubGraph) sortAndPaginateUsingVar(ctx context.Context) error {
 
 	if sg.Params.Count != 0 || sg.Params.Offset != 0 {
 		// Apply the pagination.
-		for i := 0; i < len(sg.uidMatrix); i++ {
+		for i := range sg.uidMatrix {
 			start, end := x.PageRange(sg.Params.Count, sg.Params.Offset, len(sg.uidMatrix[i].Uids))
 			sg.uidMatrix[i].Uids = sg.uidMatrix[i].Uids[start:end]
 		}
@@ -2781,7 +2781,7 @@ func (req *Request) ProcessQuery(ctx context.Context) (err error) {
 	loopStart := time.Now()
 	queries := req.DqlQuery.Query
 	// first loop converts queries to SubGraph representation and populates ReadTs And Cache.
-	for i := 0; i < len(queries); i++ {
+	for i := range queries {
 		gq := queries[i]
 
 		if gq == nil || (len(gq.UID) == 0 && gq.Func == nil && len(gq.NeedsVar) == 0 &&
@@ -2835,7 +2835,7 @@ func (req *Request) ProcessQuery(ctx context.Context) (err error) {
 		var idxList []int
 		// If we have N blocks in a query, it can take a maximum of N iterations for all of them
 		// to be executed.
-		for idx := 0; idx < len(req.Subgraphs); idx++ {
+		for idx := range req.Subgraphs {
 			if hasExecuted[idx] {
 				continue
 			}
@@ -2887,7 +2887,7 @@ func (req *Request) ProcessQuery(ctx context.Context) (err error) {
 
 		var ferr error
 		// Wait for the execution that was started in this iteration.
-		for i := 0; i < len(idxList); i++ {
+		for range idxList {
 			if err = <-errChan; err != nil {
 				ferr = err
 				continue
@@ -2910,7 +2910,7 @@ func (req *Request) ProcessQuery(ctx context.Context) (err error) {
 			// Apply pagination at the root after @cascade.
 			if len(sg.Params.Cascade.Fields) > 0 && (sg.Params.Cascade.First != 0 || sg.Params.Cascade.Offset != 0) {
 				sg.updateUidMatrix()
-				for i := 0; i < len(sg.uidMatrix); i++ {
+				for i := range sg.uidMatrix {
 					start, end := x.PageRange(sg.Params.Cascade.First,
 						sg.Params.Cascade.Offset, len(sg.uidMatrix[i].Uids))
 					sg.uidMatrix[i].Uids = sg.uidMatrix[i].Uids[start:end]

--- a/query/shortest.go
+++ b/query/shortest.go
@@ -598,7 +598,7 @@ func shortestPath(ctx context.Context, sg *SubGraph) ([]*SubGraph, error) {
 	totalWeight = dist[cur].cost
 	// The length of the path can be greater than numHops hence we loop over the dist map till we
 	// reach sg.Params.From node. See test TestShortestPathWithDepth/depth_2_numpaths_1
-	for i := 0; i < len(dist); i++ {
+	for range dist {
 		result = append(result, cur)
 		if cur == sg.Params.From {
 			break
@@ -612,7 +612,7 @@ func shortestPath(ctx context.Context, sg *SubGraph) ([]*SubGraph, error) {
 
 	l := len(result)
 	// Reverse the list.
-	for i := 0; i < l/2; i++ {
+	for i := range l / 2 {
 		result[i], result[l-i-1] = result[l-i-1], result[i]
 	}
 	// Put the path in DestUIDs of the root.
@@ -638,7 +638,7 @@ func createPathSubgraph(ctx context.Context, dist map[uint64]nodeInfo, totalWeig
 	shortestSg.uidMatrix = []*pb.List{{Uids: []uint64{curUid}}}
 
 	curNode := shortestSg
-	for i := 0; i < len(result)-1; i++ {
+	for i := range len(result) - 1 {
 		curUid := result[i]
 		childUid := result[i+1]
 		node := new(SubGraph)

--- a/raftwal/encryption_test.go
+++ b/raftwal/encryption_test.go
@@ -82,7 +82,7 @@ func TestLogRotate(t *testing.T) {
 	// Write enough entries to fill ~1.5x logfiles, causing a rotation.
 	const totalEntries = (maxNumEntries * 3) / 2
 	totalBytes := 0
-	for i := 0; i < totalEntries; i++ {
+	for i := range totalEntries {
 		entry := makeEntry(i)
 		require.NoError(t, el.AddEntries([]raftpb.Entry{entry}))
 		totalBytes += len(entry.Data)
@@ -125,7 +125,7 @@ func TestLogGrow(t *testing.T) {
 
 		// 5KB * 30000 is ~ 150MB, this will cause the log file to grow.
 		var entries []raftpb.Entry
-		for i := 0; i < numEntries; i++ {
+		for i := range numEntries {
 			data := make([]byte, 5<<10)
 			rand.Read(data)
 			entry := raftpb.Entry{Index: uint64(i + 1), Term: 1, Data: data}

--- a/raftwal/storage_test.go
+++ b/raftwal/storage_test.go
@@ -341,7 +341,7 @@ func TestTruncateStorage(t *testing.T) {
 	const numTruncated = numEntries / 2
 
 	// Insert entries.
-	for i := uint64(0); i < numEntries; i++ {
+	for i := range numEntries {
 		var typ raftpb.EntryType
 		if i%3 == 0 {
 			typ = raftpb.EntryConfChange
@@ -362,7 +362,7 @@ func TestTruncateStorage(t *testing.T) {
 	// Verify all entries.
 	entries := ds.wal.allEntries(0, math.MaxUint64, math.MaxUint64)
 	require.Len(t, entries, int(numEntries))
-	for i := uint64(0); i < numEntries; i++ {
+	for i := range numEntries {
 		idx := i + 1
 		require.Equal(t, entries[i].Data, []byte(fmt.Sprintf("entry %d", idx)))
 	}
@@ -373,7 +373,7 @@ func TestTruncateStorage(t *testing.T) {
 	// Verify all entries.
 	entries = ds.wal.allEntries(0, math.MaxUint64, math.MaxUint64)
 	require.Len(t, entries, int(numEntries))
-	for i := uint64(0); i < numEntries; i++ {
+	for i := range numEntries {
 		idx := i + 1
 		if idx < numTruncated && i%3 != 0 {
 			require.Empty(t, entries[i].Data)
@@ -398,7 +398,7 @@ func TestTruncateStorage(t *testing.T) {
 	// Verify all entries.
 	entries = ds.wal.allEntries(0, math.MaxUint64, math.MaxUint64)
 	require.Len(t, entries, int(numEntriesNew))
-	for i := uint64(0); i < numEntriesNew; i++ {
+	for i := range numEntriesNew {
 		idx := i + 1
 		if idx < numTruncated && i%3 != 0 {
 			require.Empty(t, entries[i].Data)

--- a/raftwal/wal.go
+++ b/raftwal/wal.go
@@ -114,7 +114,7 @@ func (l *wal) truncateEntriesUntil(lastIdx uint64) {
 			continue
 		}
 
-		for idx := 0; idx < maxNumEntries; idx++ {
+		for idx := range maxNumEntries {
 			entry := file.getEntry(idx)
 			if entry.Index() >= lastIdx {
 				return

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -871,7 +871,7 @@ func compareSchemaUpdates(original, update *pb.SchemaUpdate) []string {
 	vOriginal := reflect.ValueOf(*original)
 	vUpdate := reflect.ValueOf(*update)
 
-	for i := 0; i < vOriginal.NumField(); i++ {
+	for i := range vOriginal.NumField() {
 		fieldName := vOriginal.Type().Field(i).Name
 		valueOriginal := vOriginal.Field(i)
 		valueUpdate := vUpdate.Field(i)

--- a/systest/21million/common/run_queries.go
+++ b/systest/21million/common/run_queries.go
@@ -72,7 +72,7 @@ func TestQueriesFor21Million(t *testing.T) {
 			// The test query and expected result are separated by a delimiter.
 			bodies := strings.SplitN(contents, "\n---\n", 2)
 			// Dgraph can get into unhealthy state sometime. So, add retry for every query.
-			for retry := 0; retry < 3; retry++ {
+			for retry := range 3 {
 				// If a query takes too long to run, it probably means dgraph is stuck and there's
 				// no point in waiting longer or trying more tests.
 				ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)

--- a/systest/posting-list-benchmark/main.go
+++ b/systest/posting-list-benchmark/main.go
@@ -108,7 +108,7 @@ func runBenchmark() {
 	x.Check(err)
 
 	var triples []string
-	for i := uint64(0); i < opt.numMutations; i++ {
+	for i := range opt.numMutations {
 		uid := fmt.Sprintf("_:uid%d", i)
 		triple := fmt.Sprintf("%s <text> \"%s\"@en .", uid, opt.text)
 		triples = append(triples, triple)

--- a/t/t.go
+++ b/t/t.go
@@ -969,7 +969,7 @@ func run() error {
 	closer := z.NewCloser(N)
 	testCh := make(chan task)
 	errCh := make(chan error, 1000)
-	for i := 0; i < N; i++ {
+	for range N {
 		go func() {
 			if err := runTests(testCh, closer); err != nil {
 				errCh <- err

--- a/testutil/client.go
+++ b/testutil/client.go
@@ -249,7 +249,7 @@ func RetryQuery(dg *dgo.Dgraph, q string) (*api.Response, error) {
 
 func RetryAlter(dg *dgo.Dgraph, op *api.Operation) error {
 	var err error
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		err = dg.Alter(context.Background(), op)
 		if err == nil || !strings.Contains(err.Error(), "opIndexing is already running") {
 			return err

--- a/testutil/docker.go
+++ b/testutil/docker.go
@@ -79,7 +79,7 @@ func (in ContainerInstance) BestEffortWaitForHealthy(privatePort uint16) error {
 	}
 
 	tryWith := func(host string) error {
-		for i := 0; i < 60; i++ {
+		for range 60 {
 			resp, err := http.Get("http://" + host + ":" + port + "/health")
 			var body []byte
 			if resp != nil && resp.Body != nil {
@@ -147,7 +147,7 @@ func (in ContainerInstance) login() error {
 }
 
 func (in ContainerInstance) bestEffortTryLogin() error {
-	for i := 0; i < 60; i++ {
+	for range 60 {
 		err := in.login()
 		if err == nil {
 			return nil
@@ -316,7 +316,7 @@ func CheckHealthContainer(socketAddrHttp string) error {
 	var err error
 	var resp *http.Response
 	url := "http://" + socketAddrHttp + "/health"
-	for i := 0; i < 30; i++ {
+	for range 30 {
 		resp, err = http.Get(url)
 		if err == nil && resp.StatusCode == http.StatusOK {
 			return nil

--- a/tok/hnsw/helper.go
+++ b/tok/hnsw/helper.go
@@ -179,7 +179,7 @@ func ParseEdges(s string) ([]uint64, error) {
 		// Splitting based on comma-separation.
 		values := strings.Split(trimmed, ",")
 		result := make([]uint64, len(values))
-		for i := 0; i < len(values); i++ {
+		for i := range values {
 			trimmedVal := strings.TrimSpace(values[i])
 			val, err := strconv.ParseUint(trimmedVal, 10, 64)
 			if err != nil {
@@ -191,7 +191,7 @@ func ParseEdges(s string) ([]uint64, error) {
 	}
 	values := strings.Split(trimmed, " ")
 	result := make([]uint64, 0, len(values))
-	for i := 0; i < len(values); i++ {
+	for i := range values {
 		if len(values[i]) == 0 {
 			// skip if we have an empty string. This can naturally
 			// occur if input s was "[1.0     2.0]"
@@ -355,7 +355,7 @@ func getInsertLayer(maxLevels int) int {
 	// multFactor is a multiplicative factor used to normalize the distribution
 	var level int
 	randFloat := rand.Float64()
-	for i := 0; i < maxLevels; i++ {
+	for i := range maxLevels {
 		// calculate level based on section 3.1 here
 		if randFloat < math.Pow(1.0/float64(5), float64(maxLevels-1-i)) {
 			level = i
@@ -614,7 +614,7 @@ func (ph *persistentHNSW[T]) addNeighbors(ctx context.Context, tc *TxnCache,
 		}
 	}
 	var inVec, outVec []T
-	for level := 0; level < ph.maxLevels; level++ {
+	for level := range ph.maxLevels {
 		allLayerEdges[level], nnEdgesErr = ph.removeDeadNodes(allLayerEdges[level], tc)
 		if nnEdgesErr != nil {
 			return nil, nnEdgesErr

--- a/tok/hnsw/persistent_hnsw.go
+++ b/tok/hnsw/persistent_hnsw.go
@@ -377,7 +377,7 @@ func (ph *persistentHNSW[T]) SearchWithPath(
 
 	// Calculates best entry for last level (maxLevels-1) by searching each
 	// layer and using new best entry.
-	for level := 0; level < ph.maxLevels-1; level++ {
+	for level := range ph.maxLevels - 1 {
 		if isEqual(startVec, query) {
 			break
 		}
@@ -453,7 +453,7 @@ func (ph *persistentHNSW[T]) insertHelper(ctx context.Context, tc *TxnCache,
 
 	ph.visitedUids.ClearAll()
 
-	for level := 0; level < inLevel; level++ {
+	for level := range inLevel {
 		// perform insertion for layers [level, max_level) only, when level < inLevel just find better start
 		err := ph.getVecFromUid(entry, tc, &startVec)
 		if err != nil {
@@ -490,7 +490,7 @@ func (ph *persistentHNSW[T]) insertHelper(ctx context.Context, tc *TxnCache,
 		entry = layerResult.bestNeighbor().index
 
 		nns := layerResult.neighbors
-		for i := 0; i < len(nns); i++ {
+		for i := range nns {
 			nnUidArray = append(nnUidArray, nns[i].index)
 			if inboundEdgesAllLayersMap[nns[i].index] == nil {
 				inboundEdgesAllLayersMap[nns[i].index] = make([][]uint64, ph.maxLevels)
@@ -504,7 +504,7 @@ func (ph *persistentHNSW[T]) insertHelper(ctx context.Context, tc *TxnCache,
 		}
 	}
 	edge, err := ph.addNeighbors(ctx, tc, inUuid, outboundEdgesAllLayers)
-	for i := 0; i < len(nnUidArray); i++ {
+	for i := range nnUidArray {
 		edge, err := ph.addNeighbors(
 			ctx, tc, nnUidArray[i], inboundEdgesAllLayersMap[nnUidArray[i]])
 		if err != nil {

--- a/tok/hnsw/persistent_hnsw_test.go
+++ b/tok/hnsw/persistent_hnsw_test.go
@@ -95,7 +95,7 @@ func TestRaceCreateOrReplace(t *testing.T) {
 
 	var wg sync.WaitGroup
 	run := func() {
-		for i := 0; i < 10; i++ {
+		for i := range 10 {
 			vIndex, err := f.CreateOrReplace(test.pred, opts, 32)
 			if err != nil {
 				t.Errorf("Error creating index: %s for test case %d (%+v)",
@@ -109,7 +109,7 @@ func TestRaceCreateOrReplace(t *testing.T) {
 		wg.Done()
 	}
 
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		wg.Add(1)
 		go run()
 	}

--- a/tok/hnsw/test_helper.go
+++ b/tok/hnsw/test_helper.go
@@ -288,7 +288,7 @@ func equalUint64Slice(a, b []uint64) bool {
 func floatArrayAsBytes(v []float64) []byte {
 	retVal := make([]byte, 8*len(v))
 	offset := retVal
-	for i := 0; i < len(v); i++ {
+	for i := range v {
 		bits := math.Float64bits(v[i])
 		binary.LittleEndian.PutUint64(offset, bits)
 		offset = offset[8:]

--- a/tok/index/helper_test.go
+++ b/tok/index/helper_test.go
@@ -280,7 +280,7 @@ func dotProductT[T c.Float](a, b []T, floatBits int) {
 	if len(a) != len(b) {
 		return
 	}
-	for i := 0; i < len(a); i++ {
+	for i := range a {
 		dotProduct += a[i] * b[i]
 	}
 }
@@ -374,7 +374,7 @@ func littleEndianBytesAsFloatArray[T c.Float](encoded []byte, retVal *[]T, float
 	if resultLen == 0 {
 		return
 	}
-	for i := 0; i < resultLen; i++ {
+	for range resultLen {
 		// Assume LittleEndian for encoding since this is
 		// the assumption elsewhere when reading from client.
 		// See dgraph-io/dgo/protos/api.pb.go

--- a/tok/tok.go
+++ b/tok/tok.go
@@ -506,7 +506,7 @@ func (t TrigramTokenizer) Tokens(v interface{}) ([]string, error) {
 	l := len(value) - 2
 	if l > 0 {
 		tokens := make([]string, l)
-		for i := 0; i < l; i++ {
+		for i := range l {
 			tokens[i] = value[i : i+3]
 		}
 		tokens = x.RemoveDuplicates(tokens)

--- a/types/conversion.go
+++ b/types/conversion.go
@@ -69,7 +69,7 @@ func ParseVFloat(s string) ([]float32, error) {
 		// Splitting based on comma-separation.
 		values := strings.Split(trimmed, ",")
 		result := make([]float32, len(values))
-		for i := 0; i < len(values); i++ {
+		for i := range values {
 			trimmedVal := strings.TrimSpace(values[i])
 			val, err := strconv.ParseFloat(trimmedVal, 32)
 			if err != nil {
@@ -81,7 +81,7 @@ func ParseVFloat(s string) ([]float32, error) {
 	}
 	values := strings.Split(trimmed, " ")
 	result := make([]float32, 0, len(values))
-	for i := 0; i < len(values); i++ {
+	for i := range values {
 		if len(values[i]) == 0 {
 			// skip if we have an empty string. This can naturally
 			// occur if input s was "[1.0     2.0]"

--- a/types/geofilter.go
+++ b/types/geofilter.go
@@ -152,7 +152,7 @@ func queryTokensGeo(qt QueryType, g geom.T, maxDistance float64) ([]string, *Geo
 
 	case *geom.MultiPolygon:
 		// We get a loop for each polygon.
-		for i := 0; i < v.NumPolygons(); i++ {
+		for i := range v.NumPolygons() {
 			l, err := loopFromPolygon(v.Polygon(i))
 			if err != nil {
 				return nil, nil, err
@@ -277,7 +277,7 @@ func (q GeoQueryData) isWithin(g geom.T) bool {
 	case *geom.MultiPolygon:
 		// We check each polygon in the multipolygon should be within some loop of q.loops.
 		if len(q.loops) > 0 {
-			for i := 0; i < geometry.NumPolygons(); i++ {
+			for i := range geometry.NumPolygons() {
 				s2loop, err := loopFromPolygon(geometry.Polygon(i))
 				if err != nil {
 					return false
@@ -293,7 +293,7 @@ func (q GeoQueryData) isWithin(g geom.T) bool {
 }
 
 func multiPolygonContainsLoop(g *geom.MultiPolygon, l *s2.Loop) bool {
-	for i := 0; i < g.NumPolygons(); i++ {
+	for i := range g.NumPolygons() {
 		p := g.Polygon(i)
 		s2loop, err := loopFromPolygon(p)
 		if err != nil {
@@ -331,7 +331,7 @@ func (q GeoQueryData) contains(g geom.T) bool {
 		return true
 	case *geom.MultiPolygon:
 		if q.pt != nil {
-			for j := 0; j < v.NumPolygons(); j++ {
+			for j := range v.NumPolygons() {
 				if polygonContainsCoord(v.Polygon(j), q.pt) {
 					return true
 				}
@@ -358,7 +358,7 @@ func (q GeoQueryData) contains(g geom.T) bool {
 }
 
 func polygonContainsCoord(v *geom.Polygon, pt *s2.Point) bool {
-	for i := 0; i < v.NumLinearRings(); i++ {
+	for i := range v.NumLinearRings() {
 		r := v.LinearRing(i)
 		ll := s2.LatLngFromPoint(*pt)
 		p := []float64{ll.Lng.Degrees(), ll.Lat.Degrees()}
@@ -397,7 +397,7 @@ func (q GeoQueryData) intersects(g geom.T) bool {
 		return false
 	case *geom.MultiPolygon:
 		// We must compare all polygons in g with those in the query.
-		for i := 0; i < v.NumPolygons(); i++ {
+		for i := range v.NumPolygons() {
 			l, err := loopFromPolygon(v.Polygon(i))
 			if err != nil {
 				return false

--- a/types/s2.go
+++ b/types/s2.go
@@ -68,7 +68,7 @@ func intersects(l *s2.Loop, loop *s2.Loop) bool {
 
 func findVertex(a *s2.Loop, p s2.Point) int {
 	pts := a.Vertices()
-	for i := 0; i < len(pts); i++ {
+	for i := range pts {
 		if pts[i].ApproxEqual(p) {
 			return i
 		}
@@ -152,7 +152,7 @@ func convertToGeom(str string) (geom.T, error) {
 	validate := func(g geom.T) (geom.T, error) {
 		switch v := g.(type) {
 		case *geom.MultiPolygon:
-			for i := 0; i < v.NumPolygons(); i++ {
+			for i := range v.NumPolygons() {
 				if err := closed(v.Polygon(i)); err != nil {
 					return nil, err
 				}

--- a/types/s2index.go
+++ b/types/s2index.go
@@ -90,7 +90,7 @@ func indexCells(g geom.T) (parents, cover s2.CellUnion, err error) {
 	case *geom.MultiPolygon:
 		var cover s2.CellUnion
 		// Convert each polygon to loop. Get cover for each and append to cover.
-		for i := 0; i < v.NumPolygons(); i++ {
+		for i := range v.NumPolygons() {
 			p := v.Polygon(i)
 			l, err := loopFromPolygon(p)
 			if err != nil {
@@ -161,7 +161,7 @@ func isClockwise(r *geom.LinearRing) bool {
 	// The algorithm is described here https://en.wikipedia.org/wiki/Shoelace_formula
 	var a float64
 	n := r.NumCoords()
-	for i := 0; i < n; i++ {
+	for i := range n {
 		p1 := r.Coord(i)
 		p2 := r.Coord((i + 1) % n)
 		a += (p2.X() - p1.X()) * (p1.Y() + p2.Y())
@@ -174,7 +174,7 @@ func loopFromRing(r *geom.LinearRing, reverse bool) *s2.Loop {
 	// aren't allowed to repeat and the loop is assumed to be closed, so we skip the last point.
 	n := r.NumCoords()
 	pts := make([]s2.Point, n-1)
-	for i := 0; i < n-1; i++ {
+	for i := range n - 1 {
 		var c geom.Coord
 		if reverse {
 			c = r.Coord(n - 1 - i)

--- a/types/sort.go
+++ b/types/sort.go
@@ -127,7 +127,7 @@ func SortTopN(v [][]Val, ul *[]uint64, desc []bool, lang string, n int) error {
 	toBeSorted := byValue{b}
 
 	nul := 0
-	for i := 0; i < len(*ul); i++ {
+	for i := range *ul {
 		if toBeSorted.isNil(i) {
 			continue
 		}

--- a/types/sort_test.go
+++ b/types/sort_test.go
@@ -72,7 +72,7 @@ func TestQuickSelect(t *testing.T) {
 	k := 10
 	getList := func() [][]Val {
 		strs := make([]string, n)
-		for i := 0; i < n; i++ {
+		for i := range n {
 			strs[i] = fmt.Sprintf("%d", rand.Intn(100000))
 		}
 
@@ -90,7 +90,7 @@ func TestQuickSelect(t *testing.T) {
 	list := getList()
 	require.NoError(t, SortTopN(list, &ul.Uids, []bool{false}, "", k))
 
-	for i := 0; i < k; i++ {
+	for i := range k {
 		for j := k; j < n; j++ {
 			require.Equal(t, list[i][0].Value.(int64) <= list[j][0].Value.(int64), true)
 		}
@@ -102,7 +102,7 @@ func BenchmarkSortQuickSort(b *testing.B) {
 	n := 1000000
 	getList := func() [][]Val {
 		strs := make([]string, n)
-		for i := 0; i < n; i++ {
+		for i := range n {
 			strs[i] = StringWithCharset(10)
 		}
 

--- a/types/value.go
+++ b/types/value.go
@@ -35,7 +35,7 @@ func BytesAsFloatArray(encoded []byte) []float32 {
 		return []float32{}
 	}
 	retVal := make([]float32, resultLen)
-	for i := 0; i < resultLen; i++ {
+	for i := range resultLen {
 		retVal[i] = *(*float32)(unsafe.Pointer(&encoded[0]))
 		encoded = encoded[4:]
 	}
@@ -49,7 +49,7 @@ func BytesAsFloatArray(encoded []byte) []float32 {
 func FloatArrayAsBytes(v []float32) []byte {
 	retVal := make([]byte, 4*len(v))
 	offset := retVal
-	for i := 0; i < len(v); i++ {
+	for i := range v {
 		bits := math.Float32bits(v[i])
 		binary.LittleEndian.PutUint32(offset, bits)
 		offset = offset[4:]

--- a/types/value_test.go
+++ b/types/value_test.go
@@ -76,7 +76,7 @@ func TestFloatArrayTranslation(t *testing.T) {
 		asBytes := FloatArrayAsBytes(tc)
 		asFloat32 := BytesAsFloatArray(asBytes)
 		require.Equal(t, len(tc), len(asFloat32))
-		for i := 0; i < len(tc); i++ {
+		for i := range tc {
 			require.Equal(t, tc[i], asFloat32[i])
 		}
 	}

--- a/upgrade/utils.go
+++ b/upgrade/utils.go
@@ -183,7 +183,7 @@ func getQueryResult(dg *dgo.Dgraph, query string, queryResPtr interface{}) error
 	var resp *api.Response
 	var err error
 
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 
@@ -210,7 +210,7 @@ func mutateWithClient(dg *dgo.Dgraph, mutation *api.Mutation) error {
 	mutation.CommitNow = true
 
 	var err error
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 
@@ -234,7 +234,7 @@ func alterWithClient(dg *dgo.Dgraph, operation *api.Operation) error {
 	}
 
 	var err error
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 

--- a/worker/draft.go
+++ b/worker/draft.go
@@ -539,7 +539,7 @@ func (n *node) applyMutations(ctx context.Context, proposal *pb.Proposal) (rerr 
 		return process(m.Edges)
 	}
 	errCh := make(chan error, numGo)
-	for i := 0; i < numGo; i++ {
+	for i := range numGo {
 		start := i * width
 		end := start + width
 		if end > len(m.Edges) {
@@ -553,7 +553,7 @@ func (n *node) applyMutations(ctx context.Context, proposal *pb.Proposal) (rerr 
 	// all the transactions to finish. We call txn.Update() when this function exists. This could cause
 	// a deadlock with runMutation.
 	var errs error
-	for i := 0; i < numGo; i++ {
+	for range numGo {
 		if err := <-errCh; err != nil {
 			if errs == nil {
 				errs = errors.New("Got error while running mutation")

--- a/worker/export.go
+++ b/worker/export.go
@@ -1048,7 +1048,7 @@ func ExportOverNetwork(ctx context.Context, input *pb.ExportRequest) (ExportedFi
 	}
 
 	var allFiles ExportedFiles
-	for i := 0; i < len(gids); i++ {
+	for range gids {
 		pair := <-ch
 		if pair.error != nil {
 			rerr := errors.Wrapf(pair.error, "Export failed at readTs %d", readTs)

--- a/worker/mutation.go
+++ b/worker/mutation.go
@@ -783,7 +783,7 @@ func MutateOverNetwork(ctx context.Context, m *pb.Mutations) (*api.TxnContext, e
 	// Wait for all the goroutines to reply back.
 	// We return if an error was returned or the parent called ctx.Done()
 	var e error
-	for i := 0; i < len(mutationMap); i++ {
+	for range mutationMap {
 		res := <-resCh
 		if res.err != nil {
 			e = res.err

--- a/worker/proposal.go
+++ b/worker/proposal.go
@@ -39,7 +39,7 @@ const baseTimeout time.Duration = 4 * time.Second
 
 func newTimeout(retry int) time.Duration {
 	timeout := baseTimeout
-	for i := 0; i < retry; i++ {
+	for range retry {
 		timeout *= 2
 	}
 	return timeout
@@ -307,7 +307,7 @@ func (n *node) proposeAndWait(ctx context.Context, proposal *pb.Proposal) (perr 
 		return propose(newTimeout(i))
 	}
 
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		if err := proposeWithLimit(i); err != errInternalRetry {
 			return err
 		}

--- a/worker/proposal_test.go
+++ b/worker/proposal_test.go
@@ -55,7 +55,7 @@ func proposeAndWaitEmulator(l *rateLimiter, r *rand.Rand, maxRetry int, sleep bo
 		return propose(newTimeout(i))
 	}
 
-	for i := 0; i < maxRetry; i++ {
+	for i := range maxRetry {
 		if err := runPropose(i); err != errInternalRetry {
 			return err
 		}
@@ -91,7 +91,7 @@ func TestLimiterDeadlock(t *testing.T) {
 	}()
 
 	var wg sync.WaitGroup
-	for i := 0; i < 500; i++ {
+	for i := range 500 {
 		wg.Add(1)
 		go func(no int) {
 			defer wg.Done()

--- a/worker/queue.go
+++ b/worker/queue.go
@@ -150,7 +150,7 @@ func (t *tasks) Enqueue(req interface{}) (uint64, error) {
 	}
 
 	// Wait for upto 3 seconds to check for errors.
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		time.Sleep(time.Second)
 
 		t.logMu.Lock()

--- a/worker/restore_map.go
+++ b/worker/restore_map.go
@@ -787,7 +787,7 @@ func RunMapper(req *pb.RestoreRequest, mapDir string) (*mapResult, error) {
 
 	numGo := 8
 	g, ctx := errgroup.WithContext(mapper.closer.Ctx())
-	for i := 0; i < numGo; i++ {
+	for range numGo {
 		g.Go(func() error {
 			return mapper.processReqCh(ctx)
 		})

--- a/worker/restore_reduce.go
+++ b/worker/restore_reduce.go
@@ -229,7 +229,7 @@ func (r *reducer) Reduce() error {
 		errCh <- r.process()
 	}()
 
-	for i := 0; i < 2; i++ {
+	for range 2 {
 		if err := <-errCh; err != nil {
 			return err
 		}

--- a/worker/schema.go
+++ b/worker/schema.go
@@ -218,7 +218,7 @@ func GetSchemaOverNetwork(ctx context.Context, schema *pb.SchemaRequest) (
 
 	// wait for all the goroutines to reply back.
 	// we return if an error was returned or the parent called ctx.Done()
-	for i := 0; i < len(schemaMap); i++ {
+	for range schemaMap {
 		select {
 		case r := <-results:
 			if r.err != nil {

--- a/worker/sort.go
+++ b/worker/sort.go
@@ -142,7 +142,7 @@ func sortWithoutIndex(ctx context.Context, ts *pb.SortMessage) *sortresult {
 			ts.Order[0].Attr))
 	}
 
-	for i := 0; i < n; i++ {
+	for i := range n {
 		select {
 		case <-ctx.Done():
 			return resultWithError(ctx.Err())
@@ -187,7 +187,7 @@ func sortWithIndex(ctx context.Context, ts *pb.SortMessage) *sortresult {
 	n := len(ts.UidMatrix)
 	out := make([]intersectedList, n)
 	values := make([][]types.Val, 0, n) // Values corresponding to uids in the uid matrix.
-	for i := 0; i < n; i++ {
+	for i := range n {
 		// offsets[i] is the offset for i-th posting list. It gets decremented as we
 		// iterate over buckets.
 		out[i].offset = int(ts.Offset)
@@ -694,7 +694,7 @@ func intersectBucket(ctx context.Context, ts *pb.SortMessage, token string,
 	} // end for loop over UID lists in UID matrix.
 
 	// Check out[i] sizes for all i.
-	for i := 0; i < len(ts.UidMatrix); i++ { // Iterate over UID lists.
+	for i := range ts.UidMatrix { // Iterate over UID lists.
 		// We need to reduce multiSortOffset while checking the count as we might have included
 		// some extra uids earlier for the multi-sort case.
 		if len(out[i].ulist.Uids)-int(out[i].multiSortOffset) < count {
@@ -779,7 +779,7 @@ func sortByValue(ctx context.Context, ts *pb.SortMessage, ul *pb.List,
 	// nullsList is the list of UIDs for which value doesn't exist.
 	var nullsList []uint64
 	var nullVals [][]types.Val
-	for i := 0; i < lenList; i++ {
+	for i := range lenList {
 		select {
 		case <-ctx.Done():
 			return multiSortVals, ctx.Err()

--- a/worker/stringfilter.go
+++ b/worker/stringfilter.go
@@ -46,8 +46,8 @@ func matchStrings(uids *pb.List, values [][]types.Val, filter *stringFilter) *pb
 		return rv
 	}
 
-	for i := 0; i < len(values); i++ {
-		for j := 0; j < len(values[i]); j++ {
+	for i := range values {
+		for j := range values[i] {
 			if filter.match(values[i][j], filter) {
 				rv.Uids = append(rv.Uids, uids.Uids[i])
 				break

--- a/worker/task.go
+++ b/worker/task.go
@@ -585,7 +585,7 @@ func (qs *queryState) handleValuePostings(ctx context.Context, args funcArgs) er
 	} // End of calculate function.
 
 	var g errgroup.Group
-	for i := 0; i < numGo; i++ {
+	for i := range numGo {
 		start := i * width
 		end := start + width
 		if end > srcFn.n {
@@ -943,7 +943,7 @@ func (qs *queryState) handleUidPostings(
 		return nil
 	} // End of calculate function.
 
-	for i := 0; i < numGo; i++ {
+	for i := range numGo {
 		start := i * width
 		end := start + width
 		if end > srcFn.n {
@@ -953,7 +953,7 @@ func (qs *queryState) handleUidPostings(
 			errCh <- calculate(start, end)
 		}(start, end)
 	}
-	for i := 0; i < numGo; i++ {
+	for range numGo {
 		if err := <-errCh; err != nil {
 			return err
 		}
@@ -1309,7 +1309,7 @@ func (qs *queryState) handleRegexFunction(ctx context.Context, arg funcArgs) err
 		}
 	}
 
-	for i := 0; i < len(arg.out.UidMatrix); i++ {
+	for i := range arg.out.UidMatrix {
 		algo.IntersectWith(arg.out.UidMatrix[i], filtered, arg.out.UidMatrix[i])
 	}
 
@@ -1439,7 +1439,7 @@ func (qs *queryState) handleCompareFunction(ctx context.Context, arg funcArgs) e
 	switch {
 	case arg.srcFn.fname == eq:
 		// If fn is eq, we could have multiple arguments and hence multiple rows to filter.
-		for row := 0; row < len(arg.srcFn.tokens); row++ {
+		for row := range arg.srcFn.tokens {
 			compareFunc := func(dst types.Val) bool {
 				return types.CompareVals(arg.srcFn.fname, dst, arg.srcFn.eqTokens[row])
 			}
@@ -1555,7 +1555,7 @@ func (qs *queryState) handleMatchFunction(ctx context.Context, arg funcArgs) err
 		}
 	}
 
-	for i := 0; i < len(arg.out.UidMatrix); i++ {
+	for i := range arg.out.UidMatrix {
 		algo.IntersectWith(arg.out.UidMatrix[i], filtered, arg.out.UidMatrix[i])
 	}
 
@@ -1602,7 +1602,7 @@ func (qs *queryState) filterGeoFunction(ctx context.Context, arg funcArgs) error
 	}
 
 	errCh := make(chan error, numGo)
-	for i := 0; i < numGo; i++ {
+	for i := range numGo {
 		start := i * width
 		end := start + width
 		if end > len(uids.Uids) {
@@ -1612,7 +1612,7 @@ func (qs *queryState) filterGeoFunction(ctx context.Context, arg funcArgs) error
 			errCh <- filter(idx, start, end)
 		}(i, start, end)
 	}
-	for i := 0; i < numGo; i++ {
+	for range numGo {
 		if err := <-errCh; err != nil {
 			return err
 		}
@@ -1624,7 +1624,7 @@ func (qs *queryState) filterGeoFunction(ctx context.Context, arg funcArgs) error
 	if span != nil && numGo > 1 {
 		span.Annotatef(nil, "Total uids after filtering geo: %d", len(final.Uids))
 	}
-	for i := 0; i < len(arg.out.UidMatrix); i++ {
+	for i := range arg.out.UidMatrix {
 		algo.IntersectWith(arg.out.UidMatrix[i], final, arg.out.UidMatrix[i])
 	}
 	return nil
@@ -1705,7 +1705,7 @@ func (qs *queryState) filterStringFunction(arg funcArgs) error {
 		filtered = matchStrings(filtered, values, &filter)
 	}
 
-	for i := 0; i < len(arg.out.UidMatrix); i++ {
+	for i := range arg.out.UidMatrix {
 		algo.IntersectWith(arg.out.UidMatrix[i], filtered, arg.out.UidMatrix[i])
 	}
 	return nil

--- a/x/keys_test.go
+++ b/x/keys_test.go
@@ -92,8 +92,7 @@ func TestParseDataKeyWithStartUid(t *testing.T) {
 }
 
 func TestIndexKey(t *testing.T) {
-	var uid uint64
-	for uid = 0; uid < 1001; uid++ {
+	for uid := range 1001 {
 		sattr := fmt.Sprintf("attr:%d", uid)
 		sterm := fmt.Sprintf("term:%d", uid)
 
@@ -108,9 +107,8 @@ func TestIndexKey(t *testing.T) {
 }
 
 func TestIndexKeyWithStartUid(t *testing.T) {
-	var uid uint64
 	startUid := uint64(math.MaxUint64)
-	for uid = 0; uid < 1001; uid++ {
+	for uid := range 1001 {
 		sattr := fmt.Sprintf("attr:%d", uid)
 		sterm := fmt.Sprintf("term:%d", uid)
 
@@ -164,8 +162,8 @@ func TestReverseKeyWithStartUid(t *testing.T) {
 }
 
 func TestCountKey(t *testing.T) {
-	var count uint32
-	for count = 0; count < 1001; count++ {
+
+	for count := range uint32(1001) {
 		sattr := fmt.Sprintf("attr:%d", count)
 
 		key := CountKey(GalaxyAttr(sattr), count, true)
@@ -179,9 +177,8 @@ func TestCountKey(t *testing.T) {
 }
 
 func TestCountKeyWithStartUid(t *testing.T) {
-	var count uint32
 	startUid := uint64(math.MaxUint64)
-	for count = 0; count < 1001; count++ {
+	for count := range uint32(1001) {
 		sattr := fmt.Sprintf("attr:%d", count)
 
 		key := CountKey(GalaxyAttr(sattr), count, true)
@@ -199,8 +196,7 @@ func TestCountKeyWithStartUid(t *testing.T) {
 }
 
 func TestSchemaKey(t *testing.T) {
-	var uid uint64
-	for uid = 0; uid < 1001; uid++ {
+	for uid := range 1001 {
 		sattr := fmt.Sprintf("attr:%d", uid)
 
 		key := SchemaKey(GalaxyAttr(sattr))
@@ -213,8 +209,7 @@ func TestSchemaKey(t *testing.T) {
 }
 
 func TestTypeKey(t *testing.T) {
-	var uid uint64
-	for uid = 0; uid < 1001; uid++ {
+	for uid := range 1001 {
 		sattr := fmt.Sprintf("attr:%d", uid)
 
 		key := TypeKey(GalaxyAttr(sattr))

--- a/x/log_writer_test.go
+++ b/x/log_writer_test.go
@@ -78,7 +78,7 @@ func TestLogWriterWithEncryption(t *testing.T) {
 	msg := []byte("abcd")
 	msg = bytes.Repeat(msg, 256)
 	msg[1023] = '\n'
-	for i := 0; i < 10000; i++ {
+	for range 10000 {
 		n, err := lw.Write(msg)
 		require.NoError(t, err)
 		require.Equal(t, n, len(msg)+20, "write length is not equal")
@@ -131,9 +131,9 @@ func writeToLogWriterAndVerify(t *testing.T, lw *LogWriter, path string) {
 	msg := []byte("abcd")
 	msg = bytes.Repeat(msg, 256)
 	msg[1023] = '\n'
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		go func() {
-			for i := 0; i < 1000; i++ {
+			for range 1000 {
 				n, err := lw.Write(msg)
 				require.NoError(t, err)
 				require.Equal(t, n, len(msg), "write length is not equal")

--- a/x/x.go
+++ b/x/x.go
@@ -1071,7 +1071,7 @@ func GetDgraphClient(conf *viper.Viper, login bool) (*dgo.Dgraph, CloseFunc) {
 
 	for _, d := range ds {
 		var conn *grpc.ClientConn
-		for i := 0; i < retries; i++ {
+		for range retries {
 			conn, err = SetupConnection(d, tlsCfg, false, dialOpts...)
 			if err == nil {
 				break

--- a/xidmap/xidmap.go
+++ b/xidmap/xidmap.go
@@ -116,7 +116,7 @@ func New(opts XidMapOptions) *XidMap {
 		// If DB is provided, let's load up all the xid -> uid mappings in memory.
 		xm.writer = opts.DB.NewWriteBatch()
 
-		for i := 0; i < 16; i++ {
+		for range 16 {
 			xm.wg.Add(1)
 			go xm.dbWriter()
 		}


### PR DESCRIPTION
- use the int range loop introduced in go 1.22 so code is less verbose and easier to read
- add `intrange` linter to linter config