### PR TITLE
fix(zero): size-aware predicate move timeout and rebalancer backoff

### DIFF
--- a/dgraph/cmd/zero/tablet.go
+++ b/dgraph/cmd/zero/tablet.go
@@ -22,8 +22,33 @@ import (
 )
 
 const (
-	predicateMoveTimeout = 120 * time.Minute
+	// predicateMoveTimeout is the minimum time a predicate move may run before Zero cancels it.
+	// moveTimeout extends it for tablets too large to transfer within it at minMoveRate.
+	predicateMoveTimeout = 2 * time.Hour
+
+	// minMoveRate is the assumed floor throughput of a predicate move. It converts tablet size
+	// into time when computing the move timeout, so that a large tablet is not cancelled by a
+	// wall-clock limit it could never meet. The rate is deliberately conservative: the receiving
+	// group applies the whole stream through serial Raft proposals, so sustained rates are low.
+	minMoveRate = 256 << 10 // bytes per second
+
+	// moveFailureMinElapsed separates real move failures from quick validation ones: only
+	// attempts that ran at least this long feed the rebalancer's backoff.
+	moveFailureMinElapsed = time.Minute
+
+	// moveBackoffBase and moveBackoffMax bound the cooldown during which the automatic
+	// rebalancer skips a tablet whose last move failed. The cooldown doubles per consecutive
+	// failure, and is never shorter than the failed attempt itself.
+	moveBackoffBase = time.Hour
+	moveBackoffMax  = 24 * time.Hour
 )
+
+// moveTimeout returns how long a move of tab may run before Zero cancels it: at least base,
+// extended for large tablets assuming they transfer no faster than minMoveRate.
+func moveTimeout(base time.Duration, tab *pb.Tablet) time.Duration {
+	size := max(tab.OnDiskBytes, tab.UncompressedBytes)
+	return max(base, time.Duration(size/minMoveRate)*time.Second)
+}
 
 /*
 Steps to move predicate p from g1 to g2.
@@ -112,22 +137,34 @@ func (s *Server) MoveTablet(ctx context.Context, req *pb.MoveTabletRequest) (*pb
 // movePredicate is the main entry point for move predicate logic. This Zero must remain the leader
 // for the entire duration of predicate move. If this Zero stops being the leader, the final
 // proposal of reassigning the tablet to the destination would fail automatically.
-func (s *Server) movePredicate(predicate string, srcGroup, dstGroup uint32) error {
+func (s *Server) movePredicate(predicate string, srcGroup, dstGroup uint32) (err error) {
 	s.moveOngoing <- struct{}{}
 	defer func() {
 		<-s.moveOngoing
 	}()
 
-	ctx, cancel := context.WithTimeout(context.Background(), predicateMoveTimeout)
-	defer cancel()
-
-	span := trace.SpanFromContext(ctx)
-	defer span.End()
-
 	// Ensure that reserved predicates cannot be moved.
 	if x.IsReservedPredicate(predicate) {
 		return errors.Errorf("Unable to move reserved predicate %s", predicate)
 	}
+	tab := s.ServingTablet(predicate)
+	if tab == nil {
+		return errors.Errorf("Tablet to be moved: [%v] is not being served", predicate)
+	}
+
+	// Feed the outcome of this attempt back to the rebalancer, so it stops re-picking a tablet
+	// whose moves keep failing.
+	start := time.Now()
+	defer func() {
+		s.recordMoveResult(predicate, time.Since(start), err)
+	}()
+
+	timeout := moveTimeout(predicateMoveTimeout, tab)
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	span := trace.SpanFromContext(ctx)
+	defer span.End()
 
 	// Ensure that I'm connected to the rest of the Zero group, and am the leader.
 	if _, err := s.latestMembershipState(ctx); err != nil {
@@ -136,13 +173,9 @@ func (s *Server) movePredicate(predicate string, srcGroup, dstGroup uint32) erro
 	if !s.Node.AmLeader() {
 		return errors.Errorf("I am not the Zero leader")
 	}
-	tab := s.ServingTablet(predicate)
-	if tab == nil {
-		return errors.Errorf("Tablet to be moved: [%v] is not being served", predicate)
-	}
 	msg := fmt.Sprintf("Going to move predicate: [%v], size: [ondisk: %v, uncompressed: %v]"+
-		" from group %d to %d\n", predicate, humanize.IBytes(uint64(tab.OnDiskBytes)),
-		humanize.IBytes(uint64(tab.UncompressedBytes)), srcGroup, dstGroup)
+		" from group %d to %d, timeout: %v\n", predicate, humanize.IBytes(uint64(tab.OnDiskBytes)),
+		humanize.IBytes(uint64(tab.UncompressedBytes)), srcGroup, dstGroup, timeout)
 	glog.Info(msg)
 	span.SetAttributes(attribute.String("tablet", predicate))
 	span.SetStatus(1, msg)
@@ -270,6 +303,11 @@ func (s *Server) chooseTablet() (predicate string, srcGroup uint32, dstGroup uin
 			if x.IsReservedPredicate(tab.Predicate) {
 				continue
 			}
+			// Skip tablets whose recent moves failed; retrying right away would repeat hours of
+			// streaming and commit-blocking for the same outcome.
+			if s.skipMove(tab.Predicate) {
+				continue
+			}
 
 			// Finds a tablet as big a possible such that on moving it dstGroup's size is
 			// less than or equal to srcGroup.
@@ -283,4 +321,49 @@ func (s *Server) chooseTablet() (predicate string, srcGroup uint32, dstGroup uin
 		}
 	}
 	return
+}
+
+// tabletBackoff records the automatic rebalancer's backoff state for one tablet.
+type tabletBackoff struct {
+	failures int
+	until    time.Time
+}
+
+// moveCooldown returns how long the automatic rebalancer should skip a tablet after its
+// failures-th consecutive move failure, where elapsed is how long the failed attempt ran.
+func moveCooldown(failures int, elapsed time.Duration) time.Duration {
+	cooldown := moveBackoffMax
+	if shift := failures - 1; shift >= 0 && shift < 6 {
+		cooldown = min(moveBackoffBase<<shift, moveBackoffMax)
+	}
+	return max(cooldown, elapsed)
+}
+
+// recordMoveResult updates the rebalancer's backoff state for pred after a move attempt that
+// ran for elapsed. A successful move clears the state. A failed attempt that did real work
+// (ran at least moveFailureMinElapsed) pushes the next automatic attempt out by moveCooldown.
+// Only chooseTablet consults this state, so manual moves via MoveTablet are never held back.
+func (s *Server) recordMoveResult(pred string, elapsed time.Duration, err error) {
+	if err == nil {
+		s.moveBackoff.Delete(pred)
+		return
+	}
+	if elapsed < moveFailureMinElapsed {
+		return
+	}
+	failures := 1
+	if prev, ok := s.moveBackoff.Load(pred); ok {
+		failures = prev.(tabletBackoff).failures + 1
+	}
+	cooldown := moveCooldown(failures, elapsed)
+	s.moveBackoff.Store(pred, tabletBackoff{failures: failures, until: time.Now().Add(cooldown)})
+	glog.Infof("Move of tablet [%v] failed after %v (failure #%d). Skipping automatic"+
+		" rebalancing of this tablet for %v", pred, elapsed.Round(time.Second), failures, cooldown)
+}
+
+// skipMove reports whether the automatic rebalancer should currently leave pred alone because
+// its last move attempt failed.
+func (s *Server) skipMove(pred string) bool {
+	entry, ok := s.moveBackoff.Load(pred)
+	return ok && time.Now().Before(entry.(tabletBackoff).until)
 }

--- a/dgraph/cmd/zero/tablet_test.go
+++ b/dgraph/cmd/zero/tablet_test.go
@@ -1,0 +1,68 @@
+/*
+ * SPDX-FileCopyrightText: © 2017-2026 Istari Digital, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package zero
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dgraph-io/dgraph/v25/protos/pb"
+)
+
+func TestMoveTimeout(t *testing.T) {
+	base := predicateMoveTimeout
+
+	// Tablets small enough to move within the base timeout keep it.
+	small := &pb.Tablet{OnDiskBytes: 1 << 30}
+	require.Equal(t, base, moveTimeout(base, small))
+	require.Equal(t, base, moveTimeout(base, &pb.Tablet{}))
+
+	// Large tablets get size/minMoveRate.
+	big := &pb.Tablet{OnDiskBytes: 20 << 30}
+	require.Equal(t, time.Duration((20<<30)/minMoveRate)*time.Second, moveTimeout(base, big))
+
+	// The larger of on-disk and uncompressed size drives the scaling.
+	inflated := &pb.Tablet{OnDiskBytes: 1 << 30, UncompressedBytes: 64 << 30}
+	require.Equal(t, time.Duration((64<<30)/minMoveRate)*time.Second, moveTimeout(base, inflated))
+}
+
+func TestMoveCooldown(t *testing.T) {
+	require.Equal(t, time.Hour, moveCooldown(1, time.Minute))
+	require.Equal(t, 2*time.Hour, moveCooldown(2, time.Minute))
+	require.Equal(t, 16*time.Hour, moveCooldown(5, time.Minute))
+	require.Equal(t, moveBackoffMax, moveCooldown(6, time.Minute))
+	// Large failure counts must not overflow the doubling.
+	require.Equal(t, moveBackoffMax, moveCooldown(100, time.Minute))
+	// An attempt that outlasted the doubling cooldown sets the floor.
+	require.Equal(t, 30*time.Hour, moveCooldown(1, 30*time.Hour))
+}
+
+func TestMoveBackoff(t *testing.T) {
+	s := &Server{moveBackoff: new(sync.Map)}
+	pred := "name"
+	errMove := errors.New("context deadline exceeded")
+
+	require.False(t, s.skipMove(pred))
+
+	// Quick validation failures are cheap to retry and set no backoff.
+	s.recordMoveResult(pred, 5*time.Second, errMove)
+	require.False(t, s.skipMove(pred))
+
+	// A failure that did real work does.
+	s.recordMoveResult(pred, 2*time.Hour, errMove)
+	require.True(t, s.skipMove(pred))
+
+	// Other tablets are unaffected.
+	require.False(t, s.skipMove("other"))
+
+	// A successful move clears the backoff.
+	s.recordMoveResult(pred, time.Minute, nil)
+	require.False(t, s.skipMove(pred))
+}

--- a/dgraph/cmd/zero/zero.go
+++ b/dgraph/cmd/zero/zero.go
@@ -61,6 +61,9 @@ type Server struct {
 
 	moveOngoing    chan struct{}
 	blockCommitsOn *sync.Map
+	// moveBackoff tracks tablets whose most recent move failed, so the automatic rebalancer
+	// does not immediately re-pick them. Maps predicate -> tabletBackoff.
+	moveBackoff *sync.Map
 
 	checkpointPerGroup map[uint32]uint64
 	// embedding the pb.UnimplementedZeroServer struct to ensure forward compatibility of the server.
@@ -88,6 +91,7 @@ func (s *Server) Init() {
 	s.closer = z.NewCloser(2) // grpc and http
 	s.blockCommitsOn = new(sync.Map)
 	s.moveOngoing = make(chan struct{}, 1)
+	s.moveBackoff = new(sync.Map)
 	s.checkpointPerGroup = make(map[uint32]uint64)
 	if opts.limiterConfig.UidLeaseLimit > 0 {
 		// rate limiting is not enabled when lease limit is set to zero.

--- a/systest/predicate-move/README.md
+++ b/systest/predicate-move/README.md
@@ -31,10 +31,11 @@ Go default of 10m kills the test.
 
 Knobs and requirements:
 
-- `MOVE_TEST_GB` (default 8, minimum 3): value data loaded before the move. Bigger values stretch
-  every phase; the failure scenario needs the move to outlast the 75s kill point, so increase this
-  if the test reports the move finished too fast.
-- Disk: budget roughly 5x `MOVE_TEST_GB` inside the Docker Desktop VM (source + destination copies,
-  Raft WAL, and compaction headroom).
+- `MOVE_TEST_GB` (default 8, minimum 3): value data loaded before the move. This is a floor, not the
+  final size: the test measures the host's ingest rate and tops up automatically until the estimated
+  move duration outlasts the 75s kill point (roughly 17 GiB on a fast laptop NVMe, less on slower
+  disks).
+- Disk: budget roughly 5x the final loaded size inside the Docker Desktop VM (source + destination
+  copies, Raft WAL, and compaction headroom); on a fast host assume ~80-100 GB.
 - Time: about 30 minutes at the default size on an Apple Silicon laptop, dominated by the load and
   the tablet-size reporting interval (Alphas recompute tablet sizes on a periodic ticker).

--- a/systest/predicate-move/README.md
+++ b/systest/predicate-move/README.md
@@ -22,7 +22,8 @@ tablets no larger than half the group size difference, which the payload tablet 
 ## Running
 
 ```bash
-make install   # builds the Linux binary dgraphtest mounts into containers (required on macOS)
+make install       # builds the binary dgraphtest mounts into containers
+make image-local   # dgraphtest boots containers from dgraph/dgraph:local; build it if absent
 go test -v -timeout=8h --tags=largemove -run TestLargePredicateMove ./systest/predicate-move/
 ```
 

--- a/systest/predicate-move/README.md
+++ b/systest/predicate-move/README.md
@@ -1,0 +1,40 @@
+# Large predicate move test
+
+A long-running integration test for the size-aware predicate move timeout and rebalancer backoff
+(dgraph-io/dgraph#9792, fixes #9784). It is excluded from CI via the `largemove` build tag, which no
+workflow compiles: the test loads several GiB of data and can run from tens of minutes to hours
+depending on the data size and host.
+
+## What it does
+
+1. Brings up a 1-zero, 2-alpha cluster (one group per alpha) via `dgraphtest` and loads
+   `MOVE_TEST_GB` GiB (default 8) of incompressible 64KiB string values into one predicate.
+2. Waits until Zero reports the tablet size, then triggers a move and kills the destination Alpha
+   mid-stream. Asserts the move fails and Zero records the rebalancer backoff ("Skipping automatic
+   rebalancing of this tablet").
+3. Restarts the destination and retries. Asserts the move completes, every move announcement in
+   Zero's log carried a size-scaled timeout above the 2h floor, and the row count is intact on the
+   destination group.
+
+The auto-rebalancer cannot interfere: with a single dominant tablet, `chooseTablet` only picks
+tablets no larger than half the group size difference, which the payload tablet always exceeds.
+
+## Running
+
+```bash
+make install   # builds the Linux binary dgraphtest mounts into containers (required on macOS)
+go test -v -timeout=8h --tags=largemove -run TestLargePredicateMove ./systest/predicate-move/
+```
+
+Do not run this through `make test TAGS=largemove`: the Makefile does not pass a `-timeout`, so the
+Go default of 10m kills the test.
+
+Knobs and requirements:
+
+- `MOVE_TEST_GB` (default 8, minimum 3): value data loaded before the move. Bigger values stretch
+  every phase; the failure scenario needs the move to outlast the 75s kill point, so increase this
+  if the test reports the move finished too fast.
+- Disk: budget roughly 5x `MOVE_TEST_GB` inside the Docker Desktop VM (source + destination copies,
+  Raft WAL, and compaction headroom).
+- Time: about 30 minutes at the default size on an Apple Silicon laptop, dominated by the load and
+  the tablet-size reporting interval (Alphas recompute tablet sizes on a periodic ticker).

--- a/systest/predicate-move/predicate_move_test.go
+++ b/systest/predicate-move/predicate_move_test.go
@@ -92,7 +92,22 @@ func TestLargePredicateMove(t *testing.T) {
 	start := time.Now()
 	t.Logf("loading %d GiB into predicate %q", gib, predicate)
 	triples := loadPayload(t, gc, targetBytes)
-	t.Logf("loaded %d triples (%d GiB) in %v", triples, gib, time.Since(start).Round(time.Second))
+	loadDur := time.Since(start)
+	t.Logf("loaded %d triples (%d GiB) in %v", triples, gib, loadDur.Round(time.Second))
+
+	// The induced failure below needs the move stream to outlast the kill point. A move cannot
+	// run faster than ingest on the same host (it re-reads, rolls up, streams, and re-applies
+	// every byte through the destination's Raft), so requiring bytes/ingestRate >= 2*killAfter
+	// guarantees the kill lands mid-stream. Top up the data if the host is too fast for the
+	// requested size.
+	loadRate := float64(targetBytes) / loadDur.Seconds()
+	if requiredBytes := int64(loadRate * 2 * killAfter.Seconds()); requiredBytes > targetBytes {
+		extra := requiredBytes - targetBytes
+		t.Logf("host ingests %.0f MiB/s; topping up %.1f GiB so the move outlasts the %v kill point",
+			loadRate/(1<<20), float64(extra)/(1<<30), killAfter)
+		triples += loadPayload(t, gc, extra)
+		targetBytes = requiredBytes
+	}
 
 	// Wait for Zero to learn the tablet size. Alphas recompute tablet sizes on a periodic
 	// ticker, so this can take several minutes after the load finishes.
@@ -119,8 +134,8 @@ func TestLargePredicateMove(t *testing.T) {
 	go func() { moveErrCh <- hc.MoveTablet(predicate, dstGroup) }()
 	select {
 	case err := <-moveErrCh:
-		t.Fatalf("move finished before the %v kill point (err=%v); this host moves data too fast"+
-			" for the failure scenario, increase MOVE_TEST_GB", killAfter, err)
+		t.Fatalf("move finished before the %v kill point (err=%v); the move ran faster than the"+
+			" measured ingest rate predicted, increase MOVE_TEST_GB", killAfter, err)
 	case <-time.After(killAfter):
 	}
 	t.Logf("killing destination alpha%d mid-move", dstAlpha)

--- a/systest/predicate-move/predicate_move_test.go
+++ b/systest/predicate-move/predicate_move_test.go
@@ -1,0 +1,337 @@
+//go:build largemove
+
+/*
+ * SPDX-FileCopyrightText: © 2017-2026 Istari Digital, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Long-running, manually-invoked integration test for large predicate moves. It is deliberately
+// excluded from CI via the `largemove` build tag: it loads several GiB of data and can run for a
+// long time. See README.md in this directory for how to run it.
+package main
+
+import (
+	crand "crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/encoding/protojson"
+
+	"github.com/dgraph-io/dgo/v250/protos/api"
+	"github.com/dgraph-io/dgraph/v25/dgraphapi"
+	"github.com/dgraph-io/dgraph/v25/dgraphtest"
+	"github.com/dgraph-io/dgraph/v25/protos/pb"
+)
+
+const (
+	predicate = "payload"
+
+	// rawValueSize bytes of random data per triple, base64-encoded to valueSize on the wire.
+	// 48KiB is divisible by 3, so the encoding is exactly 64KiB with no padding.
+	rawValueSize = 48 << 10
+	valueSize    = 64 << 10
+	batchSize    = 32 // triples per mutation, ~2MiB per txn
+	loaders      = 8
+
+	// minSizeForScaling is the tablet size Zero must report before the move is triggered.
+	// Above ~1.8GiB the computed move timeout exceeds the 2h floor; 3GiB gives clear margin
+	// (3GiB / 256KiB-per-second is about 3.4h).
+	minSizeForScaling = 3 << 30
+
+	// killAfter must exceed Zero's moveFailureMinElapsed (1m) so the induced failure registers
+	// in the rebalancer backoff, and must be shorter than the move itself so the kill lands
+	// mid-stream.
+	killAfter = 75 * time.Second
+)
+
+// TestLargePredicateMove exercises the size-aware move timeout and the rebalancer backoff from
+// dgraph-io/dgraph#9792 against a real two-group cluster:
+//
+//  1. Load MOVE_TEST_GB (default 8) GiB of incompressible data into one predicate and wait until
+//     Zero reports the tablet size.
+//  2. Trigger a move and kill the destination Alpha mid-stream. The move must fail, and Zero must
+//     record the rebalancer backoff for the tablet.
+//  3. Restart the destination and retry. The move must complete, both move announcements must
+//     carry a size-scaled timeout (> 2h), and the data must be intact on the destination group.
+func TestLargePredicateMove(t *testing.T) {
+	gib := int64(8)
+	if v := os.Getenv("MOVE_TEST_GB"); v != "" {
+		n, err := strconv.ParseInt(v, 10, 64)
+		require.NoError(t, err, "MOVE_TEST_GB must be an integer")
+		require.Greater(t, n, int64(2), "MOVE_TEST_GB must be at least 3 for the timeout to scale")
+		gib = n
+	}
+	targetBytes := gib << 30
+
+	conf := dgraphtest.NewClusterConfig().WithNumAlphas(2).WithNumZeros(1).WithReplicas(1)
+	c, err := dgraphtest.NewLocalCluster(conf)
+	require.NoError(t, err)
+	defer func() { c.Cleanup(t.Failed()) }()
+	require.NoError(t, c.Start())
+
+	hc, err := c.HTTPClient()
+	require.NoError(t, err)
+	gc, cleanup, err := c.Client()
+	require.NoError(t, err)
+	defer cleanup()
+
+	require.NoError(t, gc.DropAll())
+	require.NoError(t, gc.SetupSchema(predicate+`: string .`))
+
+	// Phase 1: load data.
+	start := time.Now()
+	t.Logf("loading %d GiB into predicate %q", gib, predicate)
+	triples := loadPayload(t, gc, targetBytes)
+	t.Logf("loaded %d triples (%d GiB) in %v", triples, gib, time.Since(start).Round(time.Second))
+
+	// Wait for Zero to learn the tablet size. Alphas recompute tablet sizes on a periodic
+	// ticker, so this can take several minutes after the load finishes.
+	tab, srcGroup := waitForTabletSize(t, hc, minSizeForScaling, 20*time.Minute)
+	t.Logf("Zero reports tablet size: ondisk=%d uncompressed=%d, served by group %d",
+		tab.OnDiskBytes, tab.UncompressedBytes, srcGroup)
+
+	var state pb.MembershipState
+	stateBytes, err := hc.GetAlphaState()
+	require.NoError(t, err)
+	require.NoError(t, protojson.Unmarshal(stateBytes, &state))
+	dstGroup := otherGroup(t, &state, srcGroup)
+	srcAlpha := alphaInGroup(t, &state, srcGroup)
+	dstAlpha := alphaInGroup(t, &state, dstGroup)
+	t.Logf("moving group %d (alpha%d) -> group %d (alpha%d)", srcGroup, srcAlpha, dstGroup, dstAlpha)
+
+	wantCount := countPayload(t, c, srcAlpha)
+	require.Equal(t, triples, wantCount, "loaded triple count must be queryable before the move")
+
+	// Phase 2: induced failure. Kill the destination Alpha mid-stream; the move must fail and
+	// Zero must record the rebalancer backoff. The kill lands after moveFailureMinElapsed (1m)
+	// so the failure is treated as expensive.
+	moveErrCh := make(chan error, 1)
+	go func() { moveErrCh <- hc.MoveTablet(predicate, dstGroup) }()
+	select {
+	case err := <-moveErrCh:
+		t.Fatalf("move finished before the %v kill point (err=%v); this host moves data too fast"+
+			" for the failure scenario, increase MOVE_TEST_GB", killAfter, err)
+	case <-time.After(killAfter):
+	}
+	t.Logf("killing destination alpha%d mid-move", dstAlpha)
+	require.NoError(t, c.KillAlpha(dstAlpha))
+	select {
+	case err := <-moveErrCh:
+		require.Error(t, err, "move must fail after the destination died")
+		t.Logf("move failed as expected: %v", err)
+	case <-time.After(10 * time.Minute):
+		t.Fatal("move did not return within 10m of the destination dying")
+	}
+	require.NoError(t,
+		c.WaitForAnyZeroLog("Skipping automatic rebalancing of this tablet", 2*time.Minute, 5*time.Second),
+		"Zero must record the rebalancer backoff after an expensive failed move")
+
+	// The tablet must still be served by the source group, with all data intact.
+	tab, group := findTablet(t, hc)
+	require.Equal(t, srcGroup, group, "failed move must leave the tablet on the source group")
+	require.Equal(t, wantCount, countPayload(t, c, srcAlpha), "data must be intact after a failed move")
+
+	// Phase 3: recovery. Restart the destination and retry until the move goes through. Early
+	// retries may fail while Zero reconnects to the restarted group; those quick failures are
+	// expected and do not feed the backoff.
+	require.NoError(t, c.StartAlpha(dstAlpha))
+	require.NoError(t, c.HealthCheck(false))
+	start = time.Now()
+	deadline := time.Now().Add(90 * time.Minute)
+	for {
+		err = hc.MoveTablet(predicate, dstGroup)
+		if err == nil {
+			break
+		}
+		require.False(t, time.Now().After(deadline), "move did not succeed within 90m, last error: %v", err)
+		t.Logf("retrying move: %v", err)
+		time.Sleep(15 * time.Second)
+	}
+	t.Logf("move completed in %v", time.Since(start).Round(time.Second))
+
+	flipDeadline := time.Now().Add(2 * time.Minute)
+	for {
+		_, group := findTablet(t, hc)
+		if group == dstGroup {
+			break
+		}
+		require.False(t, time.Now().After(flipDeadline),
+			"tablet must be served by group %d after the move, still on group %d", dstGroup, group)
+		time.Sleep(5 * time.Second)
+	}
+	require.Equal(t, wantCount, countPayload(t, c, dstAlpha), "data must be intact on the destination group")
+
+	// Both move attempts ran after Zero learned the tablet size, so both announcements must
+	// carry a size-scaled timeout above the 2h floor.
+	logs, err := c.GetZeroLogs(0)
+	require.NoError(t, err)
+	moveLine := regexp.MustCompile(`Going to move predicate: \[(?:0-)?` + predicate + `\][^\n]*timeout: (\S+)`)
+	matches := moveLine.FindAllStringSubmatch(logs, -1)
+	require.GreaterOrEqual(t, len(matches), 2, "expected move announcements for both attempts in Zero logs")
+	for _, m := range matches {
+		d, err := time.ParseDuration(m[1])
+		require.NoError(t, err, "move announcement must include a parseable timeout: %q", m[0])
+		require.Greater(t, d, 2*time.Hour, "announced move timeout must be size-scaled above the 2h floor")
+	}
+	t.Logf("all %d move announcements carried a size-scaled timeout (last: %s)",
+		len(matches), matches[len(matches)-1][1])
+}
+
+// loadPayload writes incompressible base64 values under the payload predicate until targetBytes
+// of value data has been committed, and returns the number of triples written.
+func loadPayload(t *testing.T, gc *dgraphapi.GrpcClient, targetBytes int64) int64 {
+	var loaded, triples atomic.Int64
+	errCh := make(chan error, loaders)
+	done := make(chan struct{})
+	var wg sync.WaitGroup
+
+	go func() {
+		tick := time.NewTicker(30 * time.Second)
+		defer tick.Stop()
+		start := time.Now()
+		for {
+			select {
+			case <-done:
+				return
+			case <-tick.C:
+				n := loaded.Load()
+				rate := float64(n) / (1 << 20) / time.Since(start).Seconds()
+				t.Logf("loaded %.1f GiB of %.1f GiB (%.0f MiB/s)",
+					float64(n)/(1<<30), float64(targetBytes)/(1<<30), rate)
+			}
+		}
+	}()
+
+	for w := 0; w < loaders; w++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			raw := make([]byte, rawValueSize)
+			for loaded.Load() < targetBytes {
+				var b strings.Builder
+				b.Grow(batchSize * (valueSize + 64))
+				for i := 0; i < batchSize; i++ {
+					if _, err := crand.Read(raw); err != nil {
+						errCh <- err
+						return
+					}
+					fmt.Fprintf(&b, "_:b%d <%s> \"%s\" .\n",
+						i, predicate, base64.StdEncoding.EncodeToString(raw))
+				}
+				if _, err := gc.Mutate(&api.Mutation{
+					SetNquads: []byte(b.String()),
+					CommitNow: true,
+				}); err != nil {
+					errCh <- err
+					return
+				}
+				loaded.Add(int64(batchSize * valueSize))
+				triples.Add(batchSize)
+			}
+		}()
+	}
+	wg.Wait()
+	close(done)
+	select {
+	case err := <-errCh:
+		require.NoError(t, err, "loader failed")
+	default:
+	}
+	return triples.Load()
+}
+
+// findTablet returns the payload tablet and the group currently serving it, from the membership
+// state as seen through an Alpha.
+func findTablet(t *testing.T, hc *dgraphapi.HTTPClient) (*pb.Tablet, uint32) {
+	stateBytes, err := hc.GetAlphaState()
+	require.NoError(t, err)
+	var state pb.MembershipState
+	require.NoError(t, protojson.Unmarshal(stateBytes, &state))
+	for gid, group := range state.Groups {
+		for name, tab := range group.Tablets {
+			if name == predicate || name == "0-"+predicate {
+				return tab, gid
+			}
+		}
+	}
+	t.Fatalf("tablet %q not found in membership state", predicate)
+	return nil, 0
+}
+
+// waitForTabletSize polls the membership state until Zero reports the payload tablet at or above
+// minBytes (using the larger of on-disk and uncompressed size, mirroring Zero's moveTimeout).
+func waitForTabletSize(t *testing.T, hc *dgraphapi.HTTPClient, minBytes int64,
+	timeout time.Duration) (*pb.Tablet, uint32) {
+	deadline := time.Now().Add(timeout)
+	for {
+		tab, gid := findTablet(t, hc)
+		size := max(tab.OnDiskBytes, tab.UncompressedBytes)
+		if size >= minBytes {
+			return tab, gid
+		}
+		require.False(t, time.Now().After(deadline),
+			"Zero did not report tablet size >= %d within %v (last: ondisk=%d uncompressed=%d);"+
+				" tablet sizes are recomputed periodically, or the data may be too small",
+			minBytes, timeout, tab.OnDiskBytes, tab.UncompressedBytes)
+		t.Logf("waiting for Zero to report tablet size (ondisk=%d uncompressed=%d, want >= %d)",
+			tab.OnDiskBytes, tab.UncompressedBytes, minBytes)
+		time.Sleep(30 * time.Second)
+	}
+}
+
+// otherGroup returns a group id different from gid.
+func otherGroup(t *testing.T, state *pb.MembershipState, gid uint32) uint32 {
+	for g := range state.Groups {
+		if g != gid && g > 0 {
+			return g
+		}
+	}
+	t.Fatalf("no group other than %d in membership state", gid)
+	return 0
+}
+
+// alphaInGroup returns the container index of an Alpha serving the given group, parsed from the
+// member address (e.g. "alpha1:7080").
+func alphaInGroup(t *testing.T, state *pb.MembershipState, gid uint32) int {
+	group, ok := state.Groups[gid]
+	require.True(t, ok, "group %d not in membership state", gid)
+	for _, member := range group.Members {
+		addr := strings.TrimPrefix(member.Addr, "alpha")
+		if addr == member.Addr {
+			continue
+		}
+		if n, err := strconv.Atoi(strings.Split(addr, ":")[0]); err == nil && n >= 0 {
+			return n
+		}
+	}
+	t.Fatalf("no alpha member found for group %d", gid)
+	return -1
+}
+
+// countPayload counts nodes carrying the payload predicate, queried through the given Alpha.
+func countPayload(t *testing.T, c *dgraphtest.LocalCluster, alphaIdx int) int64 {
+	gc, cleanup, err := c.AlphaClient(alphaIdx)
+	require.NoError(t, err)
+	defer cleanup()
+
+	resp, err := gc.Query(`{ q(func: has(` + predicate + `)) { count(uid) } }`)
+	require.NoError(t, err)
+	var out struct {
+		Q []struct {
+			Count int64 `json:"count"`
+		} `json:"q"`
+	}
+	require.NoError(t, json.Unmarshal(resp.Json, &out))
+	require.Len(t, out.Q, 1)
+	return out.Q[0].Count
+}

--- a/systest/predicate-move/predicate_move_test.go
+++ b/systest/predicate-move/predicate_move_test.go
@@ -160,7 +160,20 @@ func TestLargePredicateMove(t *testing.T) {
 	// retries may fail while Zero reconnects to the restarted group; those quick failures are
 	// expected and do not feed the backoff.
 	require.NoError(t, c.StartAlpha(dstAlpha))
-	require.NoError(t, c.HealthCheck(false))
+	// The killed Alpha replays its WAL and badger state on restart (it absorbed several GiB
+	// mid-move before dying), and re-establishes cluster connections; health can take minutes
+	// to come back. Poll instead of asserting once.
+	var healthErr error
+	for deadline := time.Now().Add(10 * time.Minute); ; {
+		if healthErr = c.HealthCheck(false); healthErr == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			break
+		}
+		time.Sleep(10 * time.Second)
+	}
+	require.NoError(t, healthErr, "cluster did not become healthy within 10m of restarting alpha%d", dstAlpha)
 	start = time.Now()
 	deadline := time.Now().Add(90 * time.Minute)
 	for {

--- a/systest/predicate-move/predicate_move_test.go
+++ b/systest/predicate-move/predicate_move_test.go
@@ -151,14 +151,11 @@ func TestLargePredicateMove(t *testing.T) {
 		c.WaitForAnyZeroLog("Skipping automatic rebalancing of this tablet", 2*time.Minute, 5*time.Second),
 		"Zero must record the rebalancer backoff after an expensive failed move")
 
-	// The tablet must still be served by the source group, with all data intact.
-	tab, group := findTablet(t, hc)
-	require.Equal(t, srcGroup, group, "failed move must leave the tablet on the source group")
-	require.Equal(t, wantCount, countPayload(t, c, srcAlpha), "data must be intact after a failed move")
-
 	// Phase 3: recovery. Restart the destination and retry until the move goes through. Early
 	// retries may fail while Zero reconnects to the restarted group; those quick failures are
-	// expected and do not feed the backoff.
+	// expected and do not feed the backoff. State assertions about the failed move run after
+	// health returns: the killed alpha may be the very one serving the cluster's HTTP client,
+	// so poking /state during the outage would test our luck, not the move.
 	require.NoError(t, c.StartAlpha(dstAlpha))
 	// The killed Alpha replays its WAL and badger state on restart (it absorbed several GiB
 	// mid-move before dying), and re-establishes cluster connections; health can take minutes
@@ -174,6 +171,11 @@ func TestLargePredicateMove(t *testing.T) {
 		time.Sleep(10 * time.Second)
 	}
 	require.NoError(t, healthErr, "cluster did not become healthy within 10m of restarting alpha%d", dstAlpha)
+
+	// The failed move must have left the tablet on the source group, with all data intact.
+	_, group := findTablet(t, hc)
+	require.Equal(t, srcGroup, group, "failed move must leave the tablet on the source group")
+	require.Equal(t, wantCount, countPayload(t, c, srcAlpha), "data must be intact after a failed move")
 	start = time.Now()
 	deadline := time.Now().Add(90 * time.Minute)
 	for {


### PR DESCRIPTION
## Summary

Zero cancels every predicate move at a hardcoded 120 minutes (`predicateMoveTimeout` in dgraph/cmd/zero/tablet.go), so moves of large tablets can never complete. The report in #9784 is a 20GB predicate that needed about 16 hours. This constant has been raised once before for the same reason, from 20 minutes to 2 hours in #6388, so any fixed wall-clock value is eventually wrong for someone's data size.

The failure mode is worse than a cancelled move. While a move runs, Zero aborts every commit on the predicate (`blockTablet`, enforced in oracle.go). On timeout, all streamed work is discarded, and the auto-rebalancer deterministically re-picks the same largest tablet every `--rebalance_interval` (default 8m). A cluster with one oversized predicate ends up in a permanent loop: two hours of write aborts and streaming, cancel, discard, repeat.

## Changes

- Scale the move timeout with tablet size. `moveTimeout()` grants at least size / 256 KiB-per-second, using the larger of on-disk and uncompressed bytes, with the previous 2h constant as the floor. Tablets under ~1.8GiB behave exactly as before; the 20GB tablet from #9784 gets ~23h.
- Back off after a failed move. A failure that ran at least a minute puts the tablet on a cooldown that doubles per consecutive failure (1h up to 24h) and is never shorter than the failed attempt itself. `chooseTablet` skips tablets on cooldown, a successful move clears the state, and manual moves via `/moveTablet` bypass the backoff.
- Log the computed timeout in the move announcement line so operators can see the budget each move was given.

A configurable flag was considered and dropped. A floor-style flag reads ambiguously against a "timeout" name, and a cap-style flag recreates the original bug; the size-derived value needs no configuration.

## Why 256 KiB/s

The receive path applies the whole stream through serial 32MB Raft proposals (`batchAndProposeKeyValues` in worker/predicate_move.go): each chunk is replicated to quorum, written to the Raft WAL, and fully applied before the next is proposed. Sustained rates in the field are therefore low; the #9784 report works out to ~0.35 MB/s on-disk. The floor rate is deliberately conservative. The throughput problem itself is out of scope here and tracked in #9790 (pipeline the receive path) and #9791 (two-phase move to shrink the commit-abort window).

## Testing

- New unit tests for the timeout computation and backoff bookkeeping in dgraph/cmd/zero/tablet_test.go (`TestMoveTimeout`, `TestMoveCooldown`, `TestMoveBackoff`).
- New end-to-end test: `TestLargePredicateMove` in systest/predicate-move runs the full scenario against a real two-group cluster. It loads several GiB of incompressible data (self-calibrating the size to the host's ingest rate so the move reliably outlasts the kill point), kills the destination Alpha mid-stream, asserts the failed move triggers the rebalancer backoff and leaves the source group intact, then restarts the Alpha, retries, and asserts the move completes with both announcements carrying the size-scaled timeout. It sits behind the `largemove` build tag, which no CI workflow compiles; run it manually per the package README (a run loads GiBs of data and takes 15+ minutes).
- Verified on GCE (c3-standard-8, Ubuntu 24.04, pd-ssd): PASS in 16m at the default MOVE_TEST_GB=8. Zero announced `timeout: 9h11m59s` for the 8.68GB tablet on both attempts, the mid-stream kill produced the expected failure plus the "Skipping automatic rebalancing" backoff line, and the retry completed with all 131,296 triples intact on the destination. Observed move throughput was ~19 MiB/s against 42-68 MiB/s raw ingest even with single-replica groups, which is the receive-path bottleneck tracked in #9790.
- `go build`, gofmt, and trunk pass.
- Existing move coverage (`systest/group-delete` TestNodes, `systest/integration2` TestUniqueMultipleGroups) moves small tablets, so the 2h floor applies and behavior there is unchanged.

Fixes #9784

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dgraph-io/codesmith/dgraph/pr/9792"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787764968&installation_model_id=8575&pr_number=9792&repository=dgraph-io%2Fdgraph&return_to=https%3A%2F%2Fgithub.com%2Fdgraph-io%2Fdgraph%2Fpull%2F9792&signature=e0c0612e5b196baf0194fe9aa23f39c51e3cde8a3eb1dbb9af389d3dfbcd54eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
