### PR TITLE
chore(core): remove net/trace event log

### DIFF
--- a/dgraph/cmd/alpha/run.go
+++ b/dgraph/cmd/alpha/run.go
@@ -30,7 +30,6 @@ import (
 	"github.com/spf13/cobra"
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"go.opentelemetry.io/contrib/zpages"
-	"golang.org/x/net/trace"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	_ "google.golang.org/grpc/encoding/gzip" // grpc compression
@@ -804,13 +803,6 @@ func run() {
 
 	worker.InitServerState()
 	worker.InitTasks()
-
-	if Alpha.Conf.GetBool("expose_trace") {
-		// TODO: Remove this once we get rid of event logs.
-		trace.AuthRequest = func(req *http.Request) (any, sensitive bool) {
-			return true, true
-		}
-	}
 
 	// Posting will initialize index which requires schema. Hence, initialize
 	// schema before calling posting.Init().

--- a/dgraph/cmd/alpha/run.go
+++ b/dgraph/cmd/alpha/run.go
@@ -30,7 +30,6 @@ import (
 	"github.com/spf13/cobra"
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"go.opentelemetry.io/contrib/zpages"
-	"golang.org/x/net/trace"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	_ "google.golang.org/grpc/encoding/gzip" // grpc compression
@@ -817,13 +816,6 @@ func run() {
 
 	worker.InitServerState()
 	worker.InitTasks()
-
-	if Alpha.Conf.GetBool("expose_trace") {
-		// TODO: Remove this once we get rid of event logs.
-		trace.AuthRequest = func(req *http.Request) (any, sensitive bool) {
-			return true, true
-		}
-	}
 
 	// Posting will initialize index which requires schema. Hence, initialize
 	// schema before calling posting.Init().

--- a/dgraph/cmd/root.go
+++ b/dgraph/cmd/root.go
@@ -96,8 +96,6 @@ func initCmds() {
 			"overridden to values set with environment variables and flags.")
 	RootCmd.PersistentFlags().Bool("bindall", true,
 		"Use 0.0.0.0 instead of localhost to bind to all addresses on local machine.")
-	RootCmd.PersistentFlags().Bool("expose_trace", false,
-		"Allow trace endpoint to be accessible from remote")
 	x.Check(rootConf.BindPFlags(RootCmd.PersistentFlags()))
 
 	// Add all existing global flag (eg: from glog) to rootCmd's flags

--- a/dgraph/docker-compose.yml
+++ b/dgraph/docker-compose.yml
@@ -16,8 +16,8 @@ services:
         read_only: true
     command:
       /gobin/dgraph  ${COVERAGE_OUTPUT} zero --telemetry "reports=false; sentry=false;"
-      --my=zero1:5080 --replicas 3 --raft="idx=1" --logtostderr -v=2 --bindall --expose_trace
-      --profile_mode block --block_rate 10
+      --my=zero1:5080 --replicas 3 --raft="idx=1" --logtostderr -v=2 --bindall --profile_mode block
+      --block_rate 10
 
   zero2:
     image: dgraph/dgraph:local
@@ -84,8 +84,8 @@ services:
     command:
       /gobin/dgraph  ${COVERAGE_OUTPUT} alpha --telemetry "reports=false;" --encryption
       "key-file=/dgraph-enc/enc-key;" --my=alpha1:7080 --zero=zero1:5080,zero2:5080,zero3:5080
-      --expose_trace --profile_mode block --block_rate 10 --logtostderr -v=2 --security
-      "whitelist=0.0.0.0/0;" --acl "secret-file=/dgraph-acl/hmac-secret; access-ttl=20s;"
+      --profile_mode block --block_rate 10 --logtostderr -v=2 --security "whitelist=0.0.0.0/0;"
+      --acl "secret-file=/dgraph-acl/hmac-secret; access-ttl=20s;"
 
   alpha2:
     image: dgraph/dgraph:local
@@ -113,8 +113,8 @@ services:
       service: alpha
     command:
       /gobin/dgraph  ${COVERAGE_OUTPUT} alpha --encryption "key-file=/dgraph-enc/enc-key;"
-      --my=alpha2:7080 --zero=zero1:5080,zero2:5080,zero3:5080 --expose_trace --profile_mode block
-      --block_rate 10 --logtostderr -v=2 --security "whitelist=0.0.0.0/0;" --acl
+      --my=alpha2:7080 --zero=zero1:5080,zero2:5080,zero3:5080 --profile_mode block --block_rate 10
+      --logtostderr -v=2 --security "whitelist=0.0.0.0/0;" --acl
       "secret-file=/dgraph-acl/hmac-secret; access-ttl=20s;"
 
   alpha3:
@@ -143,8 +143,8 @@ services:
       service: alpha
     command:
       /gobin/dgraph  ${COVERAGE_OUTPUT} alpha --encryption "key-file=/dgraph-enc/enc-key;"
-      --my=alpha3:7080 --zero=zero1:5080,zero2:5080,zero3:5080 --expose_trace --profile_mode block
-      --block_rate 10 --logtostderr -v=2 --security "whitelist=0.0.0.0/0;" --acl
+      --my=alpha3:7080 --zero=zero1:5080,zero2:5080,zero3:5080 --profile_mode block --block_rate 10
+      --logtostderr -v=2 --security "whitelist=0.0.0.0/0;" --acl
       "secret-file=/dgraph-acl/hmac-secret; access-ttl=20s;"
 
   alpha4:
@@ -173,8 +173,8 @@ services:
       service: alpha
     command:
       /gobin/dgraph  ${COVERAGE_OUTPUT} alpha --encryption "key-file=/dgraph-enc/enc-key;"
-      --my=alpha4:7080 --zero=zero1:5080,zero2:5080,zero3:5080 --expose_trace --profile_mode block
-      --block_rate 10 --logtostderr -v=2 --security "whitelist=0.0.0.0/0;" --acl
+      --my=alpha4:7080 --zero=zero1:5080,zero2:5080,zero3:5080 --profile_mode block --block_rate 10
+      --logtostderr -v=2 --security "whitelist=0.0.0.0/0;" --acl
       "secret-file=/dgraph-acl/hmac-secret; access-ttl=20s;"
 
   alpha5:
@@ -203,8 +203,8 @@ services:
       service: alpha
     command:
       /gobin/dgraph  ${COVERAGE_OUTPUT} alpha --encryption "key-file=/dgraph-enc/enc-key;"
-      --my=alpha5:7080 --zero=zero1:5080,zero2:5080,zero3:5080 --expose_trace --profile_mode block
-      --block_rate 10 --logtostderr -v=2 --security "whitelist=0.0.0.0/0;" --acl
+      --my=alpha5:7080 --zero=zero1:5080,zero2:5080,zero3:5080 --profile_mode block --block_rate 10
+      --logtostderr -v=2 --security "whitelist=0.0.0.0/0;" --acl
       "secret-file=/dgraph-acl/hmac-secret; access-ttl=20s;"
 
   alpha6:
@@ -233,8 +233,8 @@ services:
       service: alpha
     command:
       /gobin/dgraph  ${COVERAGE_OUTPUT} alpha --encryption "key-file=/dgraph-enc/enc-key;"
-      --my=alpha6:7080 --zero=zero1:5080,zero2:5080,zero3:5080 --expose_trace --profile_mode block
-      --block_rate 10 --logtostderr -v=2 --security "whitelist=0.0.0.0/0;" --acl
+      --my=alpha6:7080 --zero=zero1:5080,zero2:5080,zero3:5080 --profile_mode block --block_rate 10
+      --logtostderr -v=2 --security "whitelist=0.0.0.0/0;" --acl
       "secret-file=/dgraph-acl/hmac-secret; access-ttl=20s;"
 
   minio:

--- a/go.mod
+++ b/go.mod
@@ -62,7 +62,6 @@ require (
 	golang.org/x/crypto v0.50.0
 	golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f
 	golang.org/x/mod v0.35.0
-	golang.org/x/net v0.53.0
 	golang.org/x/sync v0.20.0
 	golang.org/x/sys v0.43.0
 	golang.org/x/term v0.42.0
@@ -168,6 +167,7 @@ require (
 	go.uber.org/multierr v1.11.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.4 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
+	golang.org/x/net v0.53.0 // indirect
 	golang.org/x/time v0.15.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260427160629-7cedc36a6bc4 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260427160629-7cedc36a6bc4 // indirect

--- a/graphql/e2e/admin_auth/poorman_auth/docker-compose.yml
+++ b/graphql/e2e/admin_auth/poorman_auth/docker-compose.yml
@@ -16,7 +16,7 @@ services:
         read_only: true
     command:
       /gobin/dgraph  ${COVERAGE_OUTPUT} zero --telemetry "reports=false;" --my=zero1:5080
-      --logtostderr -v=2 --bindall --expose_trace --profile_mode block --block_rate 10
+      --logtostderr -v=2 --bindall --profile_mode block --block_rate 10
 
   alpha1:
     image: dgraph/dgraph:local
@@ -33,6 +33,6 @@ services:
       cluster: test
       service: alpha1
     command:
-      /gobin/dgraph ${COVERAGE_OUTPUT} alpha --my=alpha1:7080 --zero=zero1:5080 --expose_trace
-      --profile_mode block --block_rate 10 --logtostderr -v=2 --security "whitelist=0.0.0.0/0;
-      token=itIsSecret;" --trace "ratio=1.0;"
+      /gobin/dgraph ${COVERAGE_OUTPUT} alpha --my=alpha1:7080 --zero=zero1:5080 --profile_mode block
+      --block_rate 10 --logtostderr -v=2 --security "whitelist=0.0.0.0/0; token=itIsSecret;" --trace
+      "ratio=1.0;"

--- a/graphql/e2e/admin_auth/poorman_auth_with_acl/docker-compose.yml
+++ b/graphql/e2e/admin_auth/poorman_auth_with_acl/docker-compose.yml
@@ -16,7 +16,7 @@ services:
         read_only: true
     command:
       /gobin/dgraph  ${COVERAGE_OUTPUT} zero --telemetry "reports=false;" --my=zero1:5080
-      --logtostderr -v=2 --bindall --expose_trace --profile_mode block --block_rate 10
+      --logtostderr -v=2 --bindall --profile_mode block --block_rate 10
 
   alpha1:
     image: dgraph/dgraph:local
@@ -37,7 +37,6 @@ services:
       cluster: test
       service: alpha1
     command:
-      /gobin/dgraph ${COVERAGE_OUTPUT} alpha --my=alpha1:7080 --zero=zero1:5080 --expose_trace
-      --profile_mode block --block_rate 10 --logtostderr -v=2 --security "whitelist=0.0.0.0/0;
-      token=itIsSecret;" --acl "secret-file=/dgraph-acl/hmac-secret; access-ttl=3s;" --trace
-      "ratio=1.0;"
+      /gobin/dgraph ${COVERAGE_OUTPUT} alpha --my=alpha1:7080 --zero=zero1:5080 --profile_mode block
+      --block_rate 10 --logtostderr -v=2 --security "whitelist=0.0.0.0/0; token=itIsSecret;" --acl
+      "secret-file=/dgraph-acl/hmac-secret; access-ttl=3s;" --trace "ratio=1.0;"

--- a/graphql/e2e/auth/debug_off/docker-compose.yml
+++ b/graphql/e2e/auth/debug_off/docker-compose.yml
@@ -16,7 +16,7 @@ services:
         read_only: true
     command:
       /gobin/dgraph  ${COVERAGE_OUTPUT} zero --telemetry "reports=false;" --logtostderr -v=2
-      --bindall --expose_trace --profile_mode block --block_rate 10 --my=zero1:5080
+      --bindall --profile_mode block --block_rate 10 --my=zero1:5080
 
   alpha1:
     image: dgraph/dgraph:local
@@ -33,6 +33,5 @@ services:
       cluster: test
       service: alpha1
     command:
-      /gobin/dgraph  ${COVERAGE_OUTPUT} alpha --zero=zero1:5080 --expose_trace --profile_mode block
-      --block_rate 10 --logtostderr -v=3 --my=alpha1:7080 --security "whitelist=0.0.0.0/0;" --trace
-      "ratio=1.0;"
+      /gobin/dgraph  ${COVERAGE_OUTPUT} alpha --zero=zero1:5080 --profile_mode block --block_rate 10
+      --logtostderr -v=3 --my=alpha1:7080 --security "whitelist=0.0.0.0/0;" --trace "ratio=1.0;"

--- a/graphql/e2e/auth/docker-compose.yml
+++ b/graphql/e2e/auth/docker-compose.yml
@@ -16,7 +16,7 @@ services:
         read_only: true
     command:
       /gobin/dgraph  ${COVERAGE_OUTPUT} zero --telemetry "reports=false;" --logtostderr -v=2
-      --bindall --expose_trace --profile_mode block --block_rate 10 --my=zero1:5080
+      --bindall --profile_mode block --block_rate 10 --my=zero1:5080
 
   alpha1:
     image: dgraph/dgraph:local
@@ -33,6 +33,6 @@ services:
       cluster: test
       service: alpha1
     command:
-      /gobin/dgraph  ${COVERAGE_OUTPUT} alpha --zero=zero1:5080 --expose_trace --profile_mode block
-      --block_rate 10 --logtostderr -v=3 --my=alpha1:7080 --security "whitelist=0.0.0.0/0;"
-      --graphql "debug=true;" --trace "ratio=1.0;"
+      /gobin/dgraph  ${COVERAGE_OUTPUT} alpha --zero=zero1:5080 --profile_mode block --block_rate 10
+      --logtostderr -v=3 --my=alpha1:7080 --security "whitelist=0.0.0.0/0;" --graphql "debug=true;"
+      --trace "ratio=1.0;"

--- a/graphql/e2e/auth_closed_by_default/docker-compose.yml
+++ b/graphql/e2e/auth_closed_by_default/docker-compose.yml
@@ -16,7 +16,7 @@ services:
         read_only: true
     command:
       /gobin/dgraph  ${COVERAGE_OUTPUT} zero --telemetry "reports=false;" --logtostderr -v=2
-      --bindall --expose_trace --profile_mode block --block_rate 10 --my=zero1:5080
+      --bindall --profile_mode block --block_rate 10 --my=zero1:5080
 
   alpha1:
     image: dgraph/dgraph:local
@@ -33,6 +33,6 @@ services:
       cluster: test
       service: alpha1
     command:
-      /gobin/dgraph  ${COVERAGE_OUTPUT} alpha --zero=zero1:5080 --expose_trace --profile_mode block
-      --block_rate 10 --logtostderr -v=3 --my=alpha1:7080 --security "whitelist=0.0.0.0/0;"
-      --graphql "debug=true;" --trace "ratio=1.0;"
+      /gobin/dgraph  ${COVERAGE_OUTPUT} alpha --zero=zero1:5080 --profile_mode block --block_rate 10
+      --logtostderr -v=3 --my=alpha1:7080 --security "whitelist=0.0.0.0/0;" --graphql "debug=true;"
+      --trace "ratio=1.0;"

--- a/graphql/e2e/directives/docker-compose.yml
+++ b/graphql/e2e/directives/docker-compose.yml
@@ -16,7 +16,7 @@ services:
         read_only: true
     command:
       /gobin/dgraph  ${COVERAGE_OUTPUT} zero --telemetry "reports=false;" --logtostderr -v=2
-      --bindall --expose_trace --profile_mode block --block_rate 10 --my=zero1:5080
+      --bindall --profile_mode block --block_rate 10 --my=zero1:5080
 
   alpha1:
     image: dgraph/dgraph:local
@@ -33,9 +33,9 @@ services:
       cluster: test
       service: alpha1
     command:
-      /gobin/dgraph  ${COVERAGE_OUTPUT} alpha --zero=zero1:5080 --expose_trace --profile_mode block
-      --block_rate 10 --logtostderr -v=2 --my=alpha1:7080 --security "whitelist=0.0.0.0/0;"
-      --graphql "lambda-url=http://lambda:8686/graphql-worker; debug=true;" --trace "ratio=1.0;"
+      /gobin/dgraph  ${COVERAGE_OUTPUT} alpha --zero=zero1:5080 --profile_mode block --block_rate 10
+      --logtostderr -v=2 --my=alpha1:7080 --security "whitelist=0.0.0.0/0;" --graphql
+      "lambda-url=http://lambda:8686/graphql-worker; debug=true;" --trace "ratio=1.0;"
 
   lambda:
     image: dgraph/dgraph-lambda:latest

--- a/graphql/e2e/normal/docker-compose.yml
+++ b/graphql/e2e/normal/docker-compose.yml
@@ -16,7 +16,7 @@ services:
         read_only: true
     command:
       /gobin/dgraph  ${COVERAGE_OUTPUT} zero --telemetry "reports=false;" --logtostderr -v=2
-      --bindall --expose_trace --profile_mode block --block_rate 10 --my=zero1:5080
+      --bindall --profile_mode block --block_rate 10 --my=zero1:5080
 
   alpha1:
     image: dgraph/dgraph:local
@@ -33,9 +33,9 @@ services:
       cluster: test
       service: alpha1
     command:
-      /gobin/dgraph  ${COVERAGE_OUTPUT} alpha --zero=zero1:5080 --expose_trace --profile_mode block
-      --block_rate 10 --logtostderr -v=2 --my=alpha1:7080 --security "whitelist=0.0.0.0/0;"
-      --graphql "lambda-url=http://lambda:8686/graphql-worker; debug=true;" --trace "ratio=1.0;"
+      /gobin/dgraph  ${COVERAGE_OUTPUT} alpha --zero=zero1:5080 --profile_mode block --block_rate 10
+      --logtostderr -v=2 --my=alpha1:7080 --security "whitelist=0.0.0.0/0;" --graphql
+      "lambda-url=http://lambda:8686/graphql-worker; debug=true;" --trace "ratio=1.0;"
 
   lambda:
     image: dgraph/dgraph-lambda:latest

--- a/raftwal/storage.go
+++ b/raftwal/storage.go
@@ -9,13 +9,11 @@ import (
 	"math"
 	"sync"
 
+	"github.com/dgraph-io/dgraph/v25/x"
 	"github.com/golang/glog"
 	"github.com/pkg/errors"
 	"go.etcd.io/etcd/raft/v3"
 	"go.etcd.io/etcd/raft/v3/raftpb"
-	"golang.org/x/net/trace"
-
-	"github.com/dgraph-io/dgraph/v25/x"
 )
 
 // DiskStorage handles disk access and writing for the RAFT write-ahead log.
@@ -58,8 +56,7 @@ import (
 // HardSync is set, msync is called after every write, which flushes those
 // writes to disk.
 type DiskStorage struct {
-	dir  string
-	elog trace.EventLog
+	dir string
 
 	meta *metaFile
 	wal  *wal
@@ -91,8 +88,6 @@ func InitEncrypted(dir string, encKey x.Sensitive) (*DiskStorage, error) {
 	if w.wal, err = openWal(dir); err != nil {
 		return nil, err
 	}
-
-	w.elog = trace.NewEventLog("Badger", "RaftStorage")
 
 	snap, err := w.meta.snapshot()
 	if err != nil {
@@ -150,8 +145,6 @@ func (w *DiskStorage) InitialState() (hs raftpb.HardState, cs raftpb.ConfState, 
 	w.lock.Lock()
 	defer w.lock.Unlock()
 
-	w.elog.Printf("InitialState")
-	defer w.elog.Printf("Done")
 	hs, err = w.meta.HardState()
 	if err != nil {
 		return

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/pkg/errors"
-	"golang.org/x/net/trace"
 	"google.golang.org/protobuf/proto"
 
 	"github.com/dgraph-io/badger/v4"
@@ -52,7 +51,6 @@ func GetWriteContext(ctx context.Context) context.Context {
 func (s *state) init() {
 	s.predicate = make(map[string]*pb.SchemaUpdate)
 	s.types = make(map[string]*pb.TypeUpdate)
-	s.elog = trace.NewEventLog("Dgraph", "Schema")
 	s.mutSchema = make(map[string]*pb.SchemaUpdate)
 }
 
@@ -61,7 +59,6 @@ type state struct {
 	// Map containing predicate to type information.
 	predicate map[string]*pb.SchemaUpdate
 	types     map[string]*pb.TypeUpdate
-	elog      trace.EventLog
 	// mutSchema holds the schema update that is being applied in the background.
 	mutSchema map[string]*pb.SchemaUpdate
 }
@@ -198,7 +195,7 @@ func (s *state) Set(pred string, schema *pb.SchemaUpdate) {
 	s.Lock()
 	defer s.Unlock()
 	s.predicate[pred] = schema
-	s.elog.Printf(logUpdate(schema, pred))
+	glog.Infoln(logUpdate(schema, pred))
 }
 
 // SetMutSchema sets the mutation schema for the given predicate.
@@ -237,7 +234,7 @@ func (s *state) SetType(typeName string, typ *pb.TypeUpdate) {
 	s.Lock()
 	defer s.Unlock()
 	s.types[typeName] = typ
-	s.elog.Printf(logTypeUpdate(typ, typeName))
+	glog.Infoln(logTypeUpdate(typ, typeName))
 }
 
 // Get gets the schema for the given predicate.
@@ -552,7 +549,6 @@ func Load(predicate string) error {
 		return err
 	}
 	State().Set(predicate, &s)
-	State().elog.Printf(logUpdate(&s, predicate))
 	glog.Infoln(logUpdate(&s, predicate))
 	return nil
 }

--- a/systest/cloud/docker-compose.yml
+++ b/systest/cloud/docker-compose.yml
@@ -16,7 +16,7 @@ services:
         read_only: true
     command:
       /gobin/dgraph zero --telemetry "reports=false;" --my=zero1:5080 --raft="idx=1" --logtostderr
-      -v=2 --bindall --expose_trace --profile_mode block --block_rate 10
+      -v=2 --bindall --profile_mode block --block_rate 10
 
   alpha1:
     image: dgraph/dgraph:local
@@ -39,9 +39,9 @@ services:
       cluster: test
       service: alpha
     command:
-      /gobin/dgraph alpha --my=alpha1:7080 --zero=zero1:5080,zero2:5080,zero3:5080 --expose_trace
-      --profile_mode block --block_rate 10 --logtostderr -v=2 --security "whitelist=0.0.0.0/0;"
-      --acl "secret-file=/dgraph-acl/hmac-secret; access-ttl=20s;" --limit "shared-instance=true"
+      /gobin/dgraph alpha --my=alpha1:7080 --zero=zero1:5080,zero2:5080,zero3:5080 --profile_mode
+      block --block_rate 10 --logtostderr -v=2 --security "whitelist=0.0.0.0/0;" --acl
+      "secret-file=/dgraph-acl/hmac-secret; access-ttl=20s;" --limit "shared-instance=true"
 
   minio:
     image: minio/minio:latest

--- a/systest/multi-tenancy/docker-compose.yml
+++ b/systest/multi-tenancy/docker-compose.yml
@@ -16,8 +16,8 @@ services:
         read_only: true
     command:
       /gobin/dgraph  ${COVERAGE_OUTPUT} zero --telemetry "reports=false;"
-      --my=zero1:5080  --raft="idx=1" --logtostderr -v=2 --bindall --expose_trace --profile_mode
-      block --block_rate 10 --limit refill-interval=20s --limit uid-lease=50
+      --my=zero1:5080  --raft="idx=1" --logtostderr -v=2 --bindall --profile_mode block --block_rate
+      10 --limit refill-interval=20s --limit uid-lease=50
   alpha1:
     image: dgraph/dgraph:local
     working_dir: /data/alpha1
@@ -42,6 +42,6 @@ services:
       service: alpha
     command:
       /gobin/dgraph  ${COVERAGE_OUTPUT} alpha --encryption "key-file=/dgraph-enc/enc-key;"
-      --my=alpha1:7080 --zero=zero1:5080,zero2:5080,zero3:5080 --expose_trace --profile_mode block
-      --block_rate 10 --logtostderr -v=2 --security "whitelist=0.0.0.0/0;" --acl
+      --my=alpha1:7080 --zero=zero1:5080,zero2:5080,zero3:5080 --profile_mode block --block_rate 10
+      --logtostderr -v=2 --security "whitelist=0.0.0.0/0;" --acl
       "secret-file=/dgraph-acl/hmac-secret; access-ttl=20s;"

--- a/testutil/docker.go
+++ b/testutil/docker.go
@@ -8,6 +8,7 @@ package testutil
 import (
 	"archive/tar"
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"log"
@@ -17,13 +18,11 @@ import (
 	"strings"
 	"time"
 
+	"github.com/dgraph-io/dgraph/v25/x"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/client"
 	"github.com/golang/glog"
 	"github.com/pkg/errors"
-	"golang.org/x/net/context"
-
-	"github.com/dgraph-io/dgraph/v25/x"
 )
 
 const (


### PR DESCRIPTION
In c4bb4114c0e6bb6eb0eac5b5053b2e11b43555b0 there was an effort to replace net/trace with spans from OpenCensus. A few remnants of net/trace still remain, this PR removes them. 

The trace package exposes two endpoints: `/debug/requests` and `/debug/events`. They contain some incomplete data regarding raft indexes and schema loading. The documentation also does not refer to the endpoints or the event log at all. 

The documentation however incorrectly refers to the flag `expose_trace` (https://docs.dgraph.io/learn/howto/retrieving-debug-information#metrics-information), that is meant for the event log, but describes the flag as controlling the `/debug/vars`endpoint.

This PR does the following:

- replace golang.org/x/net/context with stdlib context package
- remove all uses of golang.org/x/net/trace
- remove `expose_trace` flag from code and docker compose files
- demote golang.org/x/net to an indirect dependency 

Regardless of this PR, the documentation should be updated to not associate the `expose_trace` config option with the `/debug/vars` endpoint