### PR TITLE
fix(posting): don't serve calculatedUids to reads below their compute ts

### DIFF
--- a/posting/list.go
+++ b/posting/list.go
@@ -1745,11 +1745,20 @@ func (l *List) calculateUids() error {
 	return nil
 }
 
-func (l *List) canUseCalculatedUids() bool {
+// canUseCalculatedUids reports whether calculatedUids can serve a read at readTs. The slice is
+// computed at committedUidsTime, so it reflects every commit up to that timestamp; serving it
+// to an older readTs would leak later commits into an earlier snapshot (issue #9795). When the
+// mutable layer has no committed entries (committedUidsTime == math.MaxUint64), the uids come
+// solely from the immutable layer, which any readTs that reaches this list may see.
+func (l *List) canUseCalculatedUids(readTs uint64) bool {
 	if l.mutationMap == nil {
 		return false
 	}
-	return l.mutationMap.isUidsCalculated && l.mutationMap.currentEntries == nil
+	if !l.mutationMap.isUidsCalculated || l.mutationMap.currentEntries != nil {
+		return false
+	}
+	return l.mutationMap.committedUidsTime == math.MaxUint64 ||
+		readTs >= l.mutationMap.committedUidsTime
 }
 
 // Uids returns the UIDs given some query params.
@@ -1761,7 +1770,7 @@ func (l *List) Uids(opt ListOptions) (*pb.List, error) {
 	}
 
 	getUidList := func() (*pb.List, error, bool) {
-		if l.canUseCalculatedUids() {
+		if l.canUseCalculatedUids(opt.ReadTs) {
 			l.RLock()
 
 			afterIdx := 0

--- a/posting/list_test.go
+++ b/posting/list_test.go
@@ -1834,3 +1834,43 @@ func BenchmarkAddMutations(b *testing.B) {
 		}
 	}
 }
+
+// TestCalculatedUidsRespectReadTs is a regression test for issue #9795: calculatedUids is
+// computed at the newest commit in the list (committedUidsTime), so a read at an older
+// timestamp must not be served from it, or later mutations leak into an earlier snapshot.
+func TestCalculatedUidsRespectReadTs(t *testing.T) {
+	key := x.DataKey(x.AttrInRootNamespace("calculatedUidsReadTs"), 7)
+
+	txn := NewTxn(5)
+	l, err := txn.Get(key)
+	require.NoError(t, err)
+	for _, uid := range []uint64{3, 4, 10} {
+		addMutationHelper(t, l, &pb.DirectedEdge{ValueId: uid}, Set, txn)
+	}
+	require.NoError(t, l.commitMutation(5, 10))
+
+	txn = NewTxn(15)
+	addMutationHelper(t, l, &pb.DirectedEdge{ValueId: 4}, Del, txn)
+	addMutationHelper(t, l, &pb.DirectedEdge{ValueId: 13}, Set, txn)
+	require.NoError(t, l.commitMutation(15, 20))
+
+	// Precompute the uid slice. It represents the newest state (commit ts 20).
+	require.NoError(t, l.calculateUids())
+	require.True(t, l.canUseCalculatedUids(20))
+	require.True(t, l.canUseCalculatedUids(25))
+	require.False(t, l.canUseCalculatedUids(15),
+		"a read below the timestamp the slice was computed at must not use it")
+
+	uidsAt := func(readTs uint64) []uint64 {
+		out, err := l.Uids(ListOptions{ReadTs: readTs})
+		require.NoError(t, err)
+		return out.Uids
+	}
+	// Reads at or after the newest commit see the newest state.
+	require.Equal(t, []uint64{3, 10, 13}, uidsAt(20))
+	require.Equal(t, []uint64{3, 10, 13}, uidsAt(25))
+	// A read between the two commits must see the ts=10 state, not the precomputed one.
+	require.Equal(t, []uint64{3, 4, 10}, uidsAt(15))
+	// A read before every commit sees nothing.
+	require.Empty(t, uidsAt(5))
+}

--- a/systest/mutations-and-queries/mutations_test.go
+++ b/systest/mutations-and-queries/mutations_test.go
@@ -2932,3 +2932,174 @@ func (ssuite *SystestTestSuite) TestAddAndQueryZeroTimeValue() {
 		]
 	  }`, string(resp.Json))
 }
+
+// TestOldTxnReadUnaffectedByLaterMutations is a regression test for
+// https://github.com/dgraph-io/dgraph/issues/9795: a query running at an earlier
+// start_ts must not see mutations committed after that timestamp.
+//
+// It follows the exact path of the reporter's failing test (spark-dgraph-connector
+// TestTransaction): seed a small Star Wars graph, pin a read-only transaction's
+// start_ts with a first query, then in separate committed transactions (1) delete a
+// <film> <starring> <leia> edge, (2) rename leia, and (3) insert a new person wired
+// into <film> <starring>. Re-reading through the pinned transaction must return
+// exactly the pre-mutation snapshot.
+//
+// The regression (bisected to 934a203f6, first bad in v25.3.0) leaked uid-list
+// predicates only: the deleted starring edge disappeared and the inserted one showed
+// up at the old start_ts, while the scalar rename stayed invisible. Root cause was
+// the timestamp-blind calculatedUids fast path in posting/list.go.
+func (ssuite *SystestTestSuite) TestOldTxnReadUnaffectedByLaterMutations() {
+	t := ssuite.T()
+	gcli, cleanup, err := doGrpcLogin(ssuite)
+	defer cleanup()
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	require.NoError(t, gcli.Alter(ctx, &api.Operation{Schema: `
+		name: string @index(term) @lang .
+		title: string @lang .
+		release_date: datetime @index(year) .
+		revenue: float .
+		running_time: int .
+		starring: [uid] .
+		director: [uid] @reverse .
+
+		type Person {
+			name
+		}
+		type Film {
+			title
+			release_date
+			revenue
+			running_time
+			starring
+			director
+		}
+	`}))
+
+	resp, err := gcli.Mutate(&api.Mutation{
+		CommitNow: true,
+		SetNquads: []byte(`
+			_:han <name> "Han Solo" .
+			_:han <dgraph.type> "Person" .
+			_:leia <name> "Princess Leia" .
+			_:leia <dgraph.type> "Person" .
+			_:luke <name> "Luke Skywalker" .
+			_:luke <dgraph.type> "Person" .
+			_:lucas <name> "George Lucas" .
+			_:lucas <dgraph.type> "Person" .
+			_:sw1 <title> "Star Wars: Episode IV - A New Hope" .
+			_:sw1 <release_date> "1977-05-25" .
+			_:sw1 <revenue> "775000000" .
+			_:sw1 <running_time> "121" .
+			_:sw1 <dgraph.type> "Film" .
+			_:sw1 <starring> _:han .
+			_:sw1 <starring> _:leia .
+			_:sw1 <starring> _:luke .
+			_:sw1 <director> _:lucas .
+		`),
+	})
+	require.NoError(t, err)
+	film, leia := resp.Uids["sw1"], resp.Uids["leia"]
+	require.NotEmpty(t, film)
+	require.NotEmpty(t, leia)
+
+	// snapshotView mirrors what the reporter's test reads back: the film's starring
+	// edges (both via the film's uid and via has(starring), the enumeration path the
+	// connector uses) and everyone's names.
+	type snapshotView struct {
+		Film []struct {
+			Title    string `json:"title"`
+			Starring []struct {
+				Name string `json:"name"`
+			} `json:"starring"`
+		} `json:"film"`
+		Edges []struct {
+			Starring []struct {
+				Name string `json:"name"`
+			} `json:"starring"`
+		} `json:"edges"`
+		People []struct {
+			Name string `json:"name"`
+		} `json:"people"`
+	}
+	query := fmt.Sprintf(`{
+		film(func: uid(%s)) {
+			title
+			starring(orderasc: name) { name }
+		}
+		edges(func: has(starring)) {
+			starring(orderasc: name) { name }
+		}
+		people(func: has(name), orderasc: name) { name }
+	}`, film)
+
+	read := func(txn *dgo.Txn) (string, snapshotView, uint64) {
+		resp, err := txn.Query(ctx, query)
+		require.NoError(t, err)
+		var v snapshotView
+		require.NoError(t, json.Unmarshal(resp.Json, &v))
+		return string(resp.Json), v, resp.Txn.StartTs
+	}
+	starringNames := func(v snapshotView) []string {
+		require.Len(t, v.Film, 1)
+		names := make([]string, 0, len(v.Film[0].Starring))
+		for _, p := range v.Film[0].Starring {
+			names = append(names, p.Name)
+		}
+		return names
+	}
+
+	// Pin the snapshot: the first query fixes the read-only txn's start_ts, and dgo
+	// sends that same start_ts with every later query in the txn — the same mechanism
+	// the reporter uses (dgraph4j sets start_ts on each query).
+	snapshot := gcli.NewReadOnlyTxn()
+	defer func() { _ = snapshot.Discard(ctx) }()
+	beforeJSON, before, startTs := read(snapshot)
+	require.NotZero(t, startTs)
+	require.Equal(t, []string{"Han Solo", "Luke Skywalker", "Princess Leia"}, starringNames(before))
+
+	// The three mutations from the issue, each committed in its own transaction after
+	// the snapshot's start_ts.
+	_, err = gcli.Mutate(&api.Mutation{
+		CommitNow: true,
+		DelNquads: []byte(fmt.Sprintf(`<%s> <starring> <%s> .`, film, leia)),
+	})
+	require.NoError(t, err)
+
+	_, err = gcli.Mutate(&api.Mutation{
+		CommitNow: true,
+		DelNquads: []byte(fmt.Sprintf(`<%s> <name> "Princess Leia" .`, leia)),
+		SetNquads: []byte(fmt.Sprintf(`<%s> <name> "Princess Leia Organa" .`, leia)),
+	})
+	require.NoError(t, err)
+
+	_, err = gcli.Mutate(&api.Mutation{
+		CommitNow: true,
+		SetNquads: []byte(fmt.Sprintf(`
+			_:obi <name> "Obi-Wan 'Ben' Kenobi" .
+			_:obi <dgraph.type> "Person" .
+			<%s> <starring> _:obi .
+		`, film)),
+	})
+	require.NoError(t, err)
+
+	// A fresh transaction must see the new state. This proves the mutations landed
+	// before we assert anything about the old snapshot.
+	latest := gcli.NewReadOnlyTxn()
+	defer func() { _ = latest.Discard(ctx) }()
+	_, after, latestTs := read(latest)
+	require.Greater(t, latestTs, startTs)
+	require.Equal(t, []string{"Han Solo", "Luke Skywalker", "Obi-Wan 'Ben' Kenobi"},
+		starringNames(after), "control read: mutations must be visible at the latest start_ts")
+
+	// The pinned transaction must still see the world exactly as it was at its
+	// start_ts. On the broken versions the starring list leaks: Princess Leia is
+	// gone and Obi-Wan shows up.
+	againJSON, again, againTs := read(snapshot)
+	require.Equal(t, startTs, againTs, "read-only txn must keep using its pinned start_ts")
+	require.Equal(t, []string{"Han Solo", "Luke Skywalker", "Princess Leia"}, starringNames(again),
+		"later mutations leaked into a read at an earlier start_ts (issue #9795)")
+	require.JSONEq(t, beforeJSON, againJSON,
+		"full snapshot read at the pinned start_ts must be identical before and after the mutations")
+}


### PR DESCRIPTION
Summary

Queries running at an earlier start_ts can see mutations committed after that timestamp on uid-list predicates: edges deleted after the snapshot disappear from it, and edges inserted after the snapshot show up in it. Scalar predicates are unaffected. This breaks snapshot isolation for any client that pins a transaction's start_ts across reads (dgraph4j's start_ts-per-query, the spark-dgraph-connector, dgo read-only txns). Reported in #9795; worked on v25.2.0, broken since v25.3.0.

Root cause

git bisect (using the integration test added here, every endpoint verified by running it) lands on 934a203f6 — "fix(posting): prevent stale cache hits when maxTs < readTs (#9597) (#9614)". That commit's logic is sound; it exposed a latent, timestamp-blind fast path:

- calculateUids() precomputes a posting list's uid slice at committedUidsTime — the newest commit in the list — and stores it in mutationMap.calculatedUids with no record of the timestamp it represents.
- canUseCalculatedUids() only checked isUidsCalculated && currentEntries == nil, never the query's readTs, so Uids() served that newest-state slice to any read, including one pinned before those commits.
- MutableLayer.clone() shares the slice into every cached copy of the list.

Before #9614 the bad combination was rare: the cache entry was updated in place on each commit, which invalidates the slice, so it was effectively recomputed per-era (reachable only via cache-eviction races). After #9614, any read at a ts newer than the cached maxTs misses the cache, rebuilds the list from disk at MaxUint64, recomputes calculatedUids at latest state, and saveInCache replaces the entry. The next read at an older ts passes both cache gates (minTs <= readTs <= maxTs), hits that entry, and receives the latest-state uid slice — mutations leak backward in time, deterministically.

Scalar values never leak because value reads go through the ts-aware findValue/iterate path; only the uid-list fast path bypasses commit-ts filtering. This matches the reporter's observation exactly (the starring edges leaked, the name rename did not).

Fix

Make the fast path timestamp-aware. canUseCalculatedUids(readTs) now serves the precomputed slice only when readTs >= committedUidsTime, i.e. at or after the state it was computed at; older reads fall back to the existing iterate(readTs, …) slow path, which filters postings by commit ts correctly. Lists whose uids come purely from the immutable layer (committedUidsTime == math.MaxUint64) keep the fast path for every read that can reach them (cache admission already guarantees readTs >= minTs).

The #9614 maxTs >= readTs cache gate is untouched, so the #9597 fix (stale cache serving new reads) remains intact — its regression test TestCacheStaleWhenMaxTsLessThanReadTs still passes.                        
Testing                                                                                                                                                                                                             
- New unit regression test TestCalculatedUidsRespectReadTs (posting/list_test.go): commits uids {3,4,10} at ts=10, deletes 4 and adds 13 at ts=20, precomputes the slice, then asserts a read at ts=15 sees the     ts=10 state while reads at ts≥20 see the newest state. Verified red on the pre-fix behavior,in milliseconds.
- New integration test TestOldTxnReadUnaffectedByLaterMutations (systest/predicate integration2 tag) reproducing the reporter's exact flow: seed the Star Wars fixture, pin a read-only txn's start_ts with a first query, commit the issue's three mutations (delete a starring edge, rename a scalar, insert a in separate txns, control-read at a fresh ts to prove they landed, then assert the pinned txn re-read is identical to the pre-mutation snapshot. Fails on v25.3.0 and main, passes with this fix (~50s). This is also the test the bisect ran.
- Full posting package suite passes; gofmt/vet clean (pre-existing vet warnings aside).

Verified version matrix: v25.1.0 ✅, v25.2.0 ✅, 3a022ed15 ✅, 934a203f6 ❌ (first bad), v25x ✅.