### PR TITLE
x,edgraph: harden reserved-namespace registration and value-lock delete coverage

### DIFF
--- a/edgraph/server.go
+++ b/edgraph/server.go
@@ -481,6 +481,23 @@ func (s *Server) alter(ctx context.Context, op *api.Operation, doAuth AuthMode) 
 				" dropped", x.ParseAttr(attr))
 		}
 
+		// A value-locked predicate's stored value is owned by the service that
+		// registered it; dropping the predicate deletes that value, so it needs
+		// the same TrustMarker the mutation-value guard checks. DropAttr builds
+		// its delete edge here and bypasses validateNQuads, so the check is
+		// repeated. The only marker-bearing path is the in-process owner;
+		// external and admin Alter callers carry no marker and are refused.
+		if marker, locked := x.ReservedPredicateValueLock(x.ParseAttr(attr)); locked {
+			trusted := false
+			if marker != nil {
+				trusted, _ = ctx.Value(marker).(bool)
+			}
+			if !trusted {
+				return empty, errors.Errorf("cannot drop value-locked predicate %s outside "+
+					"its owning service", x.ParseAttr(attr))
+			}
+		}
+
 		nq := &api.NQuad{
 			Subject:     x.Star,
 			Predicate:   x.ParseAttr(attr),
@@ -2320,6 +2337,13 @@ func validateNQuads(set, del []*api.NQuad, guardReserved reservedPredicateGuard)
 		if nq.Subject == x.Star || (nq.Predicate == x.Star && !ostar) {
 			return errors.Errorf("Only valid wildcard delete patterns are 'S * *' and 'S P *': %v", nq)
 		}
+		// guardReserved matches a named predicate, so a 'S P *' delete of a
+		// value-locked predicate is caught here. A 'S * *' delete (predicate is
+		// the wildcard) cannot be matched per-predicate: the subject's predicates
+		// aren't known at validation, and the wildcard is expanded post-Raft in
+		// worker where the request's TrustMarker is gone. Bulk subject deletes
+		// that remove a value-locked predicate are outside the value lock's scope
+		// and are gated by ACL predicate-level permissions.
 		if err := guardReserved(nq); err != nil {
 			return err
 		}

--- a/x/keys.go
+++ b/x/keys.go
@@ -692,24 +692,58 @@ var (
 // RegisterReservedNamespace records a plugin's ownership of names under the
 // reserved `dgraph.` prefix. Call it from an init(); it is safe for concurrent
 // use but is expected to run before the server starts handling requests.
+//
+// All names must be bare (no namespace separator) and uniquely owned, and a
+// non-empty ValueLocked needs a TrustMarker. It panics on any of these, so a
+// misconfiguration trips at startup rather than silently at mutation time.
 func RegisterReservedNamespace(ns ReservedNamespace) {
 	if len(ns.ValueLocked) > 0 && ns.TrustMarker == nil {
 		panic("x.RegisterReservedNamespace: ValueLocked is set but TrustMarker is nil; " +
 			"a value-locked predicate with no TrustMarker is unwritable by everyone, including its owner")
 	}
+	// Names must be bare (no namespace separator). The membership lookups strip
+	// the namespace from the query, and the value-lock guard matches the bare
+	// predicate the mutation path passes, so a namespace-qualified registration
+	// would never match — silently leaving a value-locked predicate publicly
+	// writable. Reject it at startup instead.
+	for _, group := range [][]string{{ns.PredicatePrefix}, ns.Predicates, ns.Types, ns.ValueLocked} {
+		for _, name := range group {
+			if strings.Contains(name, NsSeparator) {
+				panic(fmt.Sprintf("x.RegisterReservedNamespace: name %q must be bare, "+
+					"without the %q namespace separator", name, NsSeparator))
+			}
+		}
+	}
+
 	reservedNsMu.Lock()
 	defer reservedNsMu.Unlock()
 	if ns.PredicatePrefix != "" {
 		reservedNsPrefixes = append(reservedNsPrefixes, strings.ToLower(ns.PredicatePrefix))
 	}
+	// A reserved name has a single owner. A duplicate registration (two
+	// namespaces, or a re-init) is a programming error, and for value locks it
+	// would silently change which TrustMarker wins by import order — so panic
+	// rather than last-writer-wins.
 	for _, p := range ns.Predicates {
-		reservedNsPredicates[strings.ToLower(p)] = struct{}{}
+		key := strings.ToLower(p)
+		if _, dup := reservedNsPredicates[key]; dup {
+			panic(fmt.Sprintf("x.RegisterReservedNamespace: predicate %q already registered", key))
+		}
+		reservedNsPredicates[key] = struct{}{}
 	}
 	for _, t := range ns.Types {
-		reservedNsTypes[strings.ToLower(t)] = struct{}{}
+		key := strings.ToLower(t)
+		if _, dup := reservedNsTypes[key]; dup {
+			panic(fmt.Sprintf("x.RegisterReservedNamespace: type %q already registered", key))
+		}
+		reservedNsTypes[key] = struct{}{}
 	}
 	for _, p := range ns.ValueLocked {
-		reservedNsValueLocked[strings.ToLower(p)] = ns.TrustMarker
+		key := strings.ToLower(p)
+		if _, dup := reservedNsValueLocked[key]; dup {
+			panic(fmt.Sprintf("x.RegisterReservedNamespace: value-locked predicate %q already registered", key))
+		}
+		reservedNsValueLocked[key] = ns.TrustMarker
 	}
 }
 

--- a/x/reserved_namespace_test.go
+++ b/x/reserved_namespace_test.go
@@ -93,3 +93,27 @@ func TestRegisterReservedNamespaceRequiresTrustMarker(t *testing.T) {
 		})
 	})
 }
+
+// TestRegisterReservedNamespaceRejectsQualifiedName confirms a namespace-qualified
+// name is rejected at registration. The value-lock guard matches the bare
+// predicate, so a qualified entry would never match and the predicate would stay
+// publicly writable — it must fail closed at startup instead.
+func TestRegisterReservedNamespaceRejectsQualifiedName(t *testing.T) {
+	require.Panics(t, func() {
+		RegisterReservedNamespace(ReservedNamespace{
+			Predicates:  []string{"dgraph.qualtest.secret"},
+			ValueLocked: []string{NamespaceAttr(RootNamespace, "dgraph.qualtest.secret")},
+			TrustMarker: testTrust,
+		})
+	})
+}
+
+// TestRegisterReservedNamespaceRejectsDuplicate confirms a name claimed twice
+// panics rather than silently overwriting (for value locks, last-writer-wins
+// would let import order pick the TrustMarker).
+func TestRegisterReservedNamespaceRejectsDuplicate(t *testing.T) {
+	require.Panics(t, func() {
+		RegisterReservedNamespace(ReservedNamespace{Predicates: []string{"dgraph.duptest.x"}})
+		RegisterReservedNamespace(ReservedNamespace{Predicates: []string{"dgraph.duptest.x"}})
+	})
+}


### PR DESCRIPTION
Follow-up to #9753 (the reserved-namespace registry), addressing two hardening points from review of that work.

## Registration input validation (`x/keys.go`)

`RegisterReservedNamespace` now panics at `init()` on two misconfigurations that previously surfaced only at mutation time:

- **Namespace-qualified names.** A name containing the namespace separator never matched the bare lookups, so a value-locked predicate registered in qualified form stayed publicly writable (fail open). Rejected for `PredicatePrefix`/`Predicates`/`Types`/`ValueLocked`.
- **Duplicate ownership.** Two namespaces (or a re-init) claiming the same predicate/type/value-lock silently last-writer-wins, letting import order pick the `TrustMarker`. Now panics.

## Value-lock delete coverage (`edgraph/server.go`)

The value-lock guard (`newReservedPredicateGuard`) ran only on the `/mutate` set+del NQuad path. Two delete vectors bypassed it:

- **`Alter DropAttr`** builds its own delete edge and calls `ApplyMutations` directly. It now applies the same `TrustMarker` check, so a value-locked predicate can't be dropped by a caller lacking the owning service's marker.
- **`S * *` delete** reaches the guard with the wildcard predicate (matching no value lock), and the wildcard is expanded post-Raft in `worker` where the request context is gone, so it can't be enforced per-predicate at validation. Documented the boundary at the guard; bulk subject deletes that remove a value-locked predicate are gated by ACL predicate-level permissions instead.

## Tests / safety

`x/reserved_namespace_test.go` covers the qualified-name and duplicate rejections. The `DropAttr` enforcement is exercised by an integration test in the consuming downstream (the value lock has no in-tree consumer, since the registry is empty in a stock build). With no registration the registry stays empty and behavior is identical to before.
