### PR TITLE
fix(backup): reject incremental backups whose read_ts has regressed

### DIFF
--- a/systest/backup/advanced-scenarios/acl-nonAcl/backup_test.go
+++ b/systest/backup/advanced-scenarios/acl-nonAcl/backup_test.go
@@ -41,7 +41,12 @@ func BackupRestore(t *testing.T, jwtTokenBackupAlpha string, jwtTokenRestoreAlph
 	e2eCommon.AssertGetGQLSchema(t, testutil.ContainerAddr(backupAlpha, 8080), header)
 	utilsCommon.AddItem(t, 1, 10, jwtTokenBackupAlpha, backupAlpha)
 	utilsCommon.CheckItemExists(t, 5, jwtTokenBackupAlpha, backupAlpha)
-	utilsCommon.TakeBackup(t, jwtTokenBackupAlpha, backupDst, backupAlpha)
+	// forceFull: each top-level test in this package runs against a different
+	// alpha/zero pair but shares the same backup volume, so the chain seen at
+	// /data/backups/ may already contain manifests from a sibling test's
+	// distinct cluster. Force a fresh chain so the backup-side ReadTs guard
+	// (worker/backup.go checkBackupReadTsAdvanced) doesn't refuse the call.
+	utilsCommon.TakeFullBackup(t, jwtTokenBackupAlpha, backupDst, backupAlpha)
 	utilsCommon.RunRestore(t, jwtTokenRestoreAlpha, restoreLocation, restoreAlpha)
 	dg := testutil.DgClientWithLogin(t, "groot", "password", x.RootNamespace)
 	testutil.WaitForRestore(t, dg, testutil.ContainerAddr(restoreAlpha, 8080))

--- a/systest/backup/common/utils.go
+++ b/systest/backup/common/utils.go
@@ -187,9 +187,23 @@ func CheckItemExists(t *testing.T, desriedSuffix int, jwtToken string, whichAlph
 }
 
 func TakeBackup(t *testing.T, jwtToken string, backupDst string, whichAlpha string) {
+	takeBackupInternal(t, jwtToken, backupDst, whichAlpha, false)
+}
 
-	backupRequest := `mutation backup($dst: String!) {
-		backup(input: {destination: $dst}) {
+// TakeFullBackup forces a fresh backup chain by passing forceFull: true. Use
+// this when a test is reusing a backup destination that may contain manifests
+// from a prior cluster — the backup-side guard refuses incrementals whose
+// ReadTs has not advanced past the chain's latest manifest, which happens
+// whenever a different cluster (with a fresh Zero) writes into an existing
+// chain. forceFull starts a new chain at SinceTs=0 and sidesteps that check.
+func TakeFullBackup(t *testing.T, jwtToken string, backupDst string, whichAlpha string) {
+	takeBackupInternal(t, jwtToken, backupDst, whichAlpha, true)
+}
+
+func takeBackupInternal(t *testing.T, jwtToken string, backupDst string, whichAlpha string, forceFull bool) {
+
+	backupRequest := `mutation backup($dst: String!, $ff: Boolean) {
+		backup(input: {destination: $dst, forceFull: $ff}) {
 			response {
 				code
 			}
@@ -200,6 +214,7 @@ func TakeBackup(t *testing.T, jwtToken string, backupDst string, whichAlpha stri
 		Query: backupRequest,
 		Variables: map[string]interface{}{
 			"dst": backupDst,
+			"ff":  forceFull,
 		},
 	}
 
@@ -218,12 +233,34 @@ func TakeBackup(t *testing.T, jwtToken string, backupDst string, whichAlpha stri
 	require.NoError(t, err)
 	defer func() { require.NoError(t, resp.Body.Close()) }()
 
-	var data interface{}
-	require.NoError(t, json.NewDecoder(resp.Body).Decode(&data))
+	// Decode into a typed shape so a server-side error surfaces as a real
+	// failure message rather than a nil-map panic at the assertions below.
+	var br struct {
+		Data struct {
+			Backup struct {
+				Response struct {
+					Code string `json:"code"`
+				} `json:"response"`
+				TaskId string `json:"taskId"`
+			} `json:"backup"`
+		} `json:"data"`
+		Errors []struct {
+			Message string `json:"message"`
+		} `json:"errors"`
+	}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&br))
 
-	require.Equal(t, "Success", testutil.JsonGet(data, "data", "backup", "response", "code").(string))
-	taskId := testutil.JsonGet(data, "data", "backup", "taskId").(string)
-	testutil.WaitForTask(t, taskId, false, testutil.ContainerAddr(whichAlpha, 8080))
+	if len(br.Errors) > 0 {
+		msgs := make([]string, 0, len(br.Errors))
+		for _, e := range br.Errors {
+			msgs = append(msgs, e.Message)
+		}
+		t.Fatalf("backup mutation returned errors: %s", strings.Join(msgs, "; "))
+	}
+
+	require.Equal(t, "Success", br.Data.Backup.Response.Code,
+		"backup mutation did not return Success (forceFull=%v)", forceFull)
+	testutil.WaitForTask(t, br.Data.Backup.TaskId, false, testutil.ContainerAddr(whichAlpha, 8080))
 }
 
 func RunRestore(t *testing.T, jwtToken string, restoreLocation string, whichAlpha string) {

--- a/worker/backup.go
+++ b/worker/backup.go
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: © 2017-2025 Istari Digital, Inc.
+ * SPDX-FileCopyrightText: © 2017-2026 Istari Digital, Inc.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -87,6 +87,27 @@ type Manifest struct {
 	// DropOperations records DROP operations that occurred since the previous backup.
 	// Required by restore but omitted from the summary manifest.
 	DropOperations []*pb.DropOperation `json:"drop_operations"`
+}
+
+// checkBackupReadTsAdvanced returns an error if readTs does not advance the
+// backup chain past latestManifest. A regressed ReadTs means the cluster's
+// timestamp counter went backwards (typically because Zero state was wiped or
+// rebuilt while this backup chain was still active). The new posting list KVs
+// would carry commit_ts older than versions already in the chain, and
+// restore-reduce keeps the highest-version entry per key — so the new entries
+// are silently dropped at restore, corrupting indexes. Callers should require
+// forceFull to start a new chain when this triggers.
+func checkBackupReadTsAdvanced(latestManifest *Manifest, readTs uint64) error {
+	if latestManifest.Type == "" {
+		return nil
+	}
+	if readTs > latestManifest.ValidReadTs() {
+		return nil
+	}
+	return errors.Errorf("backup read_ts (%d) is not greater than the latest "+
+		"manifest's read_ts (%d); this usually means Zero state was reset or "+
+		"rebuilt while this backup chain was active. Use \"forceFull\" to "+
+		"start a new chain.", readTs, latestManifest.ValidReadTs())
 }
 
 type MasterManifest struct {
@@ -267,6 +288,10 @@ func ProcessBackupRequest(ctx context.Context, req *pb.BackupRequest) error {
 	if req.ForceFull {
 		req.SinceTs = 0
 	} else {
+		if err := checkBackupReadTsAdvanced(latestManifest, req.ReadTs); err != nil {
+			return err
+		}
+
 		if x.WorkerConfig.EncryptionKey != nil {
 			// If encryption key given, latest backup should be encrypted.
 			if latestManifest.Type != "" && !latestManifest.Encrypted {

--- a/worker/backup_test.go
+++ b/worker/backup_test.go
@@ -1,0 +1,91 @@
+/*
+ * SPDX-FileCopyrightText: © 2017-2026 Istari Digital, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package worker
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCheckBackupReadTsAdvanced(t *testing.T) {
+	tests := []struct {
+		name           string
+		latestManifest *Manifest
+		readTs         uint64
+		wantErr        bool
+	}{
+		{
+			// First backup ever: no prior manifest exists, any ReadTs is fine.
+			name:           "no prior manifest",
+			latestManifest: &Manifest{},
+			readTs:         100,
+			wantErr:        false,
+		},
+		{
+			name: "normal incremental advances chain",
+			latestManifest: &Manifest{
+				ManifestBase: ManifestBase{Type: "full", ReadTs: 100},
+			},
+			readTs:  200,
+			wantErr: false,
+		},
+		{
+			// Repro of the customer's chain corruption: chain reached read_ts
+			// 32M, then Zero state was lost; new ReadTs is far below.
+			name: "regressed ReadTs (Zero state reset)",
+			latestManifest: &Manifest{
+				ManifestBase: ManifestBase{Type: "incremental", ReadTs: 32000000},
+			},
+			readTs:  147784,
+			wantErr: true,
+		},
+		{
+			// Equal ReadTs means the incremental would capture nothing AND
+			// indicates ordering ambiguity — treat as regression.
+			name: "equal ReadTs",
+			latestManifest: &Manifest{
+				ManifestBase: ManifestBase{Type: "full", ReadTs: 1000},
+			},
+			readTs:  1000,
+			wantErr: true,
+		},
+		{
+			// Pre-21.03 manifests store the timestamp in SinceTsDeprecated
+			// rather than ReadTs; ValidReadTs() falls back to that. Make
+			// sure regression detection still triggers.
+			name: "regression detected via deprecated since field",
+			latestManifest: &Manifest{
+				ManifestBase: ManifestBase{Type: "incremental", SinceTsDeprecated: 500},
+			},
+			readTs:  400,
+			wantErr: true,
+		},
+		{
+			// Same as above but ReadTs DOES advance — must not trigger.
+			name: "advance detected via deprecated since field",
+			latestManifest: &Manifest{
+				ManifestBase: ManifestBase{Type: "incremental", SinceTsDeprecated: 500},
+			},
+			readTs:  600,
+			wantErr: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := checkBackupReadTsAdvanced(tc.latestManifest, tc.readTs)
+			if tc.wantErr {
+				require.Error(t, err)
+				// Operator needs to know how to recover.
+				require.Contains(t, err.Error(), "forceFull",
+					"error message should direct operator to forceFull")
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}


### PR DESCRIPTION
When Zero state is wiped or rebuilt while an existing backup chain is still active, the cluster's timestamp counter restarts low. Subsequent incremental backups were silently accepted with read_ts values below earlier manifest entries. On restore, the reduce phase keeps only the highest-version KV per key, so newer postings written at the regressed (lower) timestamps were silently dropped — leaving index posting lists missing entries while data postings sometimes survived. Indexed queries like type(X) and eq(field, value) then returned incomplete results.

Refuse the backup at request time when its ReadTs does not advance the chain past the latest manifest, and direct the operator to forceFull to start a new chain. The check is extracted into a pure helper for testability and skips the no-prior-manifest case so first-ever backups still succeed.

Fixes #9706 

**Checklist**

- [x] The PR title follows the
      [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax, leading
      with `fix:`, `feat:`, `chore:`, `ci:`, etc.
- [x] Code compiles correctly and linting (via trunk) passes locally
- [x] Tests added for new functionality, or regression tests for bug fixes added as applicable