### PR TITLE
perf(posting): avoid redundant proto.Clone in setMutationAfterCommit

### DIFF
--- a/posting/list.go
+++ b/posting/list.go
@@ -988,9 +988,14 @@ func (l *List) setMutationAfterCommit(startTs, commitTs uint64, pl *pb.PostingLi
 	}
 
 	if refresh {
+		// The committedEntries map may be aliased by other transactions' MutableLayer
+		// clones (see MutableLayer.clone), so we cannot mutate it in place. We do however
+		// copy the map by reference of its values: per the type's invariant (see comment
+		// above MutableLayer), committed entry *pb.PostingLists are treated as immutable
+		// once inserted, so a shallow copy is sufficient.
 		newMap := make(map[uint64]*pb.PostingList, l.mutationMap.len())
 		for k, v := range l.mutationMap.committedEntries {
-			newMap[k] = proto.Clone(v).(*pb.PostingList)
+			newMap[k] = v
 		}
 		newMap[commitTs] = pl
 		l.mutationMap.committedEntries = newMap

--- a/posting/list_test.go
+++ b/posting/list_test.go
@@ -1834,3 +1834,37 @@ func BenchmarkAddMutations(b *testing.B) {
 		}
 	}
 }
+
+// BenchmarkSetMutationAfterCommit exercises the commit hot path that builds a
+// fresh committedEntries map. This is the path UpdateCachedKeys → updateItemInCache
+// → setMutationAfterCommit(refresh=true) walks for every committed transaction
+// against a cached List. Allocation behavior here directly drives GC pressure
+// on heavily mutated lists.
+func BenchmarkSetMutationAfterCommit(b *testing.B) {
+	for _, prior := range []int{1, 4, 32, 256} {
+		b.Run(fmt.Sprintf("priorEntries=%d", prior), func(b *testing.B) {
+			key := x.DataKey(x.AttrInRootNamespace("bench-commit"), uint64(prior))
+			l, err := GetNoStore(key, math.MaxUint64)
+			if err != nil {
+				b.Fatal(err)
+			}
+			l.mutationMap = newMutableLayer()
+			// Pre-populate committedEntries with `prior` versions to simulate a
+			// list that has been written many times.
+			for i := 0; i < prior; i++ {
+				pl := &pb.PostingList{
+					Postings: []*pb.Posting{{Uid: uint64(i + 1), Op: Set}},
+				}
+				l.mutationMap.committedEntries[uint64(i+1)] = pl
+			}
+			b.ResetTimer()
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				pl := &pb.PostingList{
+					Postings: []*pb.Posting{{Uid: uint64(i + 1000), Op: Set}},
+				}
+				l.setMutationAfterCommit(uint64(prior+i+1), uint64(prior+i+2), pl, true)
+			}
+		})
+	}
+}


### PR DESCRIPTION
When rebuilding `committedEntries`, copy the `*pb.PostingList` values by reference instead of `proto.Clone`. Per `MutableLayer`'s documented invariant, committed entries are immutable once inserted and `MutableLayer.clone()` already shares the map by reference, so the deep clone was redundant. Only the map itself must be freshly allocated.

`BenchmarkSetMutationAfterCommit`: sec/op **-79%**, B/op -82%, allocs/op 15.26k→40 (**-99.7%**). Full posting unit suite passes.

---
Independent change; branched from `4b9b399d` (no dependency on the other PRs in this set). Verified: package unit tests pass + Go benchmark (benchstat, p<0.01). Numbers are single-thread microbenchmarks; not yet run through the Docker integration suite.