### PR TITLE
perf(algo): pre-size heap in MergeSortedPacked

### DIFF
--- a/algo/packed.go
+++ b/algo/packed.go
@@ -224,8 +224,9 @@ func MergeSortedPacked(lists []*pb.UidPack) *pb.UidPack {
 		return nil
 	}
 
-	h := &uint64Heap{}
-	heap.Init(h)
+	// Pre-size the heap and build via heap.Init (O(n)) rather than n × heap.Push,
+	// which boxes each elem into an interface{} and pays O(log n) per insert.
+	hs := make(uint64Heap, 0, len(lists))
 	maxSz := 0
 	blockSize := 0
 
@@ -244,7 +245,7 @@ func MergeSortedPacked(lists []*pb.UidPack) *pb.UidPack {
 
 		listLen := codec.ExactLen(lists[i])
 		if listLen > 0 {
-			heap.Push(h, elem{
+			hs = append(hs, elem{
 				val:       block[0],
 				listIdx:   i,
 				decoder:   decoder,
@@ -256,6 +257,8 @@ func MergeSortedPacked(lists []*pb.UidPack) *pb.UidPack {
 			}
 		}
 	}
+	h := &hs
+	heap.Init(h)
 
 	// Our final result.
 	result := codec.Encoder{BlockSize: blockSize}


### PR DESCRIPTION
Build the heap slice and call `heap.Init` (O(n)) instead of n×`heap.Push`, which boxes each `elem` into an interface{} (one heap alloc per input list).

`BenchmarkMergeSortedPacked` (1000 lists × 100 uids): allocs/op 104.1k→103.0k (-0.97%), B/op -0.58%.

---
Independent change; branched from `4b9b399d` (no dependency on the other PRs in this set). Verified: package unit tests pass + Go benchmark (benchstat, p<0.01). Numbers are single-thread microbenchmarks; not yet run through the Docker integration suite.