### PR TITLE
perf(query): faster valToBytes for UidID and PasswordID

### DIFF
--- a/query/outputnode.go
+++ b/query/outputnode.go
@@ -685,9 +685,17 @@ func valToBytes(v types.Val) ([]byte, error) {
 		b := v.Value.(big.Float)
 		return b.MarshalText()
 	case types.UidID:
-		return []byte(fmt.Sprintf("\"%#x\"", v.Value)), nil
+		// Pre-sized: opening quote + "0x" + up to 16 hex digits + closing quote = 20.
+		uid, ok := v.Value.(uint64)
+		if !ok {
+			return []byte(fmt.Sprintf("\"%#x\"", v.Value)), nil
+		}
+		buf := make([]byte, 0, 20)
+		buf = append(buf, '"', '0', 'x')
+		buf = strconv.AppendUint(buf, uid, 16)
+		return append(buf, '"'), nil
 	case types.PasswordID:
-		return []byte(fmt.Sprintf("%q", v.Value.(string))), nil
+		return stringJsonMarshal(v.Value.(string)), nil
 	case types.VFloatID:
 		return json.Marshal(v.Value.([]float32))
 	default:


### PR DESCRIPTION
**UidID:** build `"0x"+hex` via `strconv.AppendUint` into a pre-sized buffer instead of `fmt.Sprintf("%#x")` (output verified byte-identical incl. uid=0 and max uint64; keeps a type-assert fallback). **PasswordID:** use `stringJsonMarshal` instead of `fmt.Sprintf("%q")` — faster and produces proper JSON string escaping.

`BenchmarkValToBytes`: Uid 52n→18n (-65%, 2→1 allocs); Password 126n→35n (-73%, 3→1 allocs).

---
Independent change; branched from `4b9b399d`. Verified: package unit tests pass + Go benchmark (benchstat, p<0.01). Single-thread microbenchmarks; not yet run through the Docker integration suite.