### PR TITLE
Megha/cd pipeline enhancement

### DIFF
--- a/.github/workflows/cd-dgraph.yml
+++ b/.github/workflows/cd-dgraph.yml
@@ -116,7 +116,7 @@ jobs:
         if: inputs.custom-build == false
         uses: actions/upload-artifact@v4
         with:
-          name: dgraph-docker-standalone-amd64
+          name: dgraph-standalone-amd64
           path: dgraph-standalone-amd64.tar
 
   dgraph-build-arm64:
@@ -219,7 +219,7 @@ jobs:
         if: inputs.custom-build == false
         uses: actions/upload-artifact@v4
         with:
-          name: dgraph-docker-standalone-arm64
+          name: dgraph-standalone-arm64
           path: dgraph-standalone-arm64.tar
   dgraph-docker-image-and-manifests-push:
     needs: [dgraph-build-amd64, dgraph-build-arm64]
@@ -265,10 +265,38 @@ jobs:
         run: |
           docker load -i dgraph-docker-amd64.tar
 
-      # Load ARM64 Image
+      # Load Dgraph ARM64 Image
       - name: Load ARM64 Docker Image
         run: |
           docker load -i dgraph-docker-arm64.tar
+      
+      # Download Standalone AMD64 Tar File
+      - name: Download Standalone AMD64 Tar
+        if: inputs.custom-build == false
+        uses: actions/download-artifact@v4
+        with:
+          name: dgraph-standalone-amd64
+
+      # Load Standalone AMD64 Image
+      - name: Load Standalone AMD64 Docker Image
+        if: inputs.custom-build == false
+        run: |
+          docker load -i dgraph-standalone-amd64.tar
+      
+      # Download Standalone ARM64 Tar File
+      - name: Download Standalone ARM64 Tar
+        if: inputs.custom-build == false
+        uses: actions/download-artifact@v4
+        with:
+          name: dgraph-standalone-arm64
+
+      # Load Standalone ARM64 Image
+      - name: Load Standalone ARM64 Docker Image
+        if: inputs.custom-build == false
+        run: |
+          docker load -i dgraph-standalone-arm64.tar
+      
+      
       - name: Docker Manifest
         run: |
             if [ "${{ github.event.inputs.custom-build }}" == "true" ]; then

--- a/.github/workflows/cd-dgraph.yml
+++ b/.github/workflows/cd-dgraph.yml
@@ -88,15 +88,36 @@ jobs:
           cp badger/badger-linux-amd64 linux/badger
       - name: Make Dgraph Docker Image
         run: |
+          set -e
           make docker-image DGRAPH_VERSION=${{ env.DGRAPH_RELEASE_VERSION }}-amd64
           [[ "${{ inputs.latest }}" = true ]] && docker tag dgraph/dgraph:${{ env.DGRAPH_RELEASE_VERSION }}-amd64 dgraph/dgraph:latest-amd64 || true
           [[ "${{ inputs.custom-build }}" = true ]] && docker tag dgraph/dgraph:${{ env.DGRAPH_RELEASE_VERSION }}-amd64 dgraph/dgraph-custom:${{ env.DGRAPH_RELEASE_VERSION }}-amd64  || true
+          #Save all tagged images into a single tar file
+          docker save -o dgraph-docker-amd64.tar \
+                dgraph/dgraph:${{ env.DGRAPH_RELEASE_VERSION }}-amd64 \
+                $( [[ "${{ inputs.latest }}" = true ]] && echo "dgraph/dgraph:latest-amd64" ) \
+               $( [[ "${{ inputs.custom-build }}" = true ]] && echo "dgraph/dgraph-custom:${{ env.DGRAPH_RELEASE_VERSION }}-amd64" )
+      - name: Upload AMD64 Docker Image
+        uses: actions/upload-artifact@v4
+        with:
+          name: dgraph-docker-amd64
+          path: dgraph-docker-amd64.tar
       - name: Make Dgraph Standalone Docker Image with Version
         #No need to build and push Standalone Image when its a custom build
         if: inputs.custom-build == false
         run: |
+          set -e
           make docker-image-standalone DGRAPH_VERSION=${{ env.DGRAPH_RELEASE_VERSION }}-amd64
           [[ "${{ inputs.latest }}" = true ]] && docker tag dgraph/standalone:${{ env.DGRAPH_RELEASE_VERSION }}-amd64 dgraph/standalone:latest-amd64 || true
+          docker save -o dgraph-standalone-amd64.tar \
+                dgraph/standalone:${{ env.DGRAPH_RELEASE_VERSION }}-amd64 \
+                $( [[ "${{ inputs.latest }}" = true ]] && echo "dgraph/standalone:latest-amd64" )
+      - name: Upload AMD64 Standalone Image
+        if: inputs.custom-build == false
+        uses: actions/upload-artifact@v4
+        with:
+          name: dgraph-docker-standalone-amd64
+          path: dgraph-standalone-amd64.tar
 
   dgraph-build-arm64:
     runs-on: warp-ubuntu-latest-arm64-16x
@@ -171,16 +192,35 @@ jobs:
           cp badger/badger-linux-arm64 linux/badger
       - name: Make Dgraph Docker Image
         run: |
+          set -e
           make docker-image DGRAPH_VERSION=${{ env.DGRAPH_RELEASE_VERSION }}-arm64
           [[ "${{ inputs.latest }}" = true ]] && docker tag dgraph/dgraph:${{ env.DGRAPH_RELEASE_VERSION }}-arm64 dgraph/dgraph:latest-arm64 || true
           [[ "${{ inputs.custom-build }}" = true ]] && docker tag dgraph/dgraph:${{ env.DGRAPH_RELEASE_VERSION }}-arm64 dgraph/dgraph-custom:${{ env.DGRAPH_RELEASE_VERSION }}-arm64  || true
+          docker save -o dgraph-docker-arm64.tar \
+                dgraph/dgraph:${{ env.DGRAPH_RELEASE_VERSION }}-arm64 \
+                $( [[ "${{ inputs.latest }}" = true ]] && echo "dgraph/dgraph:latest-arm64" ) \
+               $( [[ "${{ inputs.custom-build }}" = true ]] && echo "dgraph/dgraph-custom:${{ env.DGRAPH_RELEASE_VERSION }}-arm64" )
+      - name: Upload ARM64 Docker Image
+        uses: actions/upload-artifact@v4
+        with:
+          name: dgraph-docker-arm64
+          path: dgraph-docker-arm64.tar
       - name: Make Dgraph Standalone Docker Image with Version
          #No need to build and push Standalone Image when its a custom build
         if: inputs.custom-build == false
         run: |
+          set -e
           make docker-image-standalone DGRAPH_VERSION=${{ env.DGRAPH_RELEASE_VERSION }}-arm64
           [[ "${{ inputs.latest }}" = true ]] && docker tag dgraph/standalone:${{ env.DGRAPH_RELEASE_VERSION }}-arm64 dgraph/standalone:latest-arm64 || true
-
+          docker save -o dgraph-standalone-arm64.tar \
+                dgraph/standalone:${{ env.DGRAPH_RELEASE_VERSION }}-arm64 \
+                $( [[ "${{ inputs.latest }}" = true ]] && echo "dgraph/standalone:latest-arm64" )
+      - name: Upload ARM64 Standalone Image
+        if: inputs.custom-build == false
+        uses: actions/upload-artifact@v4
+        with:
+          name: dgraph-docker-standalone-arm64
+          path: dgraph-standalone-arm64.tar
   dgraph-docker-image-and-manifests-push:
     needs: [dgraph-build-amd64, dgraph-build-arm64]
     runs-on: warp-ubuntu-latest-x64-16x
@@ -207,6 +247,28 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD_TOKEN }}
+        
+          # Download AMD64 Tar File
+      - name: Download Dgraph AMD64 Tar
+        uses: actions/download-artifact@v4
+        with:
+          name: dgraph-docker-amd64
+
+      # Download Dgraph ARM64 Tar File
+      - name: Download ARM64 Tar
+        uses: actions/download-artifact@v4
+        with:
+          name: dgraph-docker-arm64
+
+      # Load Dgraph AMD64 Image
+      - name: Load AMD64 Docker Image
+        run: |
+          docker load -i dgraph-docker-amd64.tar
+
+      # Load ARM64 Image
+      - name: Load ARM64 Docker Image
+        run: |
+          docker load -i dgraph-docker-arm64.tar
       - name: Docker Manifest
         run: |
             if [ "${{ github.event.inputs.custom-build }}" == "true" ]; then

--- a/.github/workflows/cd-dgraph.yml
+++ b/.github/workflows/cd-dgraph.yml
@@ -74,7 +74,7 @@ jobs:
       - name: Upload Build Artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: dgraph-build-amd
+          name: dgraph-amd-release-artifacts
           path: |
             badger/badger-checksum-linux-amd64.sha256
             badger/badger-linux-amd64.tar.gz
@@ -178,7 +178,7 @@ jobs:
       - name: Upload Build Artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: dgraph-build-arm
+          name: dgraph-arm-release-artifacts
           path: |
             badger/badger-checksum-linux-arm64.sha256
             badger/badger-linux-arm64.tar.gz


### PR DESCRIPTION
This PR introduces improvements to the Dgraph CD pipeline so that ARM and AMD images are saved as  artifacts (dgraph-docker-amd64 and dgraph-docker-arm64)  in the respective build jobs and utilizes these in the manifest creation job later. 

Key Changes:
- Save Docker Image Artifacts for Dgraph and Standalone Images - in both AMD and ARM Jobs
- The dgraph-docker-image-and-manifest job downloads the saved artifacts and loads them back into Docker using docker load, ensuring consistency across the workflow.
