### PR TITLE
fix(posting): make rollup failures diagnosable in logs

### DIFF
--- a/posting/list.go
+++ b/posting/list.go
@@ -410,8 +410,27 @@ func (mm *MutableLayer) print() string {
 		mm.deleteAllMarker)
 }
 
+// printShort returns a summary of the mutable layer with the entry counts but not the entries themselves. Use it in
+// error messages and logs, where print() is unsafe because posting values are unbounded in size.
+func (mm *MutableLayer) printShort() string {
+	if mm == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("committed: %d, proposed: %t, deleteAllMarker: %d",
+		len(mm.committedEntries), mm.currentEntries != nil, mm.deleteAllMarker)
+}
+
+// Print dumps the entire list, posting values included. It is meant for interactive debugging only. Anything that
+// ends up in a log line or an error message should use debugString() instead.
 func (l *List) Print() string {
 	return fmt.Sprintf("minTs: %d, plist: %+v, mutationMap: %s", l.minTs, l.plist, l.mutationMap.print())
+}
+
+// debugString describes the list's shape without including any posting values. Rollup retries a failing key every
+// few seconds, so an error message built from Print() will repeatedly dump multi-megabyte values into the log.
+func (l *List) debugString() string {
+	return fmt.Sprintf("key: %x, minTs: %d, maxTs: %d, splits: %v, mutationMap: {%s}",
+		l.key, l.minTs, l.maxTs, l.plist.GetSplits(), l.mutationMap.printShort())
 }
 
 // Return if piterator needs to be searched or not after mutable map and the posting if found.
@@ -1153,7 +1172,7 @@ func (l *List) iterate(readTs uint64, afterUid uint64, f func(obj *pb.Posting) e
 	// pitr iterates through immutable postings
 	err = pitr.seek(l, afterUid, deleteBelowTs)
 	if err != nil {
-		return errors.Wrapf(err, "cannot initialize iterator when calling List.iterate %v", l.Print())
+		return errors.Wrapf(err, "cannot initialize iterator when calling List.iterate %s", l.debugString())
 	}
 
 loop:
@@ -2187,15 +2206,13 @@ func (l *List) findPostingWithItr(readTs uint64, uid uint64, pitr pIterator) (fo
 	err = pitr.seek(l, uid-1, 0)
 	if err != nil {
 		return false, nil, errors.Wrapf(err,
-			"cannot initialize iterator when calling List.iterate %s",
-			l.mutationMap.print())
+			"cannot initialize iterator when calling List.iterate %s", l.debugString())
 	}
 
 	valid, err := pitr.valid()
 	if err != nil {
 		return false, nil, errors.Wrapf(err,
-			"cannot initialize iterator when calling List.iterate %s",
-			l.mutationMap.print())
+			"cannot initialize iterator when calling List.iterate %s", l.debugString())
 	}
 	if valid {
 		pp := pitr.posting()

--- a/posting/mvcc.go
+++ b/posting/mvcc.go
@@ -178,7 +178,7 @@ func (ir *incrRollupi) Process(closer *z.Closer, getNewTs func(bool) uint64) {
 				// Add/Update map and rollup.
 				m[hash] = currTs
 				if err := ir.rollUpKey(writer, key); err != nil {
-					glog.Warningf("Error rolling up key [%v]: %v", err, key)
+					glog.Warningf("Error rolling up key [%x]: %v", key, err)
 				}
 			}
 		}


### PR DESCRIPTION
**Description**

Two problems make a failing rollup nearly impossible to triage from logs. Both
turned up while looking at #9794, where the reporter's log line was truncated
right before the useful part.

**1. Reversed format arguments in `incrRollupi.Process`**

```go
glog.Warningf("Error rolling up key [%v]: %v", err, key)
```

`err` and `key` are swapped, so the message reads `Error rolling up key [<the
error>]: <the key>`. The key also rendered as a decimal byte slice, which can't
be pasted into `dgraph debug --lookup`. Now `%x` with the arguments in the right
order.

**2. The `pIterator.seek` error message dumps the whole posting list**

`List.iterate` formatted `l.Print()` into its error, and `Print()` dumps the
entire posting list plus mutation map with posting values included. On a
multi-part list holding large values that's a multi-megabyte log line. Since
`ReadPostingList` re-queues a key for rollup on every read while deltas remain,
and `doRollup` retries a given key roughly every 10 seconds, the same giant line
repeats for as long as the key stays broken.

Worse for triage: `errors.Wrapf` appends the cause *after* the format string, so
the actual error is the first thing to get cut off. `seek` has only two failure
modes and they have completely different root causes, so losing that suffix
loses the diagnosis:

```
deleteBelowTs (%d) must be greater than the minTs in the list (%d)
cannot read initial list part for list with base key %s
```

This PR adds `List.debugString()`, which reports the key (hex), `minTs`,
`maxTs`, splits, and mutation-layer counts, with no posting values, and uses it
on the three `seek` error paths in `iterate` and `findPostingWithItr`. The two
paths in `findPostingWithItr` were formatting `mutationMap.print()`, which has
the same unbounded-value problem.

`Print()` is unchanged and stays available for interactive debugging.

Sample of the new output shape:

```
cannot initialize iterator when calling List.iterate key: 000764617461..., minTs: 58256931,
maxTs: 58550095, splits: [1 8523883114575535643], mutationMap: {committed: 1, proposed: false,
deleteAllMarker: 18446744073709551615}: could not read list part with key ...: Key not found
```

Logging only. No behavior change.

Refs #9794.

**Checklist**

- [x] The PR title follows the
      [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax, leading
      with `fix:`, `feat:`, `chore:`, `ci:`, etc.
- [x] Code compiles correctly and linting (via trunk) passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dgraph-io/codesmith/dgraph/pr/9808"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788544745&installation_model_id=8575&pr_number=9808&repository=dgraph-io%2Fdgraph&return_to=https%3A%2F%2Fgithub.com%2Fdgraph-io%2Fdgraph%2Fpull%2F9808&signature=5e7bf57002008563b0ed04bfe04164d7b6007c94571381ca256e73b4416e61c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->