### PR TITLE
alpha: add public extensibility hooks for the gRPC server and CLI flags

### DIFF
--- a/dgraph/cmd/alpha/hooks.go
+++ b/dgraph/cmd/alpha/hooks.go
@@ -1,0 +1,40 @@
+/*
+ * SPDX-FileCopyrightText: © 2017-2026 Istari Digital, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package alpha
+
+import (
+	"github.com/spf13/pflag"
+	"google.golang.org/grpc"
+)
+
+// This file declares public extensibility hooks for the Alpha gRPC server.
+// Each hook is a package-level function var with an upstream-safe no-op
+// default; the fork reassigns them from dgraph/cmd/alpha/init_istari.go.
+
+// RegisterFlags registers fork-specific CLI flags onto f. Called from
+// Alpha's init() after Alpha.Cmd is initialized, so the FlagSet is live.
+// Default: no-op (OSS builds).
+var RegisterFlags = defaultRegisterFlags
+
+func defaultRegisterFlags(f *pflag.FlagSet) {}
+
+// RegisterZanzibar wires the Zanzibar gRPC service onto s and bootstraps the
+// fixed predicate schema. Default: no-op (OSS builds).
+var RegisterZanzibar = defaultRegisterZanzibar
+
+func defaultRegisterZanzibar(s *grpc.Server) {}
+
+// ZanzibarUnaryInterceptor returns a unary server interceptor for Zanzibar
+// auth gating, or nil if Zanzibar is not enabled. Default: returns nil.
+var ZanzibarUnaryInterceptor = defaultZanzibarUnaryInterceptor
+
+func defaultZanzibarUnaryInterceptor() grpc.UnaryServerInterceptor { return nil }
+
+// ZanzibarStreamInterceptor is the streaming counterpart to
+// ZanzibarUnaryInterceptor. Default: returns nil.
+var ZanzibarStreamInterceptor = defaultZanzibarStreamInterceptor
+
+func defaultZanzibarStreamInterceptor() grpc.StreamServerInterceptor { return nil }

--- a/dgraph/cmd/alpha/run.go
+++ b/dgraph/cmd/alpha/run.go
@@ -275,6 +275,8 @@ they form a Raft group and provide synchronous replication.
 			"Disabled by default (0). Note: enabling this logs query text which may contain "+
 			"sensitive data; do not enable in deployments with strict data privacy requirements.").
 		String())
+
+	RegisterFlags(flag)
 }
 
 func setupCustomTokenizers() {
@@ -456,13 +458,22 @@ func serveGRPC(l net.Listener, tlsCfg *tls.Config, closer *z.Closer) {
 
 	x.RegisterExporters(Alpha.Conf, "dgraph.alpha")
 
+	unary := []grpc.UnaryServerInterceptor{audit.AuditRequestGRPC}
+	if zi := ZanzibarUnaryInterceptor(); zi != nil {
+		unary = append(unary, zi)
+	}
+	stream := []grpc.StreamServerInterceptor{audit.AuditStreamGRPC}
+	if zs := ZanzibarStreamInterceptor(); zs != nil {
+		stream = append(stream, zs)
+	}
+
 	opt := []grpc.ServerOption{
 		grpc.MaxRecvMsgSize(x.GrpcMaxSize),
 		grpc.MaxSendMsgSize(x.GrpcMaxSize),
 		grpc.MaxConcurrentStreams(1000),
 		grpc.StatsHandler(otelgrpc.NewServerHandler()),
-		grpc.UnaryInterceptor(audit.AuditRequestGRPC),
-		grpc.StreamInterceptor(audit.AuditStreamGRPC),
+		grpc.ChainUnaryInterceptor(unary...),
+		grpc.ChainStreamInterceptor(stream...),
 	}
 	if tlsCfg != nil {
 		tlsCfg.NextProtos = []string{"h2"}
@@ -473,6 +484,7 @@ func serveGRPC(l net.Listener, tlsCfg *tls.Config, closer *z.Closer) {
 	api.RegisterDgraphServer(s, &edgraph.Server{})
 	hapi.RegisterHealthServer(s, health.NewServer())
 	worker.RegisterZeroProxyServer(s)
+	RegisterZanzibar(s)
 
 	err := s.Serve(l)
 	glog.Errorf("GRPC listener canceled: %v\n", err)


### PR DESCRIPTION
## What

Introduces `dgraph/cmd/alpha/hooks.go`, declaring package-level function vars with upstream-safe no-op defaults:

- `RegisterFlags(*pflag.FlagSet)` — register extra CLI flags
- `RegisterZanzibar(*grpc.Server)` — register an extra gRPC service
- `ZanzibarUnaryInterceptor() grpc.UnaryServerInterceptor` / `ZanzibarStreamInterceptor() grpc.StreamServerInterceptor` — optional auth interceptors (returning `nil` = not installed)

In a stock build the defaults run, so behavior is unchanged.

It also refactors `serveGRPC` to build its interceptors as slices and install them via `grpc.ChainUnaryInterceptor` / `grpc.ChainStreamInterceptor` instead of a single `grpc.UnaryInterceptor`, so multiple interceptors can compose. The audit interceptor stays first.

## Why

Lets a build register an extra gRPC service, CLI flags, and auth interceptors by reassigning the vars from its own `init()`, with no further changes to `run.go` — the same extension-hook pattern already used elsewhere in the tree.
