### PR TITLE
dgraphtest: add WithStartupArg for arbitrary Alpha flags

### DIFF
--- a/dgraphtest/config.go
+++ b/dgraphtest/config.go
@@ -106,6 +106,7 @@ type ClusterConfig struct {
 	lambdaURL             string
 	featureFlags          []string
 	customPlugins         bool
+	startupArgs           []string
 	snapShotAfterEntries  uint64
 	snapshotAfterDuration time.Duration
 	repoDir               string
@@ -240,6 +241,13 @@ func (cc ClusterConfig) WithCustomPlugins() ClusterConfig {
 // WithGraphqlLambdaURL sets the graphql lambda url for alpha
 func (cc ClusterConfig) WithGraphqlLambdaURL(url string) ClusterConfig {
 	cc.lambdaURL = url
+	return cc
+}
+
+// WithStartupArg appends an extra flag to the Alpha startup command in the form
+// --arg=value. It may be called multiple times to accumulate additional flags.
+func (cc ClusterConfig) WithStartupArg(arg, value string) ClusterConfig {
+	cc.startupArgs = append(cc.startupArgs, fmt.Sprintf("--%s=%s", arg, value))
 	return cc
 }
 

--- a/dgraphtest/dgraph.go
+++ b/dgraphtest/dgraph.go
@@ -304,6 +304,8 @@ func (a *alpha) cmd(c *LocalCluster) []string {
 		acmd = append(acmd, "--mcp")
 	}
 
+	acmd = append(acmd, c.conf.startupArgs...)
+
 	return acmd
 }
 


### PR DESCRIPTION
## What

Adds `ClusterConfig.WithStartupArg(arg, value)` to the `dgraphtest` harness. It appends `--arg=value` to the Alpha startup command and can be called multiple times to accumulate flags.

## Why

An escape hatch for passing Alpha flags that aren't (yet) modelled as first-class `ClusterConfig` options, without adding a bespoke `WithX` method for every flag.
