### PR TITLE
fix(core): Improve error handling in hnsw module

### DIFF
--- a/tok/hnsw/helper.go
+++ b/tok/hnsw/helper.go
@@ -43,8 +43,6 @@ const (
 	Euclidean            = "euclidean"
 	Cosine               = "cosine"
 	DotProd              = "dotproduct"
-	plError              = "\nerror fetching posting list for data key: "
-	dataError            = "\nerror fetching data for data key: "
 	EmptyHNSWTreeError   = "HNSW tree has no elements"
 	VecKeyword           = "__vector_"
 	visitedVectorsLevel  = "visited_vectors_level_"
@@ -62,6 +60,11 @@ const (
 	DefaultPrefix = byte(0x00)
 	// NsSeparator is the separator between the namespace and attribute.
 	NsSeparator = "-"
+)
+
+var (
+	errNilVector           = errors.New("nil vector returned")
+	errFetchingPostingList = errors.New("error fetching posting list")
 )
 
 type SearchResult struct {
@@ -240,7 +243,7 @@ func GetSimType[T c.Float](indexType string, floatBits int) SimilarityType[T] {
 	}
 }
 
-// implements CacheType interface
+// TxnCache implements CacheType interface
 type TxnCache struct {
 	txn     index.Txn
 	startTs uint64
@@ -265,7 +268,7 @@ func NewTxnCache(txn index.Txn, startTs uint64) *TxnCache {
 	}
 }
 
-// implements index.CacheType interface
+// QueryCache implements index.CacheType interface
 type QueryCache struct {
 	cache  index.LocalCache
 	readTs uint64
@@ -296,7 +299,7 @@ func getDataFromKeyWithCacheType(keyString string, uid uint64, c index.CacheType
 	key := DataKey(keyString, uid)
 	data, err := c.Get(key)
 	if err != nil {
-		return nil, errors.New(err.Error() + plError + keyString + " with uid " + strconv.FormatUint(uid, 10))
+		return nil, fmt.Errorf("%w: %w; %s", err, errFetchingPostingList, keyString+" with uid "+strconv.FormatUint(uid, 10))
 	}
 	return data, nil
 }
@@ -314,10 +317,10 @@ func populateEdgeDataFromKeyWithCacheType(
 	c index.CacheType,
 	edgeData *[][]uint64) (bool, error) {
 	data, err := getDataFromKeyWithCacheType(keyString, uid, c)
-	// Note that "dataError" errors are treated as just not having
+	// Note that posting list fetching errors are treated as just not having
 	// found the data -- no harm, no foul, as it is probably a
 	// dead reference that we can ignore.
-	if err != nil && !strings.Contains(err.Error(), dataError) {
+	if err != nil && !errors.Is(err, errFetchingPostingList) {
 		return false, err
 	}
 	if data == nil {
@@ -370,20 +373,19 @@ func getInsertLayer(maxLevels int) int {
 func (ph *persistentHNSW[T]) getVecFromUid(uid uint64, c index.CacheType, vec *[]T) error {
 	data, err := getDataFromKeyWithCacheType(ph.pred, uid, c)
 	if err != nil {
-		if strings.Contains(err.Error(), plError) {
+		if errors.Is(err, errFetchingPostingList) {
 			// no vector. Return empty array of floats
 			index.BytesAsFloatArray([]byte{}, vec, ph.floatBits)
-			return errors.New(fmt.Sprintf("Nil vector returned %s", err.Error()))
+			return fmt.Errorf("%w; %w", errNilVector, err)
 		}
 		return err
 	}
 	if data != nil {
 		index.BytesAsFloatArray(data.([]byte), vec, ph.floatBits)
 		return nil
-
 	} else {
 		index.BytesAsFloatArray([]byte{}, vec, ph.floatBits)
-		return errors.New("Nil vector returned")
+		return errNilVector
 	}
 }
 
@@ -663,7 +665,7 @@ func (ph *persistentHNSW[T]) removeDeadNodes(nnEdges []uint64, tc *TxnCache) ([]
 	// TODO add a path to delete deadNodes
 	if ph.deadNodes == nil {
 		data, err := getDataFromKeyWithCacheType(ph.vecDead, 1, tc)
-		if err != nil && err.Error() == plError {
+		if err != nil && !errors.Is(err, errFetchingPostingList) {
 			return []uint64{}, err
 		}
 


### PR DESCRIPTION
Description: 
This PR improves error handling in the hnsw module. In some cases not all errors have to be propagated to the next caller, in this case the error string is currently compared with `strings.Contains(err.Error(), "some_error_text")` or directly `err.Error() == "some_error_string"`. This is bad practice. Instead errors should be directly compared with the native `errors.Is(err, target)` function, which traverses the tree of each error and detects if it contains the specified target error. 

This refactor also fixes two occurrences where the caller of a function compared the error string to a value which could never occur:

https://github.com/dgraph-io/dgraph/pull/9236/files#diff-3a3681ae8c7d51cf49f269f9a732cfe2941dee13903fed04a17a51d5ddff3540R323
https://github.com/dgraph-io/dgraph/pull/9236/files#diff-3a3681ae8c7d51cf49f269f9a732cfe2941dee13903fed04a17a51d5ddff3540R668