### PR TITLE
chore: upgrade Go to 1.26.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/dgraph-io/dgraph/v25
 
-go 1.26.4
+go 1.26.5
 
 require (
 	contrib.go.opencensus.io/exporter/prometheus v0.4.2


### PR DESCRIPTION
## Description

This PR updates the `go` directive in `go.mod` from 1.26.4 to 1.26.5 to pick up the go1.26.5 stdlib security fixes. The relevant ones for us:

- [GO-2026-5856](https://pkg.go.dev/vuln/GO-2026-5856): Encrypted Client Hello privacy leak in `crypto/tls`. govulncheck reports the vulnerable symbols as **reachable** from our gRPC server (`worker.RunServer`), S3 backup reads, and the TLS log writer.
- [GO-2026-4970](https://pkg.go.dev/vuln/GO-2026-4970): root escape via symlink plus trailing slash in `os`. Package-level finding only; govulncheck does not report the vulnerable symbols as reachable from our code.

No workflow changes are needed: all CI jobs resolve the toolchain from `go.mod` via `setup-go`'s `go-version-file`, and the release Dockerfile picks up 1.26.5 through Go's toolchain auto-download. Verified the build locally with the 1.26.5 toolchain.