### PR TITLE
chore(test): configure Zero security whitelist in test clusters

### DIFF
--- a/compose/compose.go
+++ b/compose/compose.go
@@ -252,6 +252,12 @@ func getZero(idx int, raft string) service {
 	if opts.Vmodule != "" {
 		svc.Command += fmt.Sprintf(" --vmodule=%s", opts.Vmodule)
 	}
+	if opts.WhiteList {
+		// Zero versions that guard their admin HTTP endpoints read the security whitelist
+		// from the environment. It is not passed as a --security flag because older zero
+		// versions would fail to start on an unrecognized flag.
+		svc.Environment = append(svc.Environment, "DGRAPH_ZERO_SECURITY=whitelist=0.0.0.0/0")
+	}
 	if idx == 1 {
 		svc.Command += " --bindall"
 	} else {

--- a/dgraphtest/dgraph.go
+++ b/dgraphtest/dgraph.go
@@ -79,6 +79,7 @@ type dnode interface {
 	ports() nat.PortSet
 	bindings(int) nat.PortMap
 	cmd(*LocalCluster) []string
+	env(*LocalCluster) []string
 	workingDir() string
 	mounts(*LocalCluster) ([]mount.Mount, error)
 	healthURL(*LocalCluster) (string, error)
@@ -150,6 +151,14 @@ func (z *zero) cmd(c *LocalCluster) []string {
 	}
 
 	return zcmd
+}
+
+func (z *zero) env(c *LocalCluster) []string {
+	// Zero binaries that guard their admin HTTP endpoints read the security whitelist from
+	// the environment; older binaries used in upgrade tests simply ignore the variable. An
+	// env var is used instead of a --security flag because older zero binaries would fail
+	// to start on an unrecognized flag.
+	return []string{"DGRAPH_ZERO_SECURITY=whitelist=0.0.0.0/0"}
 }
 
 func (z *zero) workingDir() string {
@@ -311,6 +320,10 @@ func (a *alpha) cmd(c *LocalCluster) []string {
 	acmd = append(acmd, c.conf.startupArgs...)
 
 	return acmd
+}
+
+func (a *alpha) env(c *LocalCluster) []string {
+	return nil
 }
 
 func (a *alpha) workingDir() string {

--- a/dgraphtest/local_cluster.go
+++ b/dgraphtest/local_cluster.go
@@ -317,7 +317,8 @@ func (c *LocalCluster) createContainer(dc dnode) (string, error) {
 		}
 	}
 
-	cconf := &container.Config{Cmd: cmd, Image: image, WorkingDir: dc.workingDir(), ExposedPorts: dc.ports()}
+	cconf := &container.Config{Cmd: cmd, Image: image, WorkingDir: dc.workingDir(),
+		ExposedPorts: dc.ports(), Env: dc.env(c)}
 	// ApplyContainerUser is a public hook in dgraphtest/hooks.go; the
 	// default is no-op. Downstream consumers that run dgraph as a
 	// non-root user inside the test container override it to set

--- a/systest/audit/docker-compose.yml
+++ b/systest/audit/docker-compose.yml
@@ -36,5 +36,6 @@ services:
         target: /audit_dir
     command:
       /gobin/dgraph  ${COVERAGE_OUTPUT} zero --telemetry "reports=false;" --raft="idx=1;"
-      --my=zero1:5080 --logtostderr -v=2 --bindall --audit "output=/audit_dir;"
+      --my=zero1:5080 --logtostderr -v=2 --bindall --audit "output=/audit_dir;" --security
+      "whitelist=0.0.0.0/0;"
 volumes: {}

--- a/systest/audit_encrypted/docker-compose.yml
+++ b/systest/audit_encrypted/docker-compose.yml
@@ -45,5 +45,5 @@ services:
     command:
       /gobin/dgraph  ${COVERAGE_OUTPUT} zero --telemetry "reports=false;" --raft="idx=1;"
       --my=zero1:5080 --logtostderr -v=2 --bindall --audit
-      "output=/audit_dir;encrypt-file=/dgraph-enc/enc-key"
+      "output=/audit_dir;encrypt-file=/dgraph-enc/enc-key" --security "whitelist=0.0.0.0/0;"
 volumes: {}

--- a/systest/backup/encryption/docker-compose.yml
+++ b/systest/backup/encryption/docker-compose.yml
@@ -108,7 +108,8 @@ services:
       /gobin/dgraph  ${COVERAGE_OUTPUT} zero --telemetry "reports=false;" --raft="idx=1;"
       --my=zero1:5080 --replicas=1 --logtostderr -v=2 --bindall --tls "ca-cert=/dgraph-tls/ca.crt;
       server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true;
-      client-cert=/dgraph-tls/client.zero1.crt; client-key=/dgraph-tls/client.zero1.key;"
+      client-cert=/dgraph-tls/client.zero1.crt; client-key=/dgraph-tls/client.zero1.key;" --security
+      "whitelist=0.0.0.0/0;"
   minio:
     image: minio/minio:latest
     env_file:

--- a/systest/backup/filesystem/docker-compose.yml
+++ b/systest/backup/filesystem/docker-compose.yml
@@ -105,5 +105,6 @@ services:
       /gobin/dgraph  ${COVERAGE_OUTPUT} zero --telemetry "reports=false;" --raft "idx=1;"
       --my=zero1:5080 --replicas=1 --logtostderr -v=2 --bindall --tls "ca-cert=/dgraph-tls/ca.crt;
       server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true;
-      client-cert=/dgraph-tls/client.zero1.crt; client-key=/dgraph-tls/client.zero1.key;"
+      client-cert=/dgraph-tls/client.zero1.crt; client-key=/dgraph-tls/client.zero1.key;" --security
+      "whitelist=0.0.0.0/0;"
 volumes: {}

--- a/systest/backup/minio-large/docker-compose.yml
+++ b/systest/backup/minio-large/docker-compose.yml
@@ -102,5 +102,6 @@ services:
       /gobin/dgraph  ${COVERAGE_OUTPUT} zero --telemetry "reports=false;" --raft "idx=1;"
       --my=zero1:5080 --replicas=1 --logtostderr -v=2 --bindall --tls "ca-cert=/dgraph-tls/ca.crt;
       server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true;
-      client-cert=/dgraph-tls/client.zero1.crt; client-key=/dgraph-tls/client.zero1.key;"
+      client-cert=/dgraph-tls/client.zero1.crt; client-key=/dgraph-tls/client.zero1.key;" --security
+      "whitelist=0.0.0.0/0;"
 volumes: {}

--- a/systest/backup/minio/docker-compose.yml
+++ b/systest/backup/minio/docker-compose.yml
@@ -98,7 +98,8 @@ services:
       /gobin/dgraph  ${COVERAGE_OUTPUT} zero --telemetry "reports=false;" --raft "idx=1;"
       --my=zero1:5080 --replicas=1 --logtostderr -v=2 --bindall --tls "ca-cert=/dgraph-tls/ca.crt;
       server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true;
-      client-cert=/dgraph-tls/client.zero1.crt; client-key=/dgraph-tls/client.zero1.key;"
+      client-cert=/dgraph-tls/client.zero1.crt; client-key=/dgraph-tls/client.zero1.key;" --security
+      "whitelist=0.0.0.0/0;"
   minio:
     image: minio/minio:${MINIO_IMAGE_ARCH:-RELEASE.2020-11-13T20-10-18Z}
     env_file:

--- a/systest/backup/nfs-backup/docker-compose.yml
+++ b/systest/backup/nfs-backup/docker-compose.yml
@@ -103,7 +103,8 @@ services:
         read_only: true
     command:
       /gobin/dgraph  ${COVERAGE_OUTPUT} zero --telemetry "reports=false;" --raft "idx=1;"
-      --my=zero1_backup_clust_ha:5080 --replicas=3 --logtostderr -v=2 --bindall
+      --my=zero1_backup_clust_ha:5080 --replicas=3 --logtostderr -v=2 --bindall --security
+      "whitelist=0.0.0.0/0;"
 
   zero2_backup_clust_ha:
     image: dgraph-nfs-client:local
@@ -310,7 +311,8 @@ services:
         read_only: true
     command:
       /gobin/dgraph  ${COVERAGE_OUTPUT} zero --telemetry "reports=false;" --raft "idx=1;"
-      --my=zero7_backup_clust_non_ha:5080 --replicas=1 --logtostderr -v=2 --bindall
+      --my=zero7_backup_clust_non_ha:5080 --replicas=1 --logtostderr -v=2 --bindall --security
+      "whitelist=0.0.0.0/0;"
 
   alpha7_backup_clust_non_ha:
     image: dgraph-nfs-client:local

--- a/systest/group-delete/docker-compose.yml
+++ b/systest/group-delete/docker-compose.yml
@@ -65,5 +65,5 @@ services:
         read_only: true
     command:
       /gobin/dgraph ${COVERAGE_OUTPUT} zero --telemetry "reports=false;" --raft="idx=1;"
-      --my=zero1:5080 --replicas=1 --logtostderr -v=2 --bindall
+      --my=zero1:5080 --replicas=1 --logtostderr -v=2 --bindall --security "whitelist=0.0.0.0/0;"
 volumes: {}

--- a/testutil/testaudit/docker-compose.yml
+++ b/testutil/testaudit/docker-compose.yml
@@ -45,5 +45,5 @@ services:
     command:
       /gobin/dgraph  ${COVERAGE_OUTPUT} zero --telemetry "reports=false;" --raft="idx=1;"
       --my=zero1:5080 --logtostderr -v=2 --bindall --audit
-      "output=/audit_dir;encrypt-file=/dgraph-enc/enc-key"
+      "output=/audit_dir;encrypt-file=/dgraph-enc/enc-key" --security "whitelist=0.0.0.0/0;"
 volumes: {}


### PR DESCRIPTION
This PR configures a security whitelist for Zero across the test harnesses, following the hardening of Zero's admin HTTP endpoints (c32f6041). Test clusters reach Zero's HTTP port from the Docker bridge network, not loopback, so requests to the guarded `/moveTablet` and `/removeNode` endpoints now come back `401` unless a whitelist is configured. `TestUniqueMultipleGroups` in `systest/integration2` was the first casualty.

## Changes

- `dgraphtest`: zero containers now start with `DGRAPH_ZERO_SECURITY=whitelist=0.0.0.0/0`, wired through a new `env()` method on the `dnode` interface. The whitelist is passed as an env var rather than a `--security` flag because upgrade tests launch older zero binaries, which would fail to start on an unrecognized flag but silently ignore the env var.
- Compose-based suites that call the guarded endpoints from the host (`systest/audit`, `systest/audit_encrypted`, `systest/group-delete`, `systest/backup/filesystem`, `systest/backup/minio`, `systest/backup/minio-large`, `systest/backup/encryption`, `systest/backup/nfs-backup`, `testutil/testaudit`): added `--security "whitelist=0.0.0.0/0;"` to the zero command, matching what the alphas in those files already use. These files pin local images, so the flag form is safe there. In `nfs-backup`, only the two zeros the test actually contacts (`zero1_backup_clust_ha`, `zero7_backup_clust_non_ha`) get the flag.
- `compose/compose.go`: zero services get the env var when `--whitelist` is passed to the generator, which supports arbitrary image tags.

The `tlstest/zero_https` suites are intentionally untouched: their HTTPS cases only hit `/health` and `/state` (which stay open when no security is configured), and the HTTP-against-HTTPS `/removeNode` case is rejected at the TLS layer before reaching the handler.

## Testing

- `TestUniqueMultipleGroups` fails on `main` with a `401` from `/moveTablet` and passes with this change (the tablet move actually succeeds).
- `TestBackupFilesystem` (the ci-dgraph-system-tests failure on this PR's earlier revision) hits the same `401` on its `/moveTablet` call; `systest/backup/filesystem` is covered now.
- `go test ./dgraph/cmd/zero/` (including the admin auth tests) passes.
- All edited compose files validate with `docker compose config`.
