### PR TITLE
Introducing Dgraph Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@
 [![Coverage Status](https://coveralls.io/repos/github/dgraph-io/dgraph/badge.svg?branch=main)](https://coveralls.io/github/dgraph-io/dgraph?branch=main)
 [![Go Report Card](https://goreportcard.com/badge/github.com/dgraph-io/dgraph)](https://goreportcard.com/report/github.com/dgraph-io/dgraph)
 [![TODOs](https://badgen.net/https/api.tickgit.com/badgen/github.com/dgraph-io/dgraph/main)](https://www.tickgit.com/browse?repo=github.com/dgraph-io/dgraph&branch=main)
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20Dgraph%20Guru-006BFF)](https://gurubase.io/g/dgraph)
 
 Dgraph is a horizontally scalable and distributed GraphQL database with a graph backend. It provides ACID transactions, consistent replication, and linearizable reads. It's built from the ground up to perform 
 a rich set of queries. Being a native GraphQL database, it tightly controls how the


### PR DESCRIPTION
Hello team,

We are the maintainers of [Anteon](https://github.com/getanteon/anteon). Recently, we created Gurubase.io with the mission of building a centralized, open-source, tool-focused knowledge base. Each "guru" in Gurubase is equipped with custom knowledge to answer user questions based on data related to the respective tool.

We’re excited to let you know that [Dgraph Guru](https://gurubase.io/g/dgraph) has been manually added to Gurubase. Dgraph Guru uses the data from this repo and data from the [docs](https://dgraph.io/docs/) to answer questions by leveraging the LLM.

This PR introduces the "Dgraph Guru", showcasing that Dgraph now has an AI assistant available to help users with their questions. We’d love to hear your feedback on this contribution.

You also have the option to maintain the "Dgraph Guru" by following the instructions in the [Gurubase Repo](https://github.com/getanteon/gurubase?tab=readme-ov-file#how-to-claim-a-guru) and to add an ASK AI widget to the Dgraph documentation website as detailed [here](https://github.com/getanteon/gurubase?tab=readme-ov-file#widget).

If you’d prefer us to disable Dgraph Guru in Gurubase, just let us know that's totally fine.
