### PR TITLE
build: Build jemalloc without sudo

### DIFF
--- a/dgraph/Makefile
+++ b/dgraph/Makefile
@@ -49,9 +49,22 @@ ifneq ($(strip $(BUILD_RACE)),)
 	BUILD_FLAGS += -race
 endif
 
+# Set TMPDIR, jemalloc will be built here
+ifdef TMPDIR
+	# no-op
+else
+	TMPDIR := /tmp
+endif
+
 # jemalloc stuff
-HAS_JEMALLOC = $(shell test -f /usr/local/lib/libjemalloc.a && echo "jemalloc")
-JEMALLOC_URL = "https://github.com/jemalloc/jemalloc/releases/download/5.3.0/jemalloc-5.3.0.tar.bz2"
+JEMALLOC_VERSION = 5.3.0
+JEMALLOC_BUILD = $(TMPDIR)/jemalloc-$(JEMALLOC_VERSION)-u$(USER_ID)/build
+JEMALLOC_TARGET = $(TMPDIR)/jemalloc-$(JEMALLOC_VERSION)-u$(USER_ID)/target
+JEMALLOC_INCLUDE = $(JEMALLOC_TARGET)/include
+HAS_JEMALLOC = $(shell test -f ${JEMALLOC_TARGET}/lib/libjemalloc.a && echo "jemalloc")
+JEMALLOC_URL = "https://github.com/jemalloc/jemalloc/releases/download/$(JEMALLOC_VERSION)/jemalloc-$(JEMALLOC_VERSION).tar.bz2"
+export CGO_CFLAGS = -I$(JEMALLOC_INCLUDE)
+export CGO_LDFLAGS = $(JEMALLOC_TARGET)/lib/libjemalloc.a
 
 # go install variables
 HAS_SHA256SUM = $(shell which sha256sum)
@@ -93,17 +106,11 @@ install: jemalloc
 
 jemalloc:
 	@if [ -z "$(HAS_JEMALLOC)" ] ; then \
-		mkdir -p /tmp/jemalloc-temp && cd /tmp/jemalloc-temp ; \
+		mkdir -p ${JEMALLOC_BUILD} && cd ${JEMALLOC_BUILD} ; \
 		echo "Downloading jemalloc" ; \
 		curl -f -s -L ${JEMALLOC_URL} -o jemalloc.tar.bz2 ; \
 		tar xjf ./jemalloc.tar.bz2 ; \
-		cd jemalloc-5.3.0 ; \
-		./configure --with-jemalloc-prefix='je_' --with-malloc-conf='background_thread:true,metadata_thp:auto'; \
-		make ; \
-		if [ "$(USER_ID)" = "0" ]; then \
-			make install ; \
-		else \
-			echo "==== Need sudo access to install jemalloc" ; \
-			sudo make install ; \
-		fi \
+		cd jemalloc-$(JEMALLOC_VERSION) ; \
+		./configure --prefix=${JEMALLOC_TARGET} --with-jemalloc-prefix='je_' --with-malloc-conf='background_thread:true,metadata_thp:auto'; \
+		make install ; \
 	fi


### PR DESCRIPTION
**Description**

Updated the build of jemalloc during the dgraph build to not require sudo.
- Not requiring sudo makes the build available to users without sudo access on the build machine.
- Previously the build would check for jemalloc in /usr/local/lib.  There was no guarantee this was the expected version of jemalloc.
- Build jemalloc in TMPDIR if it is set instead of hard-coding to /tmp.
- Allow multiple users to build in TMPDIR by making the temporary directory name unique for each user.

This change requires a change to ristretto, since ristretto was hard-coded to look for jemalloc in /usr/local/lib.  I would expect ci to fail since it will be building against an incompatible version of ristretto.

See: https://github.com/hypermodeinc/ristretto/pull/469

I tested this locally (Red Hat & Ubuntu) with an updated ristretto by adding this to the dgraph go.mod file:

replace github.com/dgraph-io/ristretto/v2 => ../ristretto

For this to work I would expect that the ristretto changes would require ristretto be tagged with a new version number and the dgraph go.mod be updated to reference the new ristretto version number.

If there is anything else I can do on my end please let me know.

**Checklist**

- [x] Code compiles correctly and linting passes locally
- [ ] For all _code_ changes, an entry added to the `CHANGELOG.md` file describing and linking to
      this PR
- [ ] Tests added for new functionality, or regression tests for bug fixes added as applicable
- [ ] For public APIs, new features, etc., PR on [docs repo](https://github.com/hypermodeinc/docs)
      staged and linked here