### PR TITLE
chore: upgrade Go to 1.27.0

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -16,7 +16,7 @@ runtimes:
   enabled:
     - node@22.16.0
     - python@3.10.8
-    - go@1.26.1
+    - go@1.27.0
 
 # This is the section where you manage your linters. (https://docs.trunk.io/check/configuration)
 lint:
@@ -28,7 +28,7 @@ lint:
   enabled:
     - taplo@0.10.0
     - svgo@4.0.1
-    - golangci-lint2@2.11.4
+    - golangci-lint2@2.13.1
     - trivy@0.69.3
     - actionlint@1.7.11
     - checkov@3.2.513

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@
   available through your OS package manager)
 - Install [Docker](https://docs.docker.com/install/) and
   [Docker Compose](https://docs.docker.com/compose/install/).
-- [Install Go 1.24.3 or above](https://golang.org/doc/install).
+- [Install Go 1.27.0 or above](https://golang.org/doc/install).
 - Install
   [trunk](https://docs.trunk.io/code-quality/overview/getting-started/install#install-the-launcher).
   Our CI uses trunk to lint and check code, having it installed locally will save you time.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Used only by the (currently disabled) nightly build workflow
 
 ###################### Stage I ######################
-FROM golang:1.25.0 AS builder
+FROM golang:1.27.0 AS builder
 RUN apt-get update && apt-get install -y --no-install-recommends \
     bzip2=1.0.8-5+b1 \
     git=1:2.39.5-0+deb12u2 \

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ docker run -it -p 8080:8080 -p 9080:9080 -v ~/dgraph:/dgraph dgraph/standalone:l
 
 ## Install from Source
 
-If you want to install from source, install Go 1.24+ or later and the following dependencies:
+If you want to install from source, install Go 1.27+ or later and the following dependencies:
 
 ### Ubuntu
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/dgraph-io/dgraph/v25
 
-go 1.26.5
+go 1.27.0
 
 require (
 	contrib.go.opencensus.io/exporter/prometheus v0.4.2

--- a/protos/Makefile
+++ b/protos/Makefile
@@ -54,7 +54,7 @@ regenerate:
 	@echo "Running in Docker..."
 	@docker run --rm -v $(shell pwd)/..:/go/src/github.com/dgraph-io/dgraph \
 		-w /go/src/github.com/dgraph-io/dgraph/protos \
-		golang:1.25.0 \
+		golang:1.27.0 \
 		/bin/bash -c "apt-get update && apt-get install -y protobuf-compiler && make regenerate"
 else
 .PHONY: regenerate

--- a/protos/pb/pb.pb.go
+++ b/protos/pb/pb.pb.go
@@ -4017,8 +4017,7 @@ type VectorIndexSpec struct {
 	unknownFields protoimpl.UnknownFields
 
 	// This names the kind of Vector Index, e.g.,
-	//
-	//	hnsw, lsh, hypertree, ...
+	//    hnsw, lsh, hypertree, ...
 	Name    string        `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
 	Options []*OptionPair `protobuf:"bytes,2,rep,name=options,proto3" json:"options,omitempty"`
 }


### PR DESCRIPTION
**Description**

This PR updates the `go` directive in `go.mod` from 1.26.5 to 1.27.0, and updates the build and lint toolchain pieces that don't resolve their Go version from `go.mod`.

The only change here that isn't cosmetic is golangci-lint. `golangci-lint2@2.11.4` is built with go1.26 and refuses outright to lint a module targeting 1.27:

```
Error: can't load config: the Go language version (go1.26) used to build golangci-lint is lower than the targeted Go version (1.27.0)
```

Since CI gates on `trunk check`, every PR would fail at config load until we bump it. golangci-lint v2.13.0 added go1.27 support, so this moves us to 2.13.1.

| File | Change |
| --- | --- |
| `go.mod` | `go 1.26.5` → `go 1.27.0` |
| `.trunk/trunk.yaml` | `golangci-lint2@2.11.4` → `2.13.1` |
| `.trunk/trunk.yaml` | runtime `go@1.26.1` → `go@1.27.0` |
| `Dockerfile` | `golang:1.25.0` → `golang:1.27.0` |
| `protos/Makefile` | `golang:1.25.0` → `golang:1.27.0` (proto regeneration container) |
| `protos/pb/pb.pb.go` | regenerated under 1.27 (one comment line, see below) |
| `README.md`, `CONTRIBUTING.md` | documented minimum Go version `1.24` → `1.27` |

No workflow changes are needed: all CI jobs resolve the toolchain from `go.mod` via `setup-go`'s `go-version-file`. The two `golang:` base image bumps aren't strictly required either, since Go's toolchain auto-download covers the gap, but both images were two minor versions stale and every build was paying for a toolchain download to close it.

`go.sum` is unchanged, which is expected. The `go` directive only rewrites it when it crosses the 1.17 module-graph-pruning boundary.

**Generated protobuf**

The `Check protobuf` CI step regenerates the protos and gates on `git diff --exit-code`, and it failed on the first push. Go 1.27's `go/printer` no longer normalizes an indented doc-comment continuation line into a code block, so it stops emitting the blank `//` separator and the tab re-indent that 1.26 produced. `protoc-gen-go` embeds `go/printer` at build time, and that CI step rebuilds it from source with the ambient toolchain (`go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.31.0`), so regenerating under 1.27 reshapes the comment on `VectorIndexSpec.Name`.

I built protoc-gen-go v1.31.0 with both 1.26.5 and 1.27.0 and diffed their output over `pb.proto`. That comment is the only difference between them, so the regenerated file here is a single line and the blob hashes match what CI produced.

**GODEBUG defaults**

Two GODEBUG settings flip their default once the `go` directive reaches 1.27:

- `tracebacklabels=1`: `runtime/pprof` goroutine labels are now included in tracebacks.
- `x509sslcertoverrideplatform=1`: on Windows and Darwin, `crypto/x509` now loads roots from disk when `SSL_CERT_FILE` or `SSL_CERT_DIR` is set.

Neither applies to us. We don't set `runtime/pprof` labels anywhere or read either environment variable.

**Testing**

- `go build ./...` and unit tests (`tok`, `tok/hnsw`, `types`, `dql`, `posting`, `chunker`, `schema`, `algo`, `codec`) pass on the 1.27.0 toolchain.
- For the protobuf change I ran `protoc` directly against a locally built protoc-gen-go rather than the full `make regenerate`, to keep the ambient `protoc` version out of the comparison. The resulting blob hash matches the one CI reported (`ed5313d`), so the next `Check protobuf` run should come back clean.
- Spot-checked `go vet` on `chunker` and `schema` under both 1.26.5 and 1.27.0. Output is identical, so the existing protobuf `copylocks` noise is pre-existing rather than a 1.27 regression.
- Ran golangci-lint 2.13.1 over the full tree with `.trunk/configs/.golangci.json`. The only findings are `typecheck` errors caused by linting with the `integration`, `integration2`, and `upgrade` build tags at once, which compiles both the integration and upgrade variant of a suite and collides on redeclared types. Same class of error that 2.11.4 reports today, so nothing new from the bump. One thing to be aware of: 2.13.1 surfaces three of them where 2.11.4 surfaced one, so a future PR touching `acl/` or `systest/multi-tenancy/` may run into it.

**Checklist**

- [x] The PR title follows the
      [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax, leading
      with `fix:`, `feat:`, `chore:`, `ci:`, etc.
- [x] Code compiles correctly and linting (via trunk) passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)
