### PR TITLE
perf(algo): pre-size heap in internalMergeSortWithBuffer

### DIFF
--- a/algo/uidlist.go
+++ b/algo/uidlist.go
@@ -394,18 +394,21 @@ func internalMergeSortWithBuffer(lists []*pb.List, buffer []uint64) *pb.List {
 		return &pb.List{Uids: buffer[:0]}
 	}
 
-	h := &uint64Heap{}
-	heap.Init(h)
-
+	// Pre-size the heap to avoid grow-and-copy. Building the slice directly and
+	// calling heap.Init (O(n)) is also cheaper than n × heap.Push (each O(log n)
+	// + interface boxing).
+	hs := make(uint64Heap, 0, len(lists))
 	for i, l := range lists {
 		if l == nil || len(l.Uids) == 0 {
 			continue
 		}
-		heap.Push(h, elem{
+		hs = append(hs, elem{
 			val:     l.Uids[0],
 			listIdx: i,
 		})
 	}
+	h := &hs
+	heap.Init(h)
 
 	// Use the provided buffer
 	output := buffer[:0]


### PR DESCRIPTION
Build the heap slice and call `heap.Init` (O(n)) instead of n×`heap.Push` (per-element interface boxing).

`BenchmarkMergeSorted/MergeSorted` (10000 lists × 100 uids): allocs/op 20.02k→10.01k (**-50%**), B/op 11.46Mi→8.86Mi (-22.7%).

---
Independent change; branched from `4b9b399d` (no dependency on the other PRs in this set). Verified: package unit tests pass + Go benchmark (benchstat, p<0.01). Numbers are single-thread microbenchmarks; not yet run through the Docker integration suite.