### PR TITLE
Enhancing Dgraph cd pipeline to only push images to Dockerhub when both AMD and ARM builds are successful

### DIFF
--- a/.github/workflows/cd-dgraph.yml
+++ b/.github/workflows/cd-dgraph.yml
@@ -179,7 +179,7 @@ jobs:
           make docker-image-standalone DGRAPH_VERSION=${{ env.DGRAPH_RELEASE_VERSION }}-arm64
           [[ "${{ inputs.latest }}" = true ]] && docker tag dgraph/standalone:${{ env.DGRAPH_RELEASE_VERSION }}-arm64 dgraph/standalone:latest-arm64 || true
 
-  dgraph-docker-manifest:
+  dgraph-docker-image-and-manifests-push:
     needs: [dgraph-build-amd64, dgraph-build-arm64]
     runs-on: warp-ubuntu-latest-x64-16x
     steps:

--- a/.github/workflows/cd-dgraph.yml
+++ b/.github/workflows/cd-dgraph.yml
@@ -96,19 +96,6 @@ jobs:
         run: |
           make docker-image-standalone DGRAPH_VERSION=${{ env.DGRAPH_RELEASE_VERSION }}-amd64
           [[ "${{ inputs.latest }}" = true ]] && docker tag dgraph/standalone:${{ env.DGRAPH_RELEASE_VERSION }}-amd64 dgraph/standalone:latest-amd64 || true
-      - name: Login to DockerHub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD_TOKEN }}
-      - name: Push Images to DockerHub
-        run: |
-          if [ "${{ inputs.custom-build }}" == "true" ]; then
-            docker push dgraph/dgraph-custom:${{ env.DGRAPH_RELEASE_VERSION }}-amd64
-          else
-            docker push dgraph/standalone:${{ env.DGRAPH_RELEASE_VERSION }}-amd64
-            docker push dgraph/dgraph:${{ env.DGRAPH_RELEASE_VERSION }}-amd64
-          fi
 
   dgraph-build-arm64:
     runs-on: warp-ubuntu-latest-arm64-16x
@@ -191,19 +178,6 @@ jobs:
         run: |
           make docker-image-standalone DGRAPH_VERSION=${{ env.DGRAPH_RELEASE_VERSION }}-arm64
           [[ "${{ inputs.latest }}" = true ]] && docker tag dgraph/standalone:${{ env.DGRAPH_RELEASE_VERSION }}-arm64 dgraph/standalone:latest-arm64 || true
-      - name: Login to DockerHub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD_TOKEN }}
-      - name: Push Images to DockerHub
-        run: |
-          if [ "${{ inputs.custom-build }}" == "true" ]; then
-            docker push dgraph/dgraph-custom:${{ env.DGRAPH_RELEASE_VERSION }}-arm64
-          else
-            docker push dgraph/standalone:${{ env.DGRAPH_RELEASE_VERSION }}-arm64
-            docker push dgraph/dgraph:${{ env.DGRAPH_RELEASE_VERSION }}-arm64
-          fi
 
   dgraph-docker-manifest:
     needs: [dgraph-build-amd64, dgraph-build-arm64]
@@ -234,22 +208,31 @@ jobs:
       - name: Docker Manifest
         run: |
             if [ "${{ github.event.inputs.custom-build }}" == "true" ]; then
+               #Push AMD and ARM images to dgraph-custom repo
+              docker push dgraph/dgraph-custom:${{ env.DGRAPH_RELEASE_VERSION }}-amd64
+              docker push dgraph/dgraph-custom:${{ env.DGRAPH_RELEASE_VERSION }}-arm64
               docker manifest create dgraph/dgraph-custom:${{ env.DGRAPH_RELEASE_VERSION }} --amend dgraph/dgraph-custom:${{ env.DGRAPH_RELEASE_VERSION }}-amd64 --amend dgraph/dgraph-custom:${{ env.DGRAPH_RELEASE_VERSION }}-arm64
               docker manifest push dgraph/dgraph-custom:${{ env.DGRAPH_RELEASE_VERSION }}
             else
-              # standalone
+              # Push standalone Images and manifest
+              docker push dgraph/standalone:${{ env.DGRAPH_RELEASE_VERSION }}-amd64
+              docker push dgraph/standalone:${{ env.DGRAPH_RELEASE_VERSION }}-arm64
               docker manifest create dgraph/standalone:${{ env.DGRAPH_RELEASE_VERSION }} --amend dgraph/standalone:${{ env.DGRAPH_RELEASE_VERSION }}-amd64 --amend dgraph/standalone:${{ env.DGRAPH_RELEASE_VERSION }}-arm64      
               docker manifest push dgraph/standalone:${{ env.DGRAPH_RELEASE_VERSION }}
-              if [ "${{ github.event.inputs.latest }}" == "true" ]; then
-                 docker manifest create dgraph/standalone:latest --amend dgraph/standalone:${{ env.DGRAPH_RELEASE_VERSION }}-amd64 --amend dgraph/standalone:${{ env.DGRAPH_RELEASE_VERSION }}-arm64
-                 docker manifest push dgraph/standalone:latest
-              fi
-              # dgraph
+              
+             # Push Dgraph  Images  and Manifest
+              docker push dgraph/dgraph:${{ env.DGRAPH_RELEASE_VERSION }}-amd64
+              docker push dgraph/dgraph:${{ env.DGRAPH_RELEASE_VERSION }}-arm64
               docker manifest create dgraph/dgraph:${{ env.DGRAPH_RELEASE_VERSION }} --amend dgraph/dgraph:${{ env.DGRAPH_RELEASE_VERSION }}-amd64 --amend dgraph/dgraph:${{ env.DGRAPH_RELEASE_VERSION }}-arm64
               docker manifest push dgraph/dgraph:${{ env.DGRAPH_RELEASE_VERSION }}
+
+        
               if [ "${{ github.event.inputs.latest }}" == "true" ]; then
+                 docker manifest create dgraph/standalone:latest --amend dgraph/standalone:${{ env.DGRAPH_RELEASE_VERSION }}-amd64 --amend dgraph/standalone:${{ env.DGRAPH_RELEASE_VERSION }}-arm64
                  docker manifest create dgraph/dgraph:latest --amend dgraph/dgraph:${{ env.DGRAPH_RELEASE_VERSION }}-amd64 --amend dgraph/dgraph:${{ env.DGRAPH_RELEASE_VERSION }}-arm64
+                 docker manifest push dgraph/standalone:latest
                  docker manifest push dgraph/dgraph:latest
               fi
             fi
+
 


### PR DESCRIPTION
Dgraph CD pipeline was prematurely publishing Docker images to DockerHub even when one of the architectures failed. This PR makes the following changes to prevent this:
- dgraph-build-amd64 and dgraph-build-arm64 jobs build their respective images. But **do not** push them to DockerHub.
- Job **dgraph-docker-manifest** is renamed to **dgraph-docker-image-and-manifests-push** to reflect that it also pushes docker images for Dgraph/Custom/Standalone