### PR TITLE
fix: handle mremap size mismatch on Linux s390x

### DIFF
--- a/vendor/github.com/dgraph-io/ristretto/v2/z/mremap_nosize.go
+++ b/vendor/github.com/dgraph-io/ristretto/v2/z/mremap_nosize.go
@@ -1,0 +1,46 @@
+//go:build (arm64 || arm || s390x) && linux && !js
+// +build arm64 arm s390x
+// +build linux
+// +build !js
+
+/*
+ * SPDX-FileCopyrightText: © 2017-2025 Istari Digital, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package z
+
+import (
+	"reflect"
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+)
+
+// mremap is a Linux-specific system call to remap pages in memory. This can be used in place of munmap + mmap.
+func mremap(data []byte, size int) ([]byte, error) {
+	//nolint:lll
+	// taken from <https://github.com/torvalds/linux/blob/f8394f232b1eab649ce2df5c5f15b0e528c92091/include/uapi/linux/mman.h#L8>
+	const MREMAP_MAYMOVE = 0x1
+
+	header := (*reflect.SliceHeader)(unsafe.Pointer(&data))
+	// For ARM64, the second return argument for SYS_MREMAP is inconsistent (prior allocated size) with
+	// other architectures, which return the size allocated
+	mmapAddr, _, errno := unix.Syscall6(
+		unix.SYS_MREMAP,
+		header.Data,
+		uintptr(header.Len),
+		uintptr(size),
+		uintptr(MREMAP_MAYMOVE),
+		0,
+		0,
+	)
+	if errno != 0 {
+		return nil, errno
+	}
+
+	header.Data = mmapAddr
+	header.Cap = size
+	header.Len = size
+	return data, nil
+}

--- a/vendor/github.com/dgraph-io/ristretto/v2/z/mremap_size.go
+++ b/vendor/github.com/dgraph-io/ristretto/v2/z/mremap_size.go
@@ -1,0 +1,46 @@
+//go:build linux && !arm64 && !arm && !s390x && !js
+// +build linux,!arm64,!arm,!s390x,!js
+
+/*
+ * SPDX-FileCopyrightText: © 2017-2025 Istari Digital, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package z
+
+import (
+	"fmt"
+	"reflect"
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+)
+
+// mremap is a Linux-specific system call to remap pages in memory. This can be used in place of munmap + mmap.
+func mremap(data []byte, size int) ([]byte, error) {
+	//nolint:lll
+	// taken from <https://github.com/torvalds/linux/blob/f8394f232b1eab649ce2df5c5f15b0e528c92091/include/uapi/linux/mman.h#L8>
+	const MREMAP_MAYMOVE = 0x1
+
+	header := (*reflect.SliceHeader)(unsafe.Pointer(&data))
+	mmapAddr, mmapSize, errno := unix.Syscall6(
+		unix.SYS_MREMAP,
+		header.Data,
+		uintptr(header.Len),
+		uintptr(size),
+		uintptr(MREMAP_MAYMOVE),
+		0,
+		0,
+	)
+	if errno != 0 {
+		return nil, errno
+	}
+	if mmapSize != uintptr(size) {
+		return nil, fmt.Errorf("mremap size mismatch: requested: %d got: %d", size, mmapSize)
+	}
+
+	header.Data = mmapAddr
+	header.Cap = size
+	header.Len = size
+	return data, nil
+}


### PR DESCRIPTION
### **Description**

This PR fixes a runtime crash in Dgraph Alpha on IBM s390x architecture
that prevents the service from restarting after any unclean shutdown.

### **Problem**

After any unclean exit of Alpha (SSH session close, kill -9, OOM kill, VM
reboot), a stale memtable file (00001.mem, always 128 MB) is left in the
postings directory. On restart, BadgerDB calls mremap(2) to shrink the
mapping from 128 MB down to the actual data size.

On s390x, the Linux kernel does not support shrinking a mapping via mremap
— it returns the original size (134,217,728 bytes) instead of the requested
smaller size. Ristretto asserts returned == requested and calls log.Fatalf,
crashing Alpha before it can serve any requests:

    while opening memtables err: while opening fid: 3 err:
      while updating skiplist err:
        mremap size mismatch: requested: 2628 got: 134217728
    Error while creating badger KV posting store

Ristretto already has this fix for ARM64 (identical kernel behavior) via
mremap_nosize.go. The fix was never extended to s390x.

### **Fix**

This PR updates the vendored Ristretto files to add s390x to the build tags
of the existing ARM64 safe path. The upstream fix has been raised at:
https://github.com/dgraph-io/ristretto/pull/491

vendor/github.com/dgraph-io/ristretto/v2/z/mremap_nosize.go
- //go:build (arm64 || arm) && linux && !js
+ //go:build (arm64 || arm || s390x) && linux && !js
- // +build arm64 arm
+ // +build arm64 arm s390x

vendor/github.com/dgraph-io/ristretto/v2/z/mremap_size.go
- //go:build linux && !arm64 && !arm && !js
+ //go:build linux && !arm64 && !arm && !s390x && !js
- // +build linux,!arm64,!arm,!js
+ // +build linux,!arm64,!arm,!s390x,!js

**Note: The vendored files are not tracked in upstream main, so the diff
shows the full file content as additions. The only meaningful change is
the two build tag lines at the top of each file.**

### **Validation Performed**

- s390x (IBM Fyre VM, RHEL on IBM Z) - Native full runtime test
  - Alpha restarts cleanly after unclean shutdown with stale 128 MB .mem present
  - Full CRUD operations verified on Dgraph v25.3.4 and v25.3.7

- linux/arm64, linux/amd64, x86_64 - go build ./... - Build successful on all three

### **Impact**

- Resolves Alpha startup crash on IBM s390x after any unclean shutdown
- Build-tag change only — no functional logic changes introduced
- No impact on x86_64, ARM64, ARM, or any other supported architecture

### **Related**

- Upstream Ristretto fix: https://github.com/dgraph-io/ristretto/pull/491
- Follows fix: S390x compatibility (#9746) which fixed the s390x compilation blocker

### **Checklist**

- [x] The PR title follows the Conventional Commits syntax, leading with fix:
- [x] Code compiles correctly on s390x, x86_64, linux/arm64, linux/amd64

Note: A unit test for this fix is not feasible — the mremap shrink behavior
is specific to the Linux s390x kernel and cannot be reproduced or mocked on
other architectures. Runtime validation was performed directly on an IBM Z
(s390x) RHEL VM as described in the Validation section above.