### PR TITLE
ci: Add cron job to run workflow once a day

### DIFF
--- a/.github/workflows/ci-dgraph-core-tests.yml
+++ b/.github/workflows/ci-dgraph-core-tests.yml
@@ -12,6 +12,8 @@ on:
     branches:
       - main
       - 'release/**'
+  schedule:
+    - cron: "0 0 * * *" # 1 run per day
 jobs:
   dgraph-core-tests:
     if: github.event.pull_request.draft == false

--- a/.github/workflows/ci-dgraph-systest-tests.yml
+++ b/.github/workflows/ci-dgraph-systest-tests.yml
@@ -12,6 +12,8 @@ on:
     branches:
       - main
       - 'release/**'
+  schedule:
+      - cron: "0 0 * * *" # 1 run per day
 jobs:
   dgraph-systest-tests:
     if: github.event.pull_request.draft == false

--- a/.github/workflows/ci-dgraph-vector-tests.yml
+++ b/.github/workflows/ci-dgraph-vector-tests.yml
@@ -12,6 +12,8 @@ on:
     branches:
       - main
       - 'release/**'
+  schedule:
+      - cron: "0 0 * * *" # 1 run per day
 jobs:
   dgraph-vector-tests:
     if: github.event.pull_request.draft == false


### PR DESCRIPTION
This PR will add a cron job to run the workflow once a day for better flaky test detection.