### PR TITLE
perf(core): Introduce mutable map struct

### DIFF
--- a/dgraph/cmd/debug/run.go
+++ b/dgraph/cmd/debug/run.go
@@ -535,7 +535,7 @@ func lookup(db *badger.DB) {
 			log.Fatal(err)
 		}
 		pl.RLock()
-		c, _, _ := pl.GetLength(math.MaxUint64)
+		c := pl.GetLength(math.MaxUint64)
 		pl.RUnlock()
 		fmt.Fprintf(&buf, " Length: %d", c)
 
@@ -618,7 +618,7 @@ func printKeys(db *badger.DB) {
 		pl, err := posting.GetNew(key, db, opt.readTs)
 		if err == nil {
 			pl.RLock()
-			c, _, _ := pl.GetLength(math.MaxUint64)
+			c := pl.GetLength(math.MaxUint64)
 			fmt.Fprintf(&buf, " countValue: [%d]", c)
 			pl.RUnlock()
 		}

--- a/posting/index_test.go
+++ b/posting/index_test.go
@@ -270,6 +270,7 @@ func addEdgeToUID(t *testing.T, attr string, src uint64,
 }
 
 func TestCountReverseIndexWithData(t *testing.T) {
+	require.NoError(t, pstore.DropAll())
 	indexNameCountVal := "testcount: [uid] @count @reverse ."
 
 	attr := x.GalaxyAttr("testcount")
@@ -303,7 +304,7 @@ func TestCountReverseIndexWithData(t *testing.T) {
 }
 
 func TestCountReverseIndexEmptyPosting(t *testing.T) {
-	pstore.DropAll()
+	require.NoError(t, pstore.DropAll())
 	indexNameCountVal := "testcount: [uid] @count @reverse ."
 
 	attr := x.GalaxyAttr("testcount")

--- a/posting/index_test.go
+++ b/posting/index_test.go
@@ -240,6 +240,20 @@ func addEdgeToValue(t *testing.T, attr string, src uint64,
 	addMutation(t, l, edge, Set, startTs, commitTs, false)
 }
 
+func addDelEdgeToUID(t *testing.T, attr string, src uint64,
+	dst uint64, startTs, commitTs uint64) {
+	edge := &pb.DirectedEdge{
+		ValueId: dst,
+		Attr:    attr,
+		Entity:  src,
+		Op:      pb.DirectedEdge_DEL,
+	}
+	l, err := GetNoStore(x.DataKey(attr, src), startTs)
+	require.NoError(t, err)
+	// No index entries added here as we do not call AddMutationWithIndex.
+	addMutation(t, l, edge, Del, startTs, commitTs, false)
+}
+
 // addEdgeToUID adds uid edge with reverse edge
 func addEdgeToUID(t *testing.T, attr string, src uint64,
 	dst uint64, startTs, commitTs uint64) {
@@ -253,6 +267,38 @@ func addEdgeToUID(t *testing.T, attr string, src uint64,
 	require.NoError(t, err)
 	// No index entries added here as we do not call AddMutationWithIndex.
 	addMutation(t, l, edge, Set, startTs, commitTs, false)
+}
+
+func TestCountReverseIndex(t *testing.T) {
+	indexNameCountVal := "testcount: [uid] @count @reverse ."
+
+	attr := x.GalaxyAttr("testcount")
+	addDelEdgeToUID(t, attr, 1, 23, uint64(10), uint64(11))
+	l, err := GetNoStore(x.DataKey(attr, 1), 12)
+	require.NoError(t, err)
+	l.RLock()
+	require.Equal(t, l.GetLength(12), -1)
+	l.RUnlock()
+
+	require.NoError(t, schema.ParseBytes([]byte(indexNameCountVal), 1))
+	currentSchema, _ := schema.State().Get(context.Background(), attr)
+	rb := IndexRebuild{
+		Attr:          attr,
+		StartTs:       12,
+		OldSchema:     nil,
+		CurrentSchema: &currentSchema,
+	}
+	rebuildInfo := rb.needsTokIndexRebuild()
+	prefixes, err := rebuildInfo.prefixesForTokIndexes()
+	require.NoError(t, err)
+	require.NoError(t, pstore.DropPrefix(prefixes...))
+	require.NoError(t, rebuildCountIndex(context.Background(), &rb))
+
+	l, err = GetNoStore(x.DataKey(attr, 1), 14)
+	require.NoError(t, err)
+	l.RLock()
+	require.Equal(t, l.GetLength(14), 0)
+	l.RUnlock()
 }
 
 func TestRebuildTokIndex(t *testing.T) {

--- a/posting/index_test.go
+++ b/posting/index_test.go
@@ -303,6 +303,7 @@ func TestCountReverseIndexWithData(t *testing.T) {
 }
 
 func TestCountReverseIndexEmptyPosting(t *testing.T) {
+	pstore.DropAll()
 	indexNameCountVal := "testcount: [uid] @count @reverse ."
 
 	attr := x.GalaxyAttr("testcount")

--- a/posting/list.go
+++ b/posting/list.go
@@ -1223,10 +1223,6 @@ func (l *List) getPostingAndLengthNoSort(readTs, afterUid, uid uint64) (int, boo
 	}
 
 	length := l.GetLength(readTs)
-	l1, _, _ := l.getPostingAndLength(readTs, afterUid, uid)
-	if length != l1 {
-		panic(errors.Errorf("I panic"))
-	}
 
 	found, pos, err := l.findPosting(readTs, uid)
 	if err != nil {

--- a/posting/list.go
+++ b/posting/list.go
@@ -216,6 +216,7 @@ func (mm *MutableLayer) listLen(readTs uint64) int {
 
 	if mm.currentEntries != nil && (readTs == mm.readTs) {
 		if mm.populateDeleteAll(readTs) == mm.readTs {
+			// If deleteAll is present, we don't need the count from mm.length.
 			count = 0
 		}
 		checkPostingForCount(mm.currentEntries)

--- a/posting/list.go
+++ b/posting/list.go
@@ -664,7 +664,7 @@ func NewPosting(t *pb.DirectedEdge) *pb.Posting {
 	case pb.DirectedEdge_SET:
 		op = Set
 	case pb.DirectedEdge_OVR:
-		op = Set
+		op = Ovr
 	case pb.DirectedEdge_DEL:
 		op = Del
 	default:

--- a/posting/list.go
+++ b/posting/list.go
@@ -1212,6 +1212,10 @@ func (l *List) getPostingAndLengthNoSort(readTs, afterUid, uid uint64) (int, boo
 	}
 
 	length := l.GetLength(readTs)
+	l1, _, _ := l.getPostingAndLength(readTs, afterUid, uid)
+	if length != l1 {
+		panic(errors.Errorf("I panic"))
+	}
 
 	found, pos, err := l.findPosting(readTs, uid)
 	if err != nil {

--- a/posting/list_test.go
+++ b/posting/list_test.go
@@ -1708,21 +1708,21 @@ func TestSplitLength(t *testing.T) {
 	maxListSize = mb / 2
 
 	// Create a list that should be split recursively.
-	size := int(1e5)
+	size := uint64(1e5)
 	key := x.DataKey(x.GalaxyAttr(uuid.New().String()), 1333)
 	ol, err := readPostingListFromDisk(key, ps, math.MaxUint64)
 	require.NoError(t, err)
 	commits := 0
-	for i := 1; i <= size; i++ {
+	for i := uint64(1); i <= size; i++ {
 		commits++
 		edge := &pb.DirectedEdge{
-			ValueId: uint64(i),
+			ValueId: i,
 		}
-		edge.Facets = []*api.Facet{{Key: strconv.Itoa(i)}}
+		edge.Facets = []*api.Facet{{Key: fmt.Sprintf("%d", i)}}
 
 		txn := Txn{StartTs: uint64(i)}
 		addMutationHelper(t, ol, edge, Set, &txn)
-		require.NoError(t, ol.commitMutation(uint64(i), uint64(i)+1))
+		require.NoError(t, ol.commitMutation(i, i+1))
 
 		// Do not roll-up the list here to ensure the final list should
 		// be split more than once.
@@ -1737,7 +1737,7 @@ func TestSplitLength(t *testing.T) {
 	require.True(t, len(ol.plist.Splits) > 2)
 
 	ol.RLock()
-	require.Equal(t, size, ol.GetLength(uint64(size+10)))
+	require.Equal(t, int(size), ol.GetLength(size+10))
 	ol.RUnlock()
 
 }

--- a/posting/list_test.go
+++ b/posting/list_test.go
@@ -1720,7 +1720,7 @@ func TestSplitLength(t *testing.T) {
 		}
 		edge.Facets = []*api.Facet{{Key: fmt.Sprintf("%d", i)}}
 
-		txn := Txn{StartTs: uint64(i)}
+		txn := Txn{StartTs: i}
 		addMutationHelper(t, ol, edge, Set, &txn)
 		require.NoError(t, ol.commitMutation(i, i+1))
 

--- a/posting/mvcc.go
+++ b/posting/mvcc.go
@@ -497,8 +497,6 @@ func ReadPostingList(key []byte, it *badger.Iterator) (*List, error) {
 				pl.CommitTs = item.Version()
 				if l.mutationMap == nil {
 					l.mutationMap = newMutableLayer()
-					l.mutationMap.length = 0
-					l.mutationMap.deleteAllMarker = 0
 				}
 				l.mutationMap.insertCommittedPostings(pl)
 				return nil

--- a/posting/mvcc_test.go
+++ b/posting/mvcc_test.go
@@ -90,12 +90,12 @@ func TestCacheAfterDeltaUpdateRecieved(t *testing.T) {
 	// Read key at timestamp 10. Make sure cache is not updated by this, as there is a later read.
 	l, err := GetNoStore(key, 10)
 	require.NoError(t, err)
-	require.Equal(t, len(l.mutationMap), 0)
+	require.Equal(t, l.mutationMap.len(), 0)
 
 	// Read at 20 should show the value
 	l1, err := GetNoStore(key, 20)
 	require.NoError(t, err)
-	require.Equal(t, len(l1.mutationMap), 1)
+	require.Equal(t, l1.mutationMap.len(), 1)
 }
 
 func TestRollupTimestamp(t *testing.T) {

--- a/posting/size.go
+++ b/posting/size.go
@@ -68,14 +68,14 @@ func (l *List) DeepSize() uint64 {
 			unsafe.Pointer(hmap.Pointer() + uintptr(9)))))))
 		numOldBuckets := (*(*uint16)(unsafe.Pointer(hmap.Pointer() + uintptr(10))))
 		size += uint64(numOldBuckets * sizeOfBucket)
-		if len(l.mutationMap) > 0 || numBuckets > 1 {
+		if l.mutationMap.len() > 0 || numBuckets > 1 {
 			size += uint64(numBuckets * sizeOfBucket)
 		}
 	}
 	// adding the size of all the entries in the map.
-	for _, v := range l.mutationMap {
+	l.mutationMap.iterate(func(ts uint64, v *pb.PostingList) {
 		size += calculatePostingListSize(v)
-	}
+	}, math.MaxUint64)
 
 	return size
 }

--- a/posting/size_test.go
+++ b/posting/size_test.go
@@ -52,7 +52,7 @@ var (
 func BenchmarkPostingList(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		list = &List{}
-		list.mutationMap = make(map[uint64]*pb.PostingList)
+		list.mutationMap = newMutableLayer()
 	}
 }
 
@@ -82,7 +82,7 @@ func BenchmarkFacet(b *testing.B) {
 
 func TestPostingListCalculation(t *testing.T) {
 	list = &List{}
-	list.mutationMap = make(map[uint64]*pb.PostingList)
+	list.mutationMap = newMutableLayer()
 	// 144 is obtained from BenchmarkPostingList
 	require.Equal(t, uint64(144), list.DeepSize())
 }
@@ -134,7 +134,7 @@ func PopulateList(l *List, t *testing.T) {
 			continue
 		}
 		require.NoError(t, err)
-		l.mutationMap[i] = pl.plist
+		l.mutationMap.committedEntries[i] = pl.plist
 		i++
 	}
 }
@@ -147,7 +147,7 @@ func Test21MillionDataSet(t *testing.T) {
 		return
 	}
 	l := &List{}
-	l.mutationMap = make(map[uint64]*pb.PostingList)
+	l.mutationMap = newMutableLayer()
 	PopulateList(l, t)
 	// GC unwanted memory.
 	runtime.GC()

--- a/systest/mutations-and-queries/mutations_test.go
+++ b/systest/mutations-and-queries/mutations_test.go
@@ -2287,6 +2287,14 @@ func (ssuite *SystestTestSuite) CountIndexConcurrentSetDelScalarPredicate() {
 	gcli, cleanup, err = doGrpcLogin(ssuite)
 	defer cleanup()
 	require.NoError(t, err)
+
+	op.Schema = `name: string @index(exact) .`
+	require.NoError(t, gcli.Alter(ctx, op))
+
+	// We need to rebuild count index after the mutable map changes
+	op.Schema = `name: string @index(exact) @count .`
+	require.NoError(t, gcli.Alter(ctx, op))
+
 	_, err = gcli.NewTxn().Mutate(context.Background(), mu)
 	require.NoError(t, err, "mutation to delete name should have been succeeded")
 

--- a/tok/hnsw/helper.go
+++ b/tok/hnsw/helper.go
@@ -296,7 +296,7 @@ func getDataFromKeyWithCacheType(keyString string, uid uint64, c index.CacheType
 	key := DataKey(keyString, uid)
 	data, err := c.Get(key)
 	if err != nil {
-		return nil, errors.New(err.Error() + plError + keyString + " with uid" + strconv.FormatUint(uid, 10))
+		return nil, errors.New(err.Error() + plError + keyString + " with uid " + strconv.FormatUint(uid, 10))
 	}
 	return data, nil
 }
@@ -373,7 +373,7 @@ func (ph *persistentHNSW[T]) getVecFromUid(uid uint64, c index.CacheType, vec *[
 		if strings.Contains(err.Error(), plError) {
 			// no vector. Return empty array of floats
 			index.BytesAsFloatArray([]byte{}, vec, ph.floatBits)
-			return errors.New("Nil vector returned")
+			return errors.New(fmt.Sprintf("Nil vector returned %s", err.Error()))
 		}
 		return err
 	}

--- a/worker/mutation_unit_test.go
+++ b/worker/mutation_unit_test.go
@@ -64,7 +64,7 @@ func TestReverseEdge(t *testing.T) {
 	pl, err := txn.Get(x.DataKey(attr, 1))
 	require.NoError(t, err)
 	pl.RLock()
-	c, _, _ := pl.GetLength(5)
+	c := pl.GetLength(5)
 	pl.RUnlock()
 	require.Equal(t, c, 0)
 }

--- a/worker/sort_test.go
+++ b/worker/sort_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"github.com/dgraph-io/badger/v4"
+	bpb "github.com/dgraph-io/badger/v4/pb"
 	"github.com/dgraph-io/dgraph/v24/posting"
 	"github.com/dgraph-io/dgraph/v24/protos/pb"
 	"github.com/dgraph-io/dgraph/v24/schema"
@@ -30,22 +31,190 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func BenchmarkAddMutationWithIndex(b *testing.B) {
-	gr = new(groupi)
-	gr.gid = 1
-	gr.tablets = make(map[string]*pb.Tablet)
-	addTablets := func(attrs []string, gid uint32, namespace uint64) {
-		for _, attr := range attrs {
-			gr.tablets[x.NamespaceAttr(namespace, attr)] = &pb.Tablet{GroupId: gid}
+func readPostingListFromDisk(key []byte, pstore *badger.DB, readTs uint64) (*posting.List, error) {
+	txn := pstore.NewTransactionAt(readTs, false)
+	defer txn.Discard()
+
+	// When we do rollups, an older version would go to the top of the LSM tree, which can cause
+	// issues during txn.Get. Therefore, always iterate.
+	iterOpts := badger.DefaultIteratorOptions
+	iterOpts.AllVersions = true
+	iterOpts.PrefetchValues = false
+	itr := txn.NewKeyIterator(key, iterOpts)
+	defer itr.Close()
+	itr.Seek(key)
+	return posting.ReadPostingList(key, itr)
+}
+
+func rollup(t *testing.T, key []byte, pstore *badger.DB, readTs uint64) {
+	ol, err := readPostingListFromDisk(key, pstore, readTs)
+	require.NoError(t, err)
+	kvs, err := ol.Rollup(nil, readTs+1)
+	require.NoError(t, err)
+	require.NoError(t, writePostingListToDisk(kvs))
+}
+
+func writePostingListToDisk(kvs []*bpb.KV) error {
+	writer := posting.NewTxnWriter(pstore)
+	for _, kv := range kvs {
+		if err := writer.SetAt(kv.Key, kv.Value, kv.UserMeta[0], kv.Version); err != nil {
+			return err
 		}
 	}
+	return writer.Flush()
+}
 
-	addTablets([]string{"name", "name2", "age", "http://www.w3.org/2000/01/rdf-schema#range", "",
-		"friend", "dgraph.type", "dgraph.graphql.xid", "dgraph.graphql.schema"},
-		1, x.GalaxyNamespace)
-	addTablets([]string{"friend_not_served"}, 2, x.GalaxyNamespace)
-	addTablets([]string{"name"}, 1, 0x2)
+func TestSingleUid(t *testing.T) {
+	dir, err := os.MkdirTemp("", "storetest_")
+	x.Check(err)
+	defer os.RemoveAll(dir)
 
+	opt := badger.DefaultOptions(dir)
+	ps, err := badger.OpenManaged(opt)
+	x.Check(err)
+	pstore = ps
+	posting.Init(ps, 0)
+	Init(ps)
+	err = schema.ParseBytes([]byte("singleUidTest: string @index(exact) @unique ."), 1)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	txn := posting.Oracle().RegisterStartTs(5)
+	attr := x.GalaxyAttr("singleUidTest")
+
+	// Txn 1. Set 1 -> david 2 -> blush
+	x.Check(runMutation(ctx, &pb.DirectedEdge{
+		Value:  []byte("david"),
+		Attr:   attr,
+		Entity: 1,
+		Op:     pb.DirectedEdge_SET,
+	}, txn))
+
+	x.Check(runMutation(ctx, &pb.DirectedEdge{
+		Value:  []byte("blush"),
+		Attr:   attr,
+		Entity: 2,
+		Op:     pb.DirectedEdge_SET,
+	}, txn))
+
+	txn.Update()
+	writer := posting.NewTxnWriter(pstore)
+	require.NoError(t, txn.CommitToDisk(writer, 7))
+	require.NoError(t, writer.Flush())
+	txn.UpdateCachedKeys(7)
+
+	// Txn 2. Set 2 -> david 1 -> blush
+	txn = posting.Oracle().RegisterStartTs(9)
+
+	x.Check(runMutation(ctx, &pb.DirectedEdge{
+		Value:  []byte("david"),
+		Attr:   attr,
+		Entity: 2,
+		Op:     pb.DirectedEdge_SET,
+	}, txn))
+
+	x.Check(runMutation(ctx, &pb.DirectedEdge{
+		Value:  []byte("blush"),
+		Attr:   attr,
+		Entity: 1,
+		Op:     pb.DirectedEdge_SET,
+	}, txn))
+
+	txn.Update()
+	writer = posting.NewTxnWriter(pstore)
+	require.NoError(t, txn.CommitToDisk(writer, 11))
+	require.NoError(t, writer.Flush())
+	txn.UpdateCachedKeys(11)
+
+	key := x.IndexKey(attr, string([]byte{2, 100, 97, 118, 105, 100}))
+
+	// Reading the david index, we should see 2 inserted, 1 deleted
+	txn = posting.Oracle().RegisterStartTs(15)
+	l, err := txn.Get(key)
+	require.NoError(t, err)
+
+	found, mpost, err := l.FindPosting(15, 2)
+	require.NoError(t, err)
+	require.Equal(t, found, true)
+	require.Equal(t, mpost.Op, uint32(0x1))
+
+	found, _, err = l.FindPosting(15, 1)
+	require.NoError(t, err)
+	require.Equal(t, found, false)
+
+	rollup(t, key, pstore, 16)
+
+	txn = posting.Oracle().RegisterStartTs(18)
+	l, err = txn.Get(key)
+	require.NoError(t, err)
+
+	found, mpost, err = l.FindPosting(18, 2)
+	require.NoError(t, err)
+	require.Equal(t, found, true)
+	require.Equal(t, mpost.Op, uint32(0x0))
+
+	found, _, err = l.FindPosting(18, 1)
+	require.NoError(t, err)
+	require.Equal(t, found, false)
+}
+
+func TestLangExact(t *testing.T) {
+	dir, err := os.MkdirTemp("", "storetest_")
+	x.Check(err)
+	defer os.RemoveAll(dir)
+
+	opt := badger.DefaultOptions(dir)
+	ps, err := badger.OpenManaged(opt)
+	x.Check(err)
+	pstore = ps
+	// Not using posting list cache
+	posting.Init(ps, 0)
+	Init(ps)
+	err = schema.ParseBytes([]byte("testLang: string @index(term) @lang ."), 1)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	txn := posting.Oracle().RegisterStartTs(5)
+	attr := x.GalaxyAttr("testLang")
+
+	edge := &pb.DirectedEdge{
+		Value:  []byte("english"),
+		Attr:   attr,
+		Entity: 1,
+		Op:     pb.DirectedEdge_SET,
+		Lang:   "en",
+	}
+
+	x.Check(runMutation(ctx, edge, txn))
+
+	edge = &pb.DirectedEdge{
+		Value:  []byte("hindi"),
+		Attr:   attr,
+		Entity: 1,
+		Op:     pb.DirectedEdge_SET,
+		Lang:   "hi",
+	}
+
+	x.Check(runMutation(ctx, edge, txn))
+
+	txn.Update()
+	writer := posting.NewTxnWriter(pstore)
+	require.NoError(t, txn.CommitToDisk(writer, 2))
+	require.NoError(t, writer.Flush())
+	txn.UpdateCachedKeys(2)
+
+	key := x.DataKey(attr, 1)
+	rollup(t, key, pstore, 4)
+
+	pl, err := readPostingListFromDisk(key, pstore, 6)
+	require.NoError(t, err)
+
+	val, err := pl.ValueForTag(6, "hi")
+	require.NoError(t, err)
+	require.Equal(t, val.Value, []byte("hindi"))
+}
+
+func BenchmarkAddMutationWithIndex(b *testing.B) {
 	dir, err := os.MkdirTemp("", "storetest_")
 	x.Check(err)
 	defer os.RemoveAll(dir)

--- a/worker/worker_test.go
+++ b/worker/worker_test.go
@@ -357,6 +357,28 @@ func TestCountReverseIndex(t *testing.T) {
 	}
 }
 
+func TestCountIndexOverwrite(t *testing.T) {
+	schemaStr := "friend: [uid] @reverse @count ."
+	dg, err := testutil.DgraphClient(testutil.SockAddr)
+	if err != nil {
+		t.Fatalf("Error while getting a dgraph client: %v", err)
+	}
+	testutil.DropAll(t, dg)
+
+	require.NoError(t, dg.Alter(context.Background(), &api.Operation{Schema: schemaStr}))
+
+	for i := 0; i < 1000; i++ {
+		setClusterEdge(t, dg, fmt.Sprintf("<%#x> <friend> <%#x> .", 1, 2))
+	}
+	resp, err := runQuery(
+		dg,
+		"count(friend)",
+		nil,
+		[]string{"eq", "", "1"})
+	require.Equal(
+		t, string(resp.Json), `{"q":[{"uid":"0x1"}]}`)
+}
+
 func TestCountReverseWithDeletes(t *testing.T) {
 	schemaStr := "friend: [uid] @reverse @count ."
 	dg, err := testutil.DgraphClient(testutil.SockAddr)

--- a/x/debug.go
+++ b/x/debug.go
@@ -25,6 +25,7 @@ import (
 	"sort"
 
 	"github.com/golang/glog"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/dgraph-io/badger/v4"
 	bpb "github.com/dgraph-io/badger/v4/pb"
@@ -77,7 +78,7 @@ func VerifySnapshot(pstore *badger.DB, readTs uint64) {
 
 			err := item.Value(func(v []byte) error {
 				plist := &pb.PostingList{}
-				Check(plist.Unmarshal(v))
+				Check(proto.Unmarshal(v, plist))
 				VerifyPack(plist)
 				if len(plist.Splits) == 0 {
 					return nil


### PR DESCRIPTION
Currently the delta postings are being stored inside a map. When we are using cache, these deltas gets unnecessarily copied again and again because of the limitations of map. We have introduced a new struct, that would allow us to work on the list of 
deltas. 
With the introduction of this, we can now without copying the map, can pass around lists from one transaction to another without issue.

We are also going to store results like delete markers, uid to posting map and other stuff required to make queries go faster.  