### PR TITLE
perf(chunker): lazy facets map + strconv.FormatUint in mapToNquads

### DIFF
--- a/chunker/json_parser.go
+++ b/chunker/json_parser.go
@@ -397,10 +397,13 @@ func getNextBlank() string {
 func (buf *NQuadBuffer) mapToNquads(m map[string]interface{}, op int, parentPred string) (mapResponse, error) {
 	var mr mapResponse
 
-	// move all facets from global map to smaller mr.rawFacets map
-	mr.rawFacets = make(map[string]interface{})
+	// move all facets from global map to smaller mr.rawFacets map. The vast majority
+	// of input objects have no facet keys, so allocate the map lazily on first hit.
 	for k, v := range m {
 		if strings.Contains(k, x.FacetDelimiter) {
+			if mr.rawFacets == nil {
+				mr.rawFacets = make(map[string]interface{})
+			}
 			mr.rawFacets[k] = v
 			delete(m, k)
 		}
@@ -437,7 +440,7 @@ func (buf *NQuadBuffer) mapToNquads(m map[string]interface{}, op int, parentPred
 			}
 		}
 		if uid > 0 {
-			mr.uid = fmt.Sprintf("%d", uid)
+			mr.uid = strconv.FormatUint(uid, 10)
 		}
 	}
 


### PR DESCRIPTION
Allocate `rawFacets` only on the first facet key (most objects have none) and replace `fmt.Sprintf("%d", uid)` with `strconv.FormatUint`.

`BenchmarkParseJSON` (9 nested objects, no facets): allocs/op 517→502 (-2.9%), B/op -1.5%.

---
Independent change; branched from `4b9b399d` (no dependency on the other PRs in this set). Verified: package unit tests pass + Go benchmark (benchstat, p<0.01). Numbers are single-thread microbenchmarks; not yet run through the Docker integration suite.