### PR TITLE
test: align GraphQL health check retries with gRPC pattern

### DIFF
--- a/dgraphtest/local_cluster.go
+++ b/dgraphtest/local_cluster.go
@@ -868,18 +868,21 @@ func (c *LocalCluster) waitUntilGraphqlHealthCheck() error {
 		return errors.Wrap(err, "error creating http client while graphql health check")
 	}
 	if c.conf.acl {
-		for range 5 {
+		for attempt := range 10 {
 			if err = hc.LoginIntoNamespace(dgraphapi.DefaultUser, dgraphapi.DefaultPassword, x.RootNamespace); err == nil {
 				break
 			}
-			time.Sleep(1 * time.Second)
+			if attempt > 5 {
+				log.Printf("[WARNING] problem trying to login during graphql health check: %v", err)
+			}
+			time.Sleep(waitDurBeforeRetry)
 		}
 		if err != nil {
 			return errors.Wrap(err, "error during login while graphql health check")
 		}
 	}
 
-	for range 10 {
+	for attempt := range 10 {
 		// Sleep for a second before retrying
 		time.Sleep(waitDurBeforeRetry)
 		// we do this because before v21, we used to propose the initial schema to the cluster.
@@ -889,6 +892,9 @@ func (c *LocalCluster) waitUntilGraphqlHealthCheck() error {
 		if err == nil {
 			log.Printf("[INFO] graphql health check succeeded for %v", c.conf.prefix)
 			return nil
+		}
+		if attempt > 5 {
+			log.Printf("[WARNING] problem during graphql health check: %v", err)
 		}
 	}
 	return errors.Wrap(err, "error during graphql health check")


### PR DESCRIPTION
**Description**

The `waitUntilGraphqlHealthCheck` function had a retry mismatch: it only retried login 5 times before failing, while `waitUntilGrpcHealthCheck` retries 10 times. This asymmetry caused flaky failures in `TestNamespaceAwareRestoreOnMultipleGroups` (and others) when the server wasn't fully ready within the 5-second window.

Changes:
- Increase GraphQL login retry attempts from 5 to 10 (matching gRPC pattern)
- Add warning logs for failed attempts after attempt 5 for visibility
- Add logging to the DeleteUser health check loop for consistency

This gives the cluster more time to become ready without extending the total wait period beyond what gRPC health checks already do.

**Checklist**

- [x] The PR title follows the
      [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax, leading
      with `fix:`, `feat:`, `chore:`, `ci:`, etc.
- [x] Code compiles correctly and linting (via trunk) passes locally
