### PR TITLE
docs: fix typo neccessary -> necessary

### DIFF
--- a/graphql/resolve/query_rewriter.go
+++ b/graphql/resolve/query_rewriter.go
@@ -2101,7 +2101,7 @@ func buildFilter(typ schema.Type, filter map[string]interface{}) *dql.FilterTree
 					}
 				case "between":
 					// numLikes: { between : { min : 10,  max:100 }} should be rewritten into
-					// 	between(numLikes,10,20). Order of arguments (min,max) is neccessary or
+					// 	between(numLikes,10,20). Order of arguments (min,max) is necessary or
 					// it will return empty
 					vals := val.(map[string]interface{})
 					args = append(args, dql.Arg{Value: maybeQuoteArg(fn, vals["min"])},


### PR DESCRIPTION
Corrects the misspelling `neccessary` -> `necessary` in `graphql/resolve/query_rewriter.go`.

Documentation only, no behaviour change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dgraph-io/codesmith/dgraph/pr/9819"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790595681&installation_model_id=8575&pr_number=9819&repository=dgraph-io%2Fdgraph&return_to=https%3A%2F%2Fgithub.com%2Fdgraph-io%2Fdgraph%2Fpull%2F9819&signature=2a41fcb1b358c089fdf499b9a4d7153e35338dd0a1c2b937d3f681bc8468a90b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->