### PR TITLE
chore: remove unused buildvars.ComposeBuildDir Var

### DIFF
--- a/buildvars/buildvars.go
+++ b/buildvars/buildvars.go
@@ -74,8 +74,7 @@ type Var struct {
 	// override is set. Mutually exclusive with defaulter: when
 	// defaulter is non-nil, it computes the default and defaultValue
 	// is empty; when defaulter is nil, defaultValue holds the answer
-	// (possibly the empty string, which is a valid default for vars
-	// like ComposeBuildDir).
+	// (the empty string is a valid default).
 	defaultValue string
 
 	// defaulter, when non-nil, computes the default at Get() time.
@@ -201,12 +200,6 @@ var (
 
 	// RuntimeTag is the tag for RuntimeImage.
 	RuntimeTag = newVar("RUNTIME_TAG", "24.04")
-
-	// ComposeBuildDir holds generated docker-compose overlays produced
-	// by a compose-rewriting build step. Test harnesses route
-	// docker-compose invocations through this directory when set.
-	// Upstream default: empty (no overlay).
-	ComposeBuildDir = newVar("DGRAPH_COMPOSE_BUILD_DIR", "")
 
 	// BuildTags is the space-separated list of Go build tags passed to
 	// `go build` via -tags. The upstream default composes "jemalloc"
@@ -340,7 +333,6 @@ var All = []*Var{
 	BuildTag,
 	RuntimeImage,
 	RuntimeTag,
-	ComposeBuildDir,
 	BuildTags,
 	CustomBuildTags,
 	GoRunTags,

--- a/buildvars/buildvars_test.go
+++ b/buildvars/buildvars_test.go
@@ -158,7 +158,6 @@ func TestPackageDefaults(t *testing.T) {
 		{BuildTag, "24.04"},
 		{RuntimeImage, "ubuntu"},
 		{RuntimeTag, "24.04"},
-		{ComposeBuildDir, ""},
 		{GoBinDgraphPath, "/gobin/dgraph"},
 	}
 	for _, c := range cases {

--- a/t/hooks.go
+++ b/t/hooks.go
@@ -21,12 +21,10 @@ var EnvForCompose = defaultEnvForCompose
 // unchanged, matching upstream behavior where the pristine compose file
 // passes straight through.
 //
-// A fork running a compose-file generator may override this to rewrite
-// the path to a generated overlay (e.g. under $DGRAPH_COMPOSE_BUILD_DIR)
-// and add "--project-directory <original-dir>" so relative bind-mount
-// sources resolve against the pristine test package dir rather than the
-// overlay output dir. Unknown paths or an empty $DGRAPH_COMPOSE_BUILD_DIR
-// fall through to the upstream-compatible "-f <path>" form.
+// A fork may override this to layer additional `-f <overlay>` files,
+// switch the compose-file path, or add `--project-directory <dir>` so
+// relative bind-mount sources resolve against the pristine test package
+// dir rather than wherever the override emits its base file.
 var ComposeFileArgs = defaultComposeFileArgs
 
 func defaultEnvForCompose() []string { return nil }


### PR DESCRIPTION
## Summary

`buildvars.ComposeBuildDir` (env var `DGRAPH_COMPOSE_BUILD_DIR`) landed in #9691 as a hook for forks that ran a compose-file generator: tests would route `docker-compose` through `$DGRAPH_COMPOSE_BUILD_DIR` to pick up a rewritten compose tree.

The Var has **zero call sites** — upstream code never reads it, and the downstream fork that #9691 was designed for has since pivoted to a runtime overlay synthesizer that operates in `/tmp` without any env hook. It is dead surface area; remove it.

## Changes

- `buildvars/buildvars.go` — drop the `ComposeBuildDir = newVar("DGRAPH_COMPOSE_BUILD_DIR", "")` declaration, the entry in `var All`, and the stale `like ComposeBuildDir` reference in the `Var.defaultValue` doc comment.
- `buildvars/buildvars_test.go` — drop the `ComposeBuildDir` row from `TestPackageDefaults`.
- `t/hooks.go` — remove the `$DGRAPH_COMPOSE_BUILD_DIR` example from the `ComposeFileArgs` docstring. Replace with a generic "fork may override to layer additional `-f`, switch the path, or add `--project-directory`" description that doesn't presume a particular fork's mechanism.

## Verification

```
go build ./buildvars/... ./t/...   # clean
go test ./buildvars/...            # ok
```

## Backward compatibility

No call sites, no published API stability promise yet (#9691 just merged), and the env var has the empty-string default — so there's no observable behavior change for any consumer that was honoring upstream defaults.
