### PR TITLE
chore(repo): close response bodies to prevent resource leaks

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -38,3 +38,4 @@ linters:
     - unconvert
     - unused
     - intrange
+    - bodyclose

--- a/contrib/jepsen/main.go
+++ b/contrib/jepsen/main.go
@@ -43,6 +43,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/golang/glog"
 	"github.com/spf13/pflag"
 
 	"github.com/dgraph-io/dgraph/v24/contrib/jepsen/browser"
@@ -216,7 +217,12 @@ func jepsenServe() error {
 	// Check if the page is already up
 	checkServing := func() error {
 		url := jepsenURL()
-		_, err := http.Get(url) // nolint:gosec
+		resp, err := http.Get(url) // nolint:gosec
+		defer func() {
+			if err = resp.Body.Close(); err != nil {
+				glog.Errorf("Error while closing response body: %v", err)
+			}
+		}()
 		return err
 	}
 	if err := checkServing(); err == nil {

--- a/graphql/e2e/common/query.go
+++ b/graphql/e2e/common/query.go
@@ -88,6 +88,7 @@ func touchedUidsHeader(t *testing.T) {
 	client := http.Client{Timeout: 10 * time.Second}
 	resp, err := client.Do(req)
 	require.NoError(t, err)
+	defer func() { require.NoError(t, resp.Body.Close()) }()
 
 	// confirm that the header value is a non-negative integer
 	touchedUidsInHeader, err := strconv.ParseUint(resp.Header.Get("Graphql-TouchedUids"), 10, 64)
@@ -116,6 +117,7 @@ func cacheControlHeader(t *testing.T) {
 	client := http.Client{Timeout: 10 * time.Second}
 	resp, err := client.Do(req)
 	require.NoError(t, err)
+	defer func() { require.NoError(t, resp.Body.Close()) }()
 
 	// confirm that the header value is a non-negative integer
 	require.Equal(t, "public,max-age=5", resp.Header.Get("Cache-Control"))

--- a/graphql/e2e/common/subscription.go
+++ b/graphql/e2e/common/subscription.go
@@ -23,6 +23,7 @@ import (
 	"math/rand"
 	"net/http"
 
+	"github.com/golang/glog"
 	"github.com/gorilla/websocket"
 
 	"github.com/dgraph-io/dgraph/v24/graphql/schema"
@@ -68,11 +69,15 @@ func NewGraphQLSubscription(url string, req *schema.Request, subscriptionPayload
 
 	dialer := websocket.DefaultDialer
 	dialer.EnableCompression = true
-	conn, _, err := dialer.Dial(url, header)
+	conn, resp, err := dialer.Dial(url, header)
 	if err != nil {
 		return nil, err
 	}
-
+	defer func() {
+		if err = resp.Body.Close(); err != nil {
+			glog.Errorf("Error while closing response body: %v", err)
+		}
+	}()
 	// Initialize subscription.
 	init := operationMessage{
 		Type:    initMsg,

--- a/graphql/resolve/webhook.go
+++ b/graphql/resolve/webhook.go
@@ -124,6 +124,13 @@ func sendWebhookEvent(ctx context.Context, m schema.Mutation, commitTs uint64, r
 	if err != nil {
 		glog.V(3).Info(errors.Wrap(err, "unable to send webhook event"))
 	}
+
+	defer func() {
+		if err = resp.Body.Close(); err != nil {
+			glog.Errorf("Error while closing response body: %v", err)
+		}
+	}()
+
 	if resp != nil && (resp.StatusCode < 200 || resp.StatusCode >= 300) {
 		glog.V(3).Info(errors.Errorf("got unsuccessful status from webhook: %s", resp.Status))
 	}

--- a/systest/backup/common/utils.go
+++ b/systest/backup/common/utils.go
@@ -154,9 +154,9 @@ func AddItem(t *testing.T, minSuffixVal int, maxSuffixVal int, jwtToken string, 
 		client := &http.Client{}
 		resp, err := client.Do(req)
 		require.NoError(t, err)
-
 		var data interface{}
 		require.NoError(t, json.NewDecoder(resp.Body).Decode(&data))
+		require.NoError(t, resp.Body.Close())
 	}
 }
 
@@ -189,8 +189,8 @@ func CheckItemExists(t *testing.T, desriedSuffix int, jwtToken string, whichAlph
 	}
 	client := &http.Client{}
 	resp, err := client.Do(req)
-
 	require.NoError(t, err)
+	defer func() { require.NoError(t, resp.Body.Close()) }()
 
 	var data interface{}
 	require.NoError(t, json.NewDecoder(resp.Body).Decode(&data))
@@ -229,6 +229,7 @@ func TakeBackup(t *testing.T, jwtToken string, backupDst string, whichAlpha stri
 	client := &http.Client{}
 	resp, err := client.Do(req)
 	require.NoError(t, err)
+	defer func() { require.NoError(t, resp.Body.Close()) }()
 
 	var data interface{}
 	require.NoError(t, json.NewDecoder(resp.Body).Decode(&data))
@@ -265,6 +266,7 @@ func RunRestore(t *testing.T, jwtToken string, restoreLocation string, whichAlph
 	client := &http.Client{}
 	resp, err := client.Do(req)
 	require.NoError(t, err)
+	defer func() { require.NoError(t, resp.Body.Close()) }()
 
 	var data interface{}
 	require.NoError(t, json.NewDecoder(resp.Body).Decode(&data))

--- a/systest/bulk_live/common/bulk_live_cases.go
+++ b/systest/bulk_live/common/bulk_live_cases.go
@@ -798,6 +798,11 @@ func matchExportCount(opts matchExport) error {
 	if err != nil {
 		return err
 	}
+	defer func() {
+		if err = resp.Body.Close(); err != nil {
+			glog.Errorf("Error while closing response body: %v", err)
+		}
+	}()
 
 	b, err = io.ReadAll(resp.Body)
 	if err != nil {

--- a/testutil/backup.go
+++ b/testutil/backup.go
@@ -70,6 +70,7 @@ func WaitForRestore(t *testing.T, dg *dgo.Dgraph, HttpSocket string) {
 		resp, err := http.Get("http://" + HttpSocket + "/health")
 		require.NoError(t, err)
 		buf, err := io.ReadAll(resp.Body)
+		require.NoError(t, resp.Body.Close())
 		require.NoError(t, err)
 		sbuf := string(buf)
 		if !strings.Contains(sbuf, "opRestore") {


### PR DESCRIPTION
- close response bodies to prevent resource leaks ("The caller must close the response body when finished with it", see https://pkg.go.dev/net/http)
- add `bodyclose` linter to linter config
