### PR TITLE
Fixing  README.md to mention 24.0.5 as latest also fixing wrong link

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,11 +33,11 @@ Dgraph supports [GraphQL query syntax](https://dgraph.io/docs/main/query-languag
 
 ## Status
 
-Dgraph is at [version v24.0.2][rel] and is production-ready. Apart from the vast open source community, it is being used in
+Dgraph is at [version v24.0.5][rel] and is production-ready. Apart from the vast open source community, it is being used in
 production at multiple Fortune 500 companies, and by
 [Intuit Katlas](https://github.com/intuit/katlas) and [VMware Purser](https://github.com/vmware/purser). A hosted version of Dgraph is available at [https://cloud.dgraph.io](https://cloud.dgraph.io).
 
-[rel]: https://github.com/dgraph-io/dgraph/releases/tag/v22.0.0
+[rel]: https://github.com/dgraph-io/dgraph/releases/tag/v24.0.5
 
 ## Supported Platforms
 


### PR DESCRIPTION
The README in Dgraph Repo referring **v24.0.2** as the latest version and was hyperlinked to https://github.com/dgraph-io/dgraph/releases/tag/v22.0.0 which was wrong.

Fixing it to referring v24.0.5 as the latest and pointing to the v24.0.5 release