### PR TITLE
fix(query): evict highest-cost node when MaxFrontierSize exceeded in shortest path

### DIFF
--- a/query/shortest.go
+++ b/query/shortest.go
@@ -88,6 +88,22 @@ func (h *priorityQueue) Pop() interface{} {
 	return val
 }
 
+// removeMax removes and returns the highest cost item from the priority queue.
+// This is used to evict the least promising node when the frontier exceeds its
+// size limit, preserving the lowest cost nodes needed for shortest paths.
+func (h *priorityQueue) removeMax() {
+	if len(*h) == 0 {
+		return
+	}
+	maxIdx := 0
+	for i := 1; i < len(*h); i++ {
+		if (*h)[i].cost > (*h)[maxIdx].cost {
+			maxIdx = i
+		}
+	}
+	heap.Remove(h, maxIdx)
+}
+
 type mapItem struct {
 	attr  string
 	cost  float64
@@ -406,7 +422,7 @@ func runKShortestPaths(ctx context.Context, sg *SubGraph) ([]*SubGraph, error) {
 				path: route{route: curPath},
 			}
 			if int64(pq.Len()) > sg.Params.MaxFrontierSize {
-				pq.Pop()
+				pq.removeMax()
 			}
 			heap.Push(&pq, node)
 		}
@@ -562,7 +578,7 @@ func shortestPath(ctx context.Context, sg *SubGraph) ([]*SubGraph, error) {
 					hop:  item.hop + 1,
 				}
 				if int64(pq.Len()) > sg.Params.MaxFrontierSize {
-					pq.Pop()
+					pq.removeMax()
 				}
 				heap.Push(&pq, node)
 			} else {


### PR DESCRIPTION
Fixes #9577

The `MaxFrontierSize` feature introduced in #9333 has a bug in how it evicts nodes from the priority queue when the size limit is exceeded.

The current code calls `pq.Pop()` directly on the slice (not `heap.Pop`), which:
1. Removes the last element of the underlying array rather than the highest-cost item. In a min-heap, the last element's cost is arbitrary, so we might drop a low-cost node that's actually on the shortest path.
2. Doesn't maintain the heap invariant since it bypasses `container/heap`, corrupting the queue for subsequent `heap.Push`/`heap.Pop` calls.

The fix adds a `removeMax()` method that scans for the highest-cost item and removes it using `heap.Remove()`, which properly rebalances the heap. This ensures we always evict the least promising node while preserving the priority queue invariant and keeping shortest-path correctness.

Affects both the single shortest path (`shortestPath`) and k-shortest-path (`runKShortestPaths`) code paths.

All existing query package tests pass.