### PR TITLE
ci(test): integrate Trunk into multiple CI workflows to identify flaky tests

### DIFF
--- a/.github/workflows/ci-dgraph-code-coverage.yml
+++ b/.github/workflows/ci-dgraph-code-coverage.yml
@@ -23,6 +23,8 @@ jobs:
           #!/bin/bash
           # build the test binary
           cd t; go build .
+      - name: Install gotestsum
+        run: go install gotest.tools/gotestsum@latest
       - name: Clean Up Environment
         run: |
           #!/bin/bash

--- a/.github/workflows/ci-dgraph-core-tests.yml
+++ b/.github/workflows/ci-dgraph-core-tests.yml
@@ -24,6 +24,8 @@ jobs:
           go-version-file: go.mod
       - name: Install protobuf-compiler
         run: sudo apt update && sudo apt install -y protobuf-compiler
+      - name: Install gotestsum
+        run: go install gotest.tools/gotestsum@latest
       - name: Check protobuf
         run: |
           cd ./protos
@@ -57,3 +59,11 @@ jobs:
           ./t -r
           # sleep
           sleep 5
+      - name: Upload Test Results
+        if: always() # Upload the results even if the tests fail
+        continue-on-error: true # don't fail this job if the upload fails
+        uses: trunk-io/analytics-uploader@main
+        with:
+          junit-paths: "./test-results.xml"        
+          org-slug: hypermode
+          token: ${{ secrets.TRUNK_TOKEN }}

--- a/.github/workflows/ci-dgraph-ldbc-tests.yml
+++ b/.github/workflows/ci-dgraph-ldbc-tests.yml
@@ -25,6 +25,8 @@ jobs:
           go-version-file: go.mod
       - name: Make Linux Build and Docker Image
         run: make docker-image
+      - name: Install gotestsum
+        run: go install gotest.tools/gotestsum@latest
       - name: Build Test Binary
         run : |
           #!/bin/bash

--- a/.github/workflows/ci-dgraph-load-tests.yml
+++ b/.github/workflows/ci-dgraph-load-tests.yml
@@ -24,6 +24,8 @@ jobs:
           go-version-file: go.mod
       - name: Make Linux Build and Docker Image
         run: make docker-image # this internally builds dgraph binary
+      - name: Install gotestsum
+        run: go install gotest.tools/gotestsum@latest
       - name: Build Test Binary
         run: |
           #!/bin/bash

--- a/.github/workflows/ci-dgraph-systest-tests.yml
+++ b/.github/workflows/ci-dgraph-systest-tests.yml
@@ -32,6 +32,8 @@ jobs:
           git diff --exit-code -- .
       - name: Make Linux Build and Docker Image
         run: make docker-image
+      - name: Install gotestsum
+        run: go install gotest.tools/gotestsum@latest
       - name: Build Test Binary
         run: |
           #!/bin/bash
@@ -57,3 +59,11 @@ jobs:
           ./t -r
           # sleep
           sleep 5
+      - name: Upload Test Results
+        if: always() # Upload the results even if the tests fail
+        continue-on-error: true # don't fail this job if the upload fails
+        uses: trunk-io/analytics-uploader@main
+        with:
+          junit-paths: "./test-results.xml"        
+          org-slug: hypermode
+          token: ${{ secrets.TRUNK_TOKEN }}

--- a/.github/workflows/ci-dgraph-tests-arm64.yml
+++ b/.github/workflows/ci-dgraph-tests-arm64.yml
@@ -30,6 +30,8 @@ jobs:
           go mod tidy
           make regenerate
           git diff --exit-code -- .
+      - name: Install gotestsum
+        run: go install gotest.tools/gotestsum@latest
       - name: Make Linux Build and Docker Image
         run: make docker-image # this internally builds dgraph binary
       - name: Build Test Binary

--- a/.github/workflows/ci-dgraph-vector-tests.yml
+++ b/.github/workflows/ci-dgraph-vector-tests.yml
@@ -32,6 +32,8 @@ jobs:
           git diff --exit-code -- .
       - name: Make Linux Build and Docker Image
         run: make docker-image
+      - name: Install gotestsum
+        run: go install gotest.tools/gotestsum@latest
       - name: Build Test Binary
         run: |
           #!/bin/bash
@@ -57,3 +59,11 @@ jobs:
           ./t -r
           # sleep
           sleep 5
+      - name: Upload Test Results
+        if: always() # Upload the results even if the tests fail
+        continue-on-error: true # don't fail this job if the upload fails
+        uses: trunk-io/analytics-uploader@main
+        with:
+          junit-paths: "./test-results.xml"        
+          org-slug: hypermode
+          token: ${{ secrets.TRUNK_TOKEN }}


### PR DESCRIPTION
This PR adds functionality to the test framework to generate test results in the form of JUnit XML. It also introduces a new job in the workflow to upload these test results to Trunk for flaky test detection.