### PR TITLE
build(jemalloc): patch jemalloc 5.3.1 source for libstdc++ 16+ ABI removal

### DIFF
--- a/dgraph/Makefile
+++ b/dgraph/Makefile
@@ -99,6 +99,14 @@ install: jemalloc
 		echo "New SHA256:" `sha256sum $(INSTALL_TARGET) 2>/dev/null | cut -c-64` ; \
 	fi
 
+# jemalloc 5.3.1 source compat patch: libstdc++ 16+ removed
+# std::__throw_bad_alloc from the public ABI, breaking
+# src/jemalloc_cpp.cpp on GCC 16 / libstdc++ 16 toolchains (notably
+# Chainguard go-fips:v1.26.3.1-dev and later). The sed substitution
+# below is a no-op on older libstdc++ (exact-match) and rewrites the
+# legacy call to the standard `throw std::bad_alloc()` idiom on
+# libstdc++ 16+. Drop the sed line once a tagged jemalloc release
+# upstreams the fix and JEMALLOC_URL bumps past it.
 jemalloc:
 	@if [ -z "$(HAS_JEMALLOC)" ] ; then \
 		mkdir -p /tmp/jemalloc-temp && cd /tmp/jemalloc-temp ; \
@@ -106,6 +114,7 @@ jemalloc:
 		curl -f -s -L ${JEMALLOC_URL} -o jemalloc.tar.bz2 ; \
 		tar xjf ./jemalloc.tar.bz2 ; \
 		cd jemalloc-5.3.1 ; \
+		sed -i.bak 's|std::__throw_bad_alloc()|throw std::bad_alloc()|g' src/jemalloc_cpp.cpp ; \
 		./configure --with-jemalloc-prefix='je_' --with-malloc-conf='background_thread:true,metadata_thp:auto'; \
 		make ; \
 		if [ "$(USER_ID)" = "0" ]; then \


### PR DESCRIPTION
## Problem

libstdc++ 16 removed `std::__throw_bad_alloc` from the public ABI. jemalloc 5.3.1's `src/jemalloc_cpp.cpp` still calls that legacy private symbol and fails to compile under GCC 16 / libstdc++ 16:

```
src/jemalloc_cpp.cpp:103:22: error: '__throw_bad_alloc' is not a member of 'std'
```

`dgraph/Makefile` builds jemalloc 5.3.1 from source (the distro package lacks the `je_` symbol prefix ristretto's cgo binding needs), so any toolchain on GCC 16+ hits this during `make dgraph`.

## Fix

Add a `sed` substitution in the `jemalloc:` target that rewrites the legacy call to the standard `throw std::bad_alloc()` after the tarball is extracted and before `./configure` runs. The substitution is exact-match, so it's a no-op on older libstdc++ where the legacy symbol still exists.

Can be dropped once jemalloc cuts a release with the fix baked in and `JEMALLOC_URL` bumps past it.
