### PR TITLE
fix(backup): contain restore file paths within the handler root

### DIFF
--- a/worker/backup_handler.go
+++ b/worker/backup_handler.go
@@ -13,6 +13,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/golang/glog"
@@ -74,6 +75,16 @@ func createBackupFile(h UriHandler, uri *url.URL, req *pb.BackupRequest) (io.Wri
 
 func backupName(since uint64, groupId uint32) string {
 	return fmt.Sprintf(backupNameFmt, since, groupId)
+}
+
+// cleanRelPath anchors path at the root and cleans it so that a leading
+// separator or any number of ".." segments can never resolve above a handler's
+// root. It mirrors the containment in http.Dir.Open. The "path" field of a
+// backup manifest is read back from the backup location, so a manifest planted
+// there must not be able to steer reads/writes outside the handler root.
+func cleanRelPath(path string) string {
+	sep := string(filepath.Separator)
+	return strings.TrimPrefix(filepath.Join(sep, filepath.FromSlash(path)), sep)
 }
 
 // UriHandler interface is implemented by URI scheme handlers.
@@ -161,7 +172,7 @@ func (h *fileHandler) FileExists(path string) bool      { return pathExist(h.Joi
 func (h *fileHandler) Read(path string) ([]byte, error) { return os.ReadFile(h.JoinPath(path)) }
 
 func (h *fileHandler) JoinPath(path string) string {
-	return filepath.Join(h.rootDir, h.prefix, path)
+	return filepath.Join(h.rootDir, h.prefix, cleanRelPath(path))
 }
 func (h *fileHandler) Stream(path string) (io.ReadCloser, error) {
 	return os.Open(h.JoinPath(path))
@@ -288,7 +299,7 @@ func (h *s3Handler) FileExists(path string) bool {
 }
 
 func (h *s3Handler) JoinPath(path string) string {
-	return filepath.Join(h.bucketName, h.objectPrefix, path)
+	return filepath.Join(h.bucketName, h.objectPrefix, cleanRelPath(path))
 }
 
 func (h *s3Handler) Read(path string) ([]byte, error) {
@@ -410,5 +421,5 @@ func (h *s3Handler) Rename(srcPath, dstPath string) error {
 }
 
 func (h *s3Handler) getObjectPath(path string) string {
-	return filepath.Join(h.objectPrefix, path)
+	return filepath.Join(h.objectPrefix, cleanRelPath(path))
 }

--- a/worker/backup_handler_test.go
+++ b/worker/backup_handler_test.go
@@ -13,6 +13,35 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestCleanRelPath(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"empty", "", ""},
+		{"dot", ".", ""},
+		{"dot dot", "..", ""},
+		{"only dot dot segments", "../../..", ""},
+		{"leading dot segment", "./a/b", filepath.FromSlash("a/b")},
+		{"internal dot dot resolved", "a/../b", "b"},
+		{"internal dot dot contained", "a/../../b", "b"},
+		{"leading dot dot", "../../etc/passwd", filepath.FromSlash("etc/passwd")},
+		{"absolute path anchored", "/etc/hosts", filepath.FromSlash("etc/hosts")},
+		{"absolute root", "/", ""},
+		{"trailing separator", "a/b/", filepath.FromSlash("a/b")},
+		{"duplicate separators", "a//b///c", filepath.FromSlash("a/b/c")},
+		{"legitimate backup path unchanged",
+			"dgraph.20260101.120000.000/r42-g1.backup",
+			filepath.FromSlash("dgraph.20260101.120000.000/r42-g1.backup")},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, cleanRelPath(tc.in))
+		})
+	}
+}
+
 // escapesRoot reports whether target is outside base.
 func escapesRoot(t *testing.T, base, target string) bool {
 	t.Helper()

--- a/worker/backup_handler_test.go
+++ b/worker/backup_handler_test.go
@@ -1,0 +1,63 @@
+/*
+ * SPDX-FileCopyrightText: © 2017-2025 Istari Digital, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package worker
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// escapesRoot reports whether target is outside base.
+func escapesRoot(t *testing.T, base, target string) bool {
+	t.Helper()
+	rel, err := filepath.Rel(base, target)
+	require.NoError(t, err)
+	return rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator))
+}
+
+func TestFileHandlerJoinPathContainment(t *testing.T) {
+	root := t.TempDir()
+	h := &fileHandler{rootDir: root + string(filepath.Separator), prefix: "backups"}
+	base := filepath.Join(root, "backups")
+
+	traversals := []string{
+		"../../../../etc/passwd",
+		"dgraph.20260101.120000.000/../../../../../../etc/shadow",
+		filepath.Join("..", "..", "secret.txt"),
+		"/etc/hosts",
+	}
+	for _, p := range traversals {
+		got := h.JoinPath(p)
+		require.Falsef(t, escapesRoot(t, base, got),
+			"JoinPath(%q) escaped handler root: %q", p, got)
+	}
+
+	// A legitimate relative backup path must be untouched.
+	good := filepath.Join("dgraph.20260101.120000.000", backupName(42, 1))
+	require.Equal(t, filepath.Join(base, good), h.JoinPath(good))
+}
+
+func TestS3HandlerGetObjectPathContainment(t *testing.T) {
+	h := &s3Handler{objectPrefix: "dgraph/backups"}
+
+	traversals := []string{
+		"../../../../etc/passwd",
+		"dgraph.1/../../../../other/secret",
+		"/etc/hosts",
+	}
+	for _, p := range traversals {
+		got := h.getObjectPath(p)
+		require.Falsef(t, strings.HasPrefix(got, ".."),
+			"getObjectPath(%q) escaped object prefix: %q", p, got)
+	}
+
+	// A legitimate relative object path must be untouched.
+	good := filepath.Join("dgraph.1", backupName(42, 1))
+	require.Equal(t, filepath.Join("dgraph/backups", good), h.getObjectPath(good))
+}

--- a/worker/backup_manifest_test.go
+++ b/worker/backup_manifest_test.go
@@ -7,6 +7,7 @@ package worker
 
 import (
 	"encoding/json"
+	"io"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -14,6 +15,8 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/dgraph-io/dgraph/v25/protos/pb"
 )
 
 func TestParseBackupTime(t *testing.T) {
@@ -403,4 +406,79 @@ func TestListBackupManifests_EmptyLocation(t *testing.T) {
 	// No manifest files — getConsolidatedManifest returns empty MasterManifest
 	_, err := ListBackupManifests(tmpDir, nil, false)
 	require.NoError(t, err)
+}
+
+// TestRestorePathContainmentEndToEnd drives the restore-side flow over a real
+// backup layout: the master manifest is read back from the backup location and
+// its "path" field feeds getManifestsToRestore and the handler reads. A
+// manifest planted with a traversal path must not make the handler see or
+// stream files outside its root, while a legitimate layout must restore
+// unchanged.
+func TestRestorePathContainmentEndToEnd(t *testing.T) {
+	req := &pb.RestoreRequest{}
+
+	t.Run("planted traversal manifest is contained", func(t *testing.T) {
+		base := t.TempDir()
+		backupRoot := filepath.Join(base, "backups")
+		outside := filepath.Join(base, "outside")
+		require.NoError(t, os.MkdirAll(backupRoot, 0755))
+		require.NoError(t, os.MkdirAll(outside, 0755))
+
+		// Plant the target where "../outside" used to resolve before containment.
+		outsideFile := filepath.Join(outside, backupName(5, 1))
+		require.NoError(t, os.WriteFile(outsideFile, []byte("outside-data"), 0644))
+
+		evil := &Manifest{
+			ManifestBase: ManifestBase{
+				Type: "full", BackupId: "evil", BackupNum: 1,
+				Path: "../outside", ReadTs: 5, Version: 2105,
+			},
+			Groups: map[uint32][]string{1: {"name"}},
+		}
+		writeMasterManifestToDir(t, backupRoot, []*Manifest{evil})
+
+		h, uri := testFileHandlerForDir(t, backupRoot)
+		manifests, err := getManifestsToRestore(h, uri, req)
+		require.NoError(t, err)
+		require.Empty(t, manifests)
+
+		// The planted file exists on disk, but the handler must not reach it.
+		require.FileExists(t, outsideFile)
+		file := filepath.Join(evil.Path, backupName(5, 1))
+		require.False(t, h.FileExists(file))
+		_, err = h.Stream(file)
+		require.Error(t, err)
+	})
+
+	t.Run("legitimate backup restores unchanged", func(t *testing.T) {
+		base := t.TempDir()
+		backupRoot := filepath.Join(base, "backups")
+		backupDir := "dgraph.20260101.000000.000"
+		require.NoError(t, os.MkdirAll(filepath.Join(backupRoot, backupDir), 0755))
+
+		backupFile := filepath.Join(backupRoot, backupDir, backupName(5, 1))
+		require.NoError(t, os.WriteFile(backupFile, []byte("backup-data"), 0644))
+
+		good := &Manifest{
+			ManifestBase: ManifestBase{
+				Type: "full", BackupId: "ok", BackupNum: 1,
+				Path: backupDir, ReadTs: 5, Version: 2105,
+			},
+			Groups: map[uint32][]string{1: {"name"}},
+		}
+		writeMasterManifestToDir(t, backupRoot, []*Manifest{good})
+
+		h, uri := testFileHandlerForDir(t, backupRoot)
+		manifests, err := getManifestsToRestore(h, uri, req)
+		require.NoError(t, err)
+		require.Len(t, manifests, 1)
+
+		m := manifests[0]
+		rc, err := h.Stream(filepath.Join(m.Path, backupName(m.ValidReadTs(), 1)))
+		require.NoError(t, err)
+		defer func() { require.NoError(t, rc.Close()) }()
+		data, err := io.ReadAll(rc)
+		require.NoError(t, err)
+		require.Equal(t, "backup-data", string(data))
+	})
 }


### PR DESCRIPTION
**Description**

The `path` field of a backup manifest is read back from the backup location (`readMasterManifest`) and used as-is during restore.

1. `restore_map.go` joins `manifest.Path` with the backup file name and streams it through `fileHandler.Stream` -> `os.Open(filepath.Join(rootDir, prefix, path))`.
2. `getManifestsToRestore` joins the same `manifest.Path` for `FileExists`, and the s3/minio handler builds object keys the same way in `getObjectPath`.

`JoinPath`/`getObjectPath` do not contain the relative path, so a manifest left in the backup target with `path` set to `../../..` steers those reads outside the handler root. The fix sits in the handlers because that is the single choke point every backup/restore file op goes through.

`Repro:` `worker/backup_handler_test.go` (fails before, passes after).
`Expected:` the resolved path stays under the handler root.
`Actual:` `JoinPath("../../../../etc/passwd")` returns `/etc/passwd`; `getObjectPath` returns `../../etc/passwd`.
`Fix:` `cleanRelPath` anchors the path at the root and drops a leading separator / `..` before the join; `JoinPath` (file + s3) and `getObjectPath` all route through it.

**Checklist**

- [x] The PR title follows the
      [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax, leading
      with `fix:`, `feat:`, `chore:`, `ci:`, etc.
- [x] Code compiles correctly and linting (via trunk) passes locally
- [x] Tests added for new functionality, or regression tests for bug fixes added as applicable
