### PR TITLE
fix(acl): preserve user permissions across namespaces

### DIFF
--- a/edgraph/access.go
+++ b/edgraph/access.go
@@ -647,9 +647,10 @@ func authorizePreds(ctx context.Context, userData *userData, preds []string,
 		return &authPredResult{allowed: nil, blocked: blockedPreds}
 	}
 	// User can have multiple permission for same predicate, add predicate
-	allowedPreds := make([]string, 0, len(worker.AclCachePtr.GetUserPredPerms(userId)))
+	userPredPerms := worker.AclCachePtr.GetUserPredPerms(userId)
+	allowedPreds := make([]string, 0, len(userPredPerms))
 	// only if the acl.Op is covered in the set of permissions for the user
-	for predicate, perm := range worker.AclCachePtr.GetUserPredPerms(userId) {
+	for predicate, perm := range userPredPerms {
 		if (perm & aclOp.Code) > 0 {
 			allowedPreds = append(allowedPreds, predicate)
 		}

--- a/worker/acl_cache.go
+++ b/worker/acl_cache.go
@@ -51,9 +51,18 @@ var AclCachePtr = &AclCache{
 }
 
 func (cache *AclCache) GetUserPredPerms(userId string) map[string]int32 {
-	cache.Lock()
-	defer cache.Unlock()
-	return cache.userPredPerms[userId]
+	cache.RLock()
+	defer cache.RUnlock()
+
+	perms, found := cache.userPredPerms[userId]
+	if !found {
+		return nil
+	}
+	snapshot := make(map[string]int32, len(perms))
+	for predicate, permission := range perms {
+		snapshot[predicate] = permission
+	}
+	return snapshot
 }
 
 func (cache *AclCache) Update(ns uint64, groups []acl.Group) {
@@ -135,11 +144,14 @@ func (cache *AclCache) Update(ns uint64, groups []acl.Group) {
 		}
 	}
 
-	for _, v := range AclCachePtr.userPredPerms {
-		for k := range v {
+	for userID, perms := range AclCachePtr.userPredPerms {
+		for k := range perms {
 			if x.ParseNamespace(k) == ns {
-				delete(v, k)
+				delete(perms, k)
 			}
+		}
+		if len(perms) == 0 {
+			delete(AclCachePtr.userPredPerms, userID)
 		}
 	}
 

--- a/worker/acl_cache.go
+++ b/worker/acl_cache.go
@@ -148,8 +148,17 @@ func (cache *AclCache) Update(ns uint64, groups []acl.Group) {
 		AclCachePtr.predPerms[k] = v
 	}
 
-	for k, v := range userPredPerms {
-		AclCachePtr.userPredPerms[k] = v
+	// User IDs are namespace-local, so the same ID can exist in multiple namespaces. Merge the
+	// namespaced predicates instead of replacing permissions collected from another namespace.
+	for userID, newPerms := range userPredPerms {
+		perms, found := AclCachePtr.userPredPerms[userID]
+		if !found {
+			perms = make(map[string]int32)
+			AclCachePtr.userPredPerms[userID] = perms
+		}
+		for predicate, permission := range newPerms {
+			perms[predicate] = permission
+		}
 	}
 }
 

--- a/worker/acl_cache_test.go
+++ b/worker/acl_cache_test.go
@@ -14,10 +14,20 @@ import (
 	"github.com/dgraph-io/dgraph/v25/x"
 )
 
-func TestAclCache(t *testing.T) {
+func resetAclCacheForTest(t *testing.T) {
+	t.Helper()
+	original := AclCachePtr
 	AclCachePtr = &AclCache{
-		predPerms: make(map[string]map[string]int32),
+		predPerms:     make(map[string]map[string]int32),
+		userPredPerms: make(map[string]map[string]int32),
 	}
+	t.Cleanup(func() {
+		AclCachePtr = original
+	})
+}
+
+func TestAclCache(t *testing.T) {
+	resetAclCacheForTest(t)
 
 	var emptyGroups []string
 	group := "dev"
@@ -50,4 +60,60 @@ func TestAclCache(t *testing.T) {
 	// the anonymous user should have access again
 	require.Error(t, AclCachePtr.AuthorizePredicate(emptyGroups, predicate, acl.Read),
 		"the anonymous user should not have access when the acl cache is empty")
+}
+
+func TestAclCacheMergesSameUserAcrossNamespaces(t *testing.T) {
+	const (
+		userID = "shared-user"
+		nsOne  = uint64(1)
+		nsTwo  = uint64(2)
+	)
+
+	groups := func(groupID, predicate string, permission int32) []acl.Group {
+		return []acl.Group{{
+			GroupID: groupID,
+			Users:   []acl.User{{UserID: userID}},
+			Rules:   []acl.Acl{{Predicate: predicate, Perm: permission}},
+		}}
+	}
+
+	for _, tc := range []struct {
+		name  string
+		order []uint64
+	}{
+		{name: "namespace one then two", order: []uint64{nsOne, nsTwo}},
+		{name: "namespace two then one", order: []uint64{nsTwo, nsOne}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			resetAclCacheForTest(t)
+
+			for _, ns := range tc.order {
+				switch ns {
+				case nsOne:
+					AclCachePtr.Update(nsOne, groups("group-one", "pred-one", acl.Read.Code))
+				case nsTwo:
+					AclCachePtr.Update(nsTwo, groups("group-two", "pred-two", acl.Write.Code))
+				}
+			}
+
+			require.Equal(t, map[string]int32{
+				x.NamespaceAttr(nsOne, "pred-one"): acl.Read.Code,
+				x.NamespaceAttr(nsTwo, "pred-two"): acl.Write.Code,
+			}, AclCachePtr.GetUserPredPerms(userID))
+
+			AclCachePtr.Update(nsOne,
+				groups("group-one", "pred-one-new", acl.Modify.Code))
+			require.Equal(t, map[string]int32{
+				x.NamespaceAttr(nsOne, "pred-one-new"): acl.Modify.Code,
+				x.NamespaceAttr(nsTwo, "pred-two"):     acl.Write.Code,
+			}, AclCachePtr.GetUserPredPerms(userID),
+				"refreshing one namespace should replace only that namespace's permissions")
+
+			AclCachePtr.Update(nsOne, nil)
+			require.Equal(t, map[string]int32{
+				x.NamespaceAttr(nsTwo, "pred-two"): acl.Write.Code,
+			}, AclCachePtr.GetUserPredPerms(userID),
+				"clearing one namespace should preserve permissions from other namespaces")
+		})
+	}
 }

--- a/worker/acl_cache_test.go
+++ b/worker/acl_cache_test.go
@@ -114,6 +114,39 @@ func TestAclCacheMergesSameUserAcrossNamespaces(t *testing.T) {
 				x.NamespaceAttr(nsTwo, "pred-two"): acl.Write.Code,
 			}, AclCachePtr.GetUserPredPerms(userID),
 				"clearing one namespace should preserve permissions from other namespaces")
+
+			AclCachePtr.Update(nsTwo, nil)
+			require.NotContains(t, AclCachePtr.userPredPerms, userID,
+				"clearing the last namespace should remove the empty user entry")
 		})
 	}
+}
+
+func TestGetUserPredPermsReturnsSnapshot(t *testing.T) {
+	resetAclCacheForTest(t)
+
+	const (
+		userID = "alice"
+		ns     = uint64(1)
+	)
+	groups := func(predicate string, permission int32) []acl.Group {
+		return []acl.Group{{
+			GroupID: "dev",
+			Users:   []acl.User{{UserID: userID}},
+			Rules:   []acl.Acl{{Predicate: predicate, Perm: permission}},
+		}}
+	}
+
+	oldPredicate := x.NamespaceAttr(ns, "old-predicate")
+	AclCachePtr.Update(ns, groups("old-predicate", acl.Read.Code))
+	snapshot := AclCachePtr.GetUserPredPerms(userID)
+
+	AclCachePtr.Update(ns, groups("new-predicate", acl.Write.Code))
+	require.Equal(t, map[string]int32{oldPredicate: acl.Read.Code}, snapshot,
+		"updating the cache should not mutate a previously returned snapshot")
+
+	snapshot[x.NamespaceAttr(ns, "caller-only")] = acl.Modify.Code
+	require.NotContains(t, AclCachePtr.GetUserPredPerms(userID),
+		x.NamespaceAttr(ns, "caller-only"),
+		"mutating a snapshot should not mutate the cache")
 }


### PR DESCRIPTION
**Description**

`AclCache.Update` clears cached permissions belonging to the namespace being
refreshed. However, when writing the new `userPredPerms`, it replaced the
user's entire predicate-permission map.

User IDs are namespace-local, so the same user ID can exist in multiple
namespaces. Refreshing ACLs for one namespace could therefore discard that
user's permissions from every other namespace.

Because `RefreshACLs` iterates over a Go map of namespaces, the last namespace
loaded could differ between Alpha instances and restarts. This could leave
different Alpha instances with different allowed-predicate sets and affect
predicate discovery paths such as `expand(_all_)`.

This change preserves the existing per-user map and merges the newly refreshed
namespaced predicates into it after removing only the permissions belonging to
the namespace being refreshed.

Regression tests cover:

- Loading the same user ID in both namespace orders.
- Refreshing permissions in one namespace without affecting another.
- Clearing permissions in one namespace while preserving another namespace.

This addresses the same-user collision not covered by the different-user
multi-namespace scenario added in #8418.

**Checklist**

- [x] The PR title follows the Conventional Commits syntax.
- [x] Regression tests for the bug have been added.
- [ ] Code compiles correctly and linting via trunk passes locally.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dgraph-io/codesmith/dgraph/pr/9812"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789813502&installation_model_id=8575&pr_number=9812&repository=dgraph-io%2Fdgraph&return_to=https%3A%2F%2Fgithub.com%2Fdgraph-io%2Fdgraph%2Fpull%2F9812&signature=21ad1c1984c00a7a3b1e0ea1ad39609409c7910de9ca65e81c63ceeb80ed7c8c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->