### PR TITLE
edgraph: add AlterNoAuth for trusted in-process schema callers

### DIFF
--- a/edgraph/alter_noauth_test.go
+++ b/edgraph/alter_noauth_test.go
@@ -1,0 +1,89 @@
+/*
+ * SPDX-FileCopyrightText: © 2017-2025 Istari Digital, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package edgraph
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	"github.com/dgraph-io/dgo/v250/protos/api"
+	"github.com/dgraph-io/dgraph/v25/x"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/peer"
+)
+
+// TestValidateAlterOperationAuthGate isolates the authorization gate that an
+// in-process Alter caller hits. It proves the bug (a context with no gRPC peer
+// is rejected at the IP-whitelist check) and the fix (NoAuthorize skips that
+// check), without booting a cluster. The full Alter body past
+// validateAlterOperation needs a running cluster.
+func TestValidateAlterOperationAuthGate(t *testing.T) {
+	// validateAlterOperation calls x.HealthCheck before the auth checks; mark
+	// the node healthy so we reach the gate we want to exercise.
+	x.UpdateHealthStatus(true)
+	defer x.UpdateHealthStatus(false)
+
+	op := &api.Operation{Schema: "name: string @index(exact) @upsert ."}
+
+	t.Run("bug: background context is rejected at the IP whitelist", func(t *testing.T) {
+		// context.Background() carries no gRPC peer, so x.HasWhitelistedIP can't
+		// find a source IP. This is exactly what an in-process caller passes, and
+		// it fails on every config — not only under --security whitelist.
+		err := validateAlterOperation(context.Background(), op, NeedAuthorize)
+		require.ErrorContains(t, err, "unable to find source ip")
+	})
+
+	t.Run("the whitelist check is what rejects a non-loopback peer", func(t *testing.T) {
+		// A real but non-whitelisted peer is rejected for a different reason,
+		// confirming the gate we bypass below is the IP whitelist.
+		ctx := peer.NewContext(context.Background(), &peer.Peer{
+			Addr: &net.TCPAddr{IP: net.ParseIP("8.8.8.8"), Port: 4321},
+		})
+		err := validateAlterOperation(ctx, op, NeedAuthorize)
+		require.ErrorContains(t, err, "unauthorized ip address: 8.8.8.8")
+	})
+
+	t.Run("fix: NoAuthorize skips the IP whitelist for in-process callers", func(t *testing.T) {
+		// AlterNoAuth threads NoAuthorize through to here; the same background
+		// context that failed above now passes validation.
+		err := validateAlterOperation(context.Background(), op, NoAuthorize)
+		require.NoError(t, err)
+	})
+
+	t.Run("NoAuthorize still enforces structural validation", func(t *testing.T) {
+		// Skipping auth must not skip the "at least one field set" check.
+		err := validateAlterOperation(context.Background(), &api.Operation{}, NoAuthorize)
+		require.ErrorContains(t, err, "at least one field set")
+	})
+
+	t.Run("NoAuthorize still enforces the health check", func(t *testing.T) {
+		x.UpdateHealthStatus(false)
+		defer x.UpdateHealthStatus(true)
+		err := validateAlterOperation(context.Background(), op, NoAuthorize)
+		require.Error(t, err)
+	})
+}
+
+// TestAlterNoAuthRejectsDrops proves AlterNoAuth is schema-only: every drop
+// form is refused before reaching the cluster, so bypassing auth can never be
+// used to remove data. The guard returns early, so this needs no cluster.
+func TestAlterNoAuthRejectsDrops(t *testing.T) {
+	drops := map[string]*api.Operation{
+		"DropAll":         {DropAll: true},
+		"DropOp_ALL":      {DropOp: api.Operation_ALL},
+		"DropOp_DATA":     {DropOp: api.Operation_DATA},
+		"DropOp_ATTR":     {DropOp: api.Operation_ATTR, DropValue: "name"},
+		"DropOp_TYPE":     {DropOp: api.Operation_TYPE, DropValue: "Person"},
+		"legacy DropAttr": {DropAttr: "name"},
+	}
+	for name, op := range drops {
+		t.Run(name, func(t *testing.T) {
+			_, err := (&Server{}).AlterNoAuth(context.Background(), op)
+			require.ErrorContains(t, err, "only supports schema operations")
+		})
+	}
+}

--- a/edgraph/server.go
+++ b/edgraph/server.go
@@ -173,7 +173,7 @@ func UpdateGQLSchema(ctx context.Context, gqlSchema,
 	// The schema could be empty if it only has custom types/queries/mutations.
 	if dgraphSchema != "" {
 		op := &api.Operation{Schema: dgraphSchema}
-		if err = validateAlterOperation(ctx, op); err != nil {
+		if err = validateAlterOperation(ctx, op, NeedAuthorize); err != nil {
 			return nil, err
 		}
 		if parsedDgraphSchema, err = parseSchemaFromAlterOperation(ctx, op.Schema); err != nil {
@@ -189,8 +189,12 @@ func UpdateGQLSchema(ctx context.Context, gqlSchema,
 	})
 }
 
-// validateAlterOperation validates the given operation for alter.
-func validateAlterOperation(ctx context.Context, op *api.Operation) error {
+// validateAlterOperation validates the given operation for alter. The
+// structural checks (field set, health, drop consistency, mutations-allowed)
+// always run; the admin-IP-whitelist and ACL authorization checks run only
+// when doAuth is NeedAuthorize. doAuth is NoAuthorize for trusted in-process
+// callers (see AlterNoAuth) that run with a context carrying no gRPC peer.
+func validateAlterOperation(ctx context.Context, op *api.Operation, doAuth AuthMode) error {
 	// The following code block checks if the operation should run or not.
 	if op.Schema == "" && op.DropAttr == "" && !op.DropAll && op.DropOp == api.Operation_NONE {
 		// Must have at least one field set. This helps users if they attempt
@@ -207,6 +211,10 @@ func validateAlterOperation(ctx context.Context, op *api.Operation) error {
 
 	if !isMutationAllowed(ctx) {
 		return errors.Errorf("No mutations allowed by server.")
+	}
+
+	if doAuth == NoAuthorize {
+		return nil
 	}
 
 	if _, err := hasAdminAuth(ctx, "Alter"); err != nil {
@@ -334,8 +342,29 @@ func InsertDropRecord(ctx context.Context, dropOp string) error {
 	return err
 }
 
-// Alter handles requests to change the schema or remove parts or all of the data.
+// Alter handles requests to change the schema or remove parts or all of the
+// data. It enforces the admin-IP-whitelist and ACL authorization checks.
 func (s *Server) Alter(ctx context.Context, op *api.Operation) (*api.Payload, error) {
+	return s.alter(ctx, op, NeedAuthorize)
+}
+
+// AlterNoAuth is Alter without the admin-IP-whitelist and ACL authorization
+// checks. It mirrors QueryNoAuth and is intended only for trusted in-process
+// callers that run with a context.Background() and therefore carry no gRPC
+// peer for x.HasWhitelistedIP to inspect — under the regular Alter path such
+// calls are always rejected with "unable to find source ip", regardless of the
+// --security whitelist setting. It must not be exposed to network clients.
+//
+// It is restricted to schema operations: drop requests are refused so that
+// bypassing auth can never be used to remove data.
+func (s *Server) AlterNoAuth(ctx context.Context, op *api.Operation) (*api.Payload, error) {
+	if isDropOperation(op) {
+		return nil, errors.New("AlterNoAuth only supports schema operations, not drops")
+	}
+	return s.alter(ctx, op, NoAuthorize)
+}
+
+func (s *Server) alter(ctx context.Context, op *api.Operation, doAuth AuthMode) (*api.Payload, error) {
 	ctx, span := otel.Tracer("").Start(ctx, "Server.Alter")
 	defer span.End()
 
@@ -346,7 +375,7 @@ func (s *Server) Alter(ctx context.Context, op *api.Operation) (*api.Payload, er
 	glog.Infof("Received ALTER op: %+v", op)
 
 	// check if the operation is valid
-	if err := validateAlterOperation(ctx, op); err != nil {
+	if err := validateAlterOperation(ctx, op, doAuth); err != nil {
 		return nil, err
 	}
 
@@ -2349,6 +2378,12 @@ func isDropAll(op *api.Operation) bool {
 		return true
 	}
 	return false
+}
+
+// isDropOperation reports whether op is any form of drop (all, data, attr, or
+// type) rather than a schema change.
+func isDropOperation(op *api.Operation) bool {
+	return op.DropAll || op.DropOp != api.Operation_NONE || len(op.DropAttr) > 0
 }
 
 func verifyUniqueWithinMutation(qc *queryContext) error {


### PR DESCRIPTION
## What

Adds `AlterNoAuth` — `Alter` without the admin-IP-whitelist and ACL authorization checks — mirroring the existing `Query`/`QueryNoAuth` pair, for trusted in-process callers.

- `validateAlterOperation` gains an `AuthMode`: the structural checks (field set, health, mutations-allowed, reserved-namespace) always run; the IP-whitelist and ACL checks run only under `NeedAuthorize`.
- `Alter` and `AlterNoAuth` share a private `alter()`.
- `AlterNoAuth` is restricted to schema operations — `isDropOperation` refuses every drop form — so bypassing auth can never be used to remove data. It must not be exposed to network clients.

## Why

An in-process caller using `context.Background()` carries no gRPC peer, so `x.HasWhitelistedIP` fails with `"unable to find source ip"` on every config — not only under `--security` whitelist. `QueryNoAuth` already solves this for queries; `AlterNoAuth` is its schema-write counterpart.

## Tests

`edgraph/alter_noauth_test.go` (white-box) exercises the `validateAlterOperation` auth gate — a background context is rejected under `NeedAuthorize`, accepted under `NoAuthorize`, and the structural/health checks still fire — plus `AlterNoAuth`'s drop refusal. No cluster needed.
