### PR TITLE
chore: add three published CVEs to openvex.json

### DIFF
--- a/openvex.json
+++ b/openvex.json
@@ -2,8 +2,8 @@
   "@context": "https://openvex.dev/ns/v0.2.0",
   "@id": "https://github.com/dgraph-io/dgraph/blob/main/openvex.json",
   "author": "Dgraph maintainers",
-  "timestamp": "2026-05-19T00:00:00Z",
-  "version": 1,
+  "timestamp": "2026-07-23T00:00:00Z",
+  "version": 2,
   "statements": [
     {
       "vulnerability": {
@@ -49,6 +49,33 @@
       "products": [{ "@id": "pkg:golang/github.com/dgraph-io/dgraph/v25" }],
       "status": "fixed",
       "impact_statement": "Fix is present in the main branch. The advisory database has not yet recorded a fixed version, so Trivy cannot determine this by version comparison alone."
+    },
+    {
+      "vulnerability": {
+        "@id": "https://nvd.nist.gov/vuln/detail/CVE-2026-44840",
+        "name": "CVE-2026-44840"
+      },
+      "products": [{ "@id": "pkg:golang/github.com/dgraph-io/dgraph/v25" }],
+      "status": "fixed",
+      "impact_statement": "Fix is present in the main branch (commit cee702c93, 2026-05-11). The advisory records the fix in release 25.3.4; nightly CI builds embed a Go pseudo-version that sorts below that tag."
+    },
+    {
+      "vulnerability": {
+        "@id": "https://nvd.nist.gov/vuln/detail/CVE-2026-54061",
+        "name": "CVE-2026-54061"
+      },
+      "products": [{ "@id": "pkg:golang/github.com/dgraph-io/dgraph/v25" }],
+      "status": "fixed",
+      "impact_statement": "Fix is present in the main branch (commit aba579ace, 2026-06-11). The advisory records the fix in release 25.3.5; nightly CI builds embed a Go pseudo-version that sorts below that tag."
+    },
+    {
+      "vulnerability": {
+        "@id": "https://nvd.nist.gov/vuln/detail/CVE-2026-63637",
+        "name": "CVE-2026-63637"
+      },
+      "products": [{ "@id": "pkg:golang/github.com/dgraph-io/dgraph/v25" }],
+      "status": "fixed",
+      "impact_statement": "Fix is present in the main branch (commit aaff09ab9, 2026-07-06). The advisory database has not yet recorded a fixed version, so Trivy cannot determine this by version comparison alone."
     }
   ]
 }


### PR DESCRIPTION
## Summary

Adds VEX statements for the three published advisories that were missing from `openvex.json`. All three fixes are already on main, but nightly builds embed a Go pseudo-version (`v25.0.0-YYYYMMDDHHMMSS-<commit>`) that sorts below the fixed release tags, so Trivy flags them as false positives without a statement.

## Changes

| CVE | Advisory | Fix commit on main | Fixed release |
|---|---|---|---|
| CVE-2026-44840 | GHSA-q2m9-6jp9-c6mc (checkUserPassword DQL injection) | cee702c93 | 25.3.4 |
| CVE-2026-54061 | GHSA-rrwh-6jrq-wp5v (unauthenticated external snapshot import) | aba579ace | 25.3.5 |
| CVE-2026-63637 | GHSA-33p8-wc97-5qcj (regexp filter DQL injection) | aaff09ab9 | none recorded yet |

Also bumps the document `version` to 2 and refreshes the timestamp.

Deliberately excluded: CVE-2023-31135 only affects the pre-`/v25` module path below v23.0.0, so it can't match current builds.

Side note for whoever owns the advisories: GHSA-33p8-wc97-5qcj records the affected package as `github.com/dgraph-io/dgraph` without the `/v25` suffix and has no patched version, which is why version comparison can't clear it. Worth fixing on the GitHub side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)