### PR TITLE
fix(unique): include language in value identity

### DIFF
--- a/edgraph/server.go
+++ b/edgraph/server.go
@@ -1772,6 +1772,13 @@ func parseRequest(ctx context.Context, qc *queryContext) error {
 	return validateQuery(qc.dqlRes.Query)
 }
 
+func predicateNameWithLang(pred *api.NQuad) string {
+	if pred.Lang == "" {
+		return pred.Predicate
+	}
+	return fmt.Sprintf("%s@%s", pred.Predicate, pred.Lang)
+}
+
 // verifyUnique verifies uniqueness of mutation
 func verifyUnique(qc *queryContext, qr query.Request) error {
 	if len(qc.uniqueVars) == 0 {
@@ -1781,6 +1788,7 @@ func verifyUnique(qc *queryContext, qr query.Request) error {
 	for i, queryVar := range qc.uniqueVars {
 		gmuIndex, rdfIndex := decodeIndex(i)
 		pred := qc.gmuList[gmuIndex].Set[rdfIndex]
+		predicateName := predicateNameWithLang(pred)
 		queryResult := qr.Vars[queryVar.queryVar]
 		if !isUpsertCondTrue(qc, int(gmuIndex)) {
 			continue
@@ -1797,7 +1805,7 @@ func verifyUnique(qc *queryContext, qr query.Request) error {
 			} else if len(varName.Uids.Uids) == 1 {
 				subjectUid = varName.Uids.Uids[0]
 			} else {
-				return errors.Errorf("unique constraint violated for predicate [%v]", pred.Predicate)
+				return errors.Errorf("unique constraint violated for predicate [%v]", predicateName)
 			}
 		} else {
 			var err error
@@ -1822,7 +1830,7 @@ func verifyUnique(qc *queryContext, qr query.Request) error {
 					varNameVal, _ := varName.Vals.Get(subjectUid)
 					if v.Value == varNameVal.Value && uidOfv != subjectUid {
 						return errors.Errorf("could not insert duplicate value [%v] for predicate [%v]",
-							v.Value, pred.Predicate)
+							v.Value, predicateName)
 					}
 					return nil
 				})
@@ -1841,9 +1849,9 @@ func verifyUnique(qc *queryContext, qr query.Request) error {
 		if !isEmpty(queryResult.Uids) {
 			if len(queryResult.Uids.Uids) > 1 {
 				glog.Errorf("unique constraint violated for predicate [%v].uids: [%v].namespace: [%v]",
-					pred.Predicate, queryResult.Uids.Uids, pred.Namespace)
+					predicateName, queryResult.Uids.Uids, pred.Namespace)
 				return errors.Errorf("there are duplicates in existing data for predicate [%v]."+
-					"Please drop the unique constraint and re-add it after fixing the predicate data", pred.Predicate)
+					"Please drop the unique constraint and re-add it after fixing the predicate data", predicateName)
 			} else if queryResult.Uids.Uids[0] != subjectUid {
 				// Determine whether the mutation is a swap mutation
 				isSwap, err := isSwap(qc, queryResult.Uids.Uids[0], pred.Predicate, pred.Lang)
@@ -1852,7 +1860,7 @@ func verifyUnique(qc *queryContext, qr query.Request) error {
 				}
 				if !isSwap {
 					return errors.Errorf("could not insert duplicate value [%v] for predicate [%v]",
-						predValue, pred.Predicate)
+						predValue, predicateName)
 				}
 			}
 		}
@@ -2473,7 +2481,7 @@ func verifyUniqueWithinMutation(qc *queryContext) error {
 				dql.TypeValFrom(pred2.ObjectValue).Value == pred1Value &&
 				pred2.Subject != pred1.Subject {
 				return errors.Errorf("could not insert duplicate value [%v] for predicate [%v]",
-					pred1Value, pred1.Predicate)
+					pred1Value, predicateNameWithLang(pred1))
 			}
 		}
 	}

--- a/edgraph/server.go
+++ b/edgraph/server.go
@@ -1846,7 +1846,7 @@ func verifyUnique(qc *queryContext, qr query.Request) error {
 					"Please drop the unique constraint and re-add it after fixing the predicate data", pred.Predicate)
 			} else if queryResult.Uids.Uids[0] != subjectUid {
 				// Determine whether the mutation is a swap mutation
-				isSwap, err := isSwap(qc, queryResult.Uids.Uids[0], pred.Predicate)
+				isSwap, err := isSwap(qc, queryResult.Uids.Uids[0], pred.Predicate, pred.Lang)
 				if err != nil {
 					return err
 				}
@@ -2469,7 +2469,8 @@ func verifyUniqueWithinMutation(qc *queryContext) error {
 			if pred2.ObjectValue == nil {
 				continue
 			}
-			if pred2.Predicate == pred1.Predicate && dql.TypeValFrom(pred2.ObjectValue).Value == pred1Value &&
+			if pred2.Predicate == pred1.Predicate && pred2.Lang == pred1.Lang &&
+				dql.TypeValFrom(pred2.ObjectValue).Value == pred1Value &&
 				pred2.Subject != pred1.Subject {
 				return errors.Errorf("could not insert duplicate value [%v] for predicate [%v]",
 					pred1Value, pred1.Predicate)
@@ -2489,7 +2490,7 @@ func isUpsertCondTrue(qc *queryContext, gmuIndex int) bool {
 	return ok && len(uids) == 1
 }
 
-func isSwap(qc *queryContext, pred1SubjectUid uint64, pred1Predicate string) (bool, error) {
+func isSwap(qc *queryContext, pred1SubjectUid uint64, pred1Predicate, pred1Lang string) (bool, error) {
 	for i := range qc.uniqueVars {
 		gmuIndex, rdfIndex := decodeIndex(i)
 		pred2 := qc.gmuList[gmuIndex].Set[rdfIndex]
@@ -2504,7 +2505,8 @@ func isSwap(qc *queryContext, pred1SubjectUid uint64, pred1Predicate string) (bo
 			pred2SubjectUid = 0
 		}
 
-		if pred2SubjectUid == pred1SubjectUid && pred1Predicate == pred2.Predicate {
+		if pred2SubjectUid == pred1SubjectUid && pred1Predicate == pred2.Predicate &&
+			pred1Lang == pred2.Lang {
 			return true, nil
 		}
 	}

--- a/edgraph/server_test.go
+++ b/edgraph/server_test.go
@@ -253,6 +253,11 @@ func TestVerifyUniqueWithinMutationLanguageIdentity(t *testing.T) {
 			err := verifyUniqueWithinMutation(qc)
 			if tc.wantError {
 				require.ErrorContains(t, err, "could not insert duplicate value")
+				predicateName := "gxid"
+				if tc.firstLang != "" {
+					predicateName += "@" + tc.firstLang
+				}
+				require.ErrorContains(t, err, "predicate ["+predicateName+"]")
 			} else {
 				require.NoError(t, err)
 			}

--- a/edgraph/server_test.go
+++ b/edgraph/server_test.go
@@ -208,6 +208,81 @@ func TestGetHash(t *testing.T) {
 	require.Equal(t, hex.EncodeToString(h.Sum(nil)), getHash(10, 20))
 }
 
+func TestVerifyUniqueWithinMutationLanguageIdentity(t *testing.T) {
+	tests := []struct {
+		name       string
+		firstLang  string
+		secondLang string
+		wantError  bool
+	}{
+		{name: "same language", firstLang: "en", secondLang: "en", wantError: true},
+		{name: "different languages", firstLang: "en", secondLang: "fr"},
+		{name: "both untagged", wantError: true},
+		{name: "tagged and untagged", firstLang: "en"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			qc := &queryContext{
+				gmuList: []*dql.Mutation{{
+					Set: []*api.NQuad{
+						{
+							Subject:   "_:a",
+							Predicate: "gxid",
+							ObjectValue: &api.Value{
+								Val: &api.Value_StrVal{StrVal: "same"},
+							},
+							Lang: tc.firstLang,
+						},
+						{
+							Subject:   "_:b",
+							Predicate: "gxid",
+							ObjectValue: &api.Value{
+								Val: &api.Value_StrVal{StrVal: "same"},
+							},
+							Lang: tc.secondLang,
+						},
+					},
+				}},
+				uniqueVars: map[uint64]uniquePredMeta{
+					encodeIndex(0, 0): {},
+					encodeIndex(0, 1): {},
+				},
+			}
+
+			err := verifyUniqueWithinMutation(qc)
+			if tc.wantError {
+				require.ErrorContains(t, err, "could not insert duplicate value")
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestIsSwapLanguageIdentity(t *testing.T) {
+	qc := &queryContext{
+		gmuList: []*dql.Mutation{{
+			Set: []*api.NQuad{{
+				Subject:   "0x1",
+				Predicate: "gxid",
+				Lang:      "fr",
+			}},
+		}},
+		uniqueVars: map[uint64]uniquePredMeta{
+			encodeIndex(0, 0): {},
+		},
+	}
+
+	got, err := isSwap(qc, 1, "gxid", "en")
+	require.NoError(t, err)
+	require.False(t, got, "updating another language does not release the existing value")
+
+	got, err = isSwap(qc, 1, "gxid", "fr")
+	require.NoError(t, err)
+	require.True(t, got)
+}
+
 func TestVerifyUniqueWithinMutationBoundsChecks(t *testing.T) {
 	t.Run("gmuIndex out of bounds", func(t *testing.T) {
 		qc := &queryContext{

--- a/systest/unique_test.go
+++ b/systest/unique_test.go
@@ -903,7 +903,8 @@ func TestUniqueWithNonLatinPredName(t *testing.T) {
 		CommitNow: true,
 	})
 	require.Error(t, err)
-	require.ErrorContains(t, err, "could not insert duplicate value [example@email.com] for predicate [ईमेल#$%&]")
+	require.ErrorContains(t, err,
+		"could not insert duplicate value [example@email.com] for predicate [ईमेल#$%&@hi]")
 }
 
 func TestUniqueMultipleMutationsInSingleReqWithDelNqd(t *testing.T) {

--- a/systest/unique_test.go
+++ b/systest/unique_test.go
@@ -523,12 +523,101 @@ func TestUniqueForLangDirective(t *testing.T) {
 		CommitNow: true,
 	})
 	require.Error(t, err)
-	require.ErrorContains(t, err, "could not insert duplicate value [अमित] for predicate [name]")
+	require.ErrorContains(t, err, "could not insert duplicate value [अमित] for predicate [name@hi]")
 	_, err = dg.Mutate(&api.Mutation{
 		SetNquads: []byte(`_:a <name@en> "अमित" .`),
 		CommitNow: true,
 	})
 	require.NoError(t, err)
+}
+
+func TestUniqueLangTaggedAndUntaggedAcrossMutations(t *testing.T) {
+	dg := setUpDgraph(t)
+	require.NoError(t, dg.SetupSchema(`name: string @unique @lang @index(exact) .`))
+
+	for _, mutation := range []string{
+		`<0x101> <name> "untagged-first" .`,
+		`<0x102> <name@en> "untagged-first" .`,
+		`<0x103> <name@en> "tagged-first" .`,
+		`<0x104> <name> "tagged-first" .`,
+	} {
+		_, err := dg.Mutate(&api.Mutation{
+			SetNquads: []byte(mutation),
+			CommitNow: true,
+		})
+		require.NoError(t, err)
+	}
+
+	resp, err := dg.Query(`{
+		untaggedFirst(func: uid(0x101)) { uid name }
+		taggedSecond(func: uid(0x102)) { uid name@en }
+		taggedFirst(func: uid(0x103)) { uid name@en }
+		untaggedSecond(func: uid(0x104)) { uid name }
+	}`)
+	require.NoError(t, err)
+	require.NoError(t, dgraphapi.CompareJSON(`{
+		"untaggedFirst": [{"uid": "0x101", "name": "untagged-first"}],
+		"taggedSecond": [{"uid": "0x102", "name@en": "untagged-first"}],
+		"taggedFirst": [{"uid": "0x103", "name@en": "tagged-first"}],
+		"untaggedSecond": [{"uid": "0x104", "name": "tagged-first"}]
+	}`, string(resp.Json)))
+}
+
+func TestUniqueLangRejectsSwapAcrossLanguages(t *testing.T) {
+	dg := setUpDgraph(t)
+	require.NoError(t, dg.SetupSchema(`name: string @unique @lang @index(exact) .`))
+
+	_, err := dg.Mutate(&api.Mutation{
+		SetNquads: []byte(`<0x201> <name@en> "occupied" .`),
+		CommitNow: true,
+	})
+	require.NoError(t, err)
+
+	_, err = dg.Mutate(&api.Mutation{
+		SetNquads: []byte(`<0x202> <name@en> "occupied" .
+		                   <0x201> <name@fr> "other-language" .`),
+		CommitNow: true,
+	})
+	require.ErrorContains(t, err,
+		"could not insert duplicate value [occupied] for predicate [name@en]")
+
+	resp, err := dg.Query(`{
+		english(func: eq(name@en, "occupied")) { uid name@en }
+		french(func: eq(name@fr, "other-language")) { uid name@fr }
+	}`)
+	require.NoError(t, err)
+	require.NoError(t, dgraphapi.CompareJSON(`{
+		"english": [{"uid": "0x201", "name@en": "occupied"}],
+		"french": []
+	}`, string(resp.Json)))
+}
+
+func TestUniqueLangAllowsSwapWithinLanguage(t *testing.T) {
+	dg := setUpDgraph(t)
+	require.NoError(t, dg.SetupSchema(`name: string @unique @lang @index(exact) .`))
+
+	_, err := dg.Mutate(&api.Mutation{
+		SetNquads: []byte(`<0x301> <name@en> "available" .`),
+		CommitNow: true,
+	})
+	require.NoError(t, err)
+
+	_, err = dg.Mutate(&api.Mutation{
+		SetNquads: []byte(`<0x302> <name@en> "available" .
+		                   <0x301> <name@en> "replacement" .`),
+		CommitNow: true,
+	})
+	require.NoError(t, err)
+
+	resp, err := dg.Query(`{
+		available(func: eq(name@en, "available")) { uid name@en }
+		replacement(func: eq(name@en, "replacement")) { uid name@en }
+	}`)
+	require.NoError(t, err)
+	require.NoError(t, dgraphapi.CompareJSON(`{
+		"available": [{"uid": "0x302", "name@en": "available"}],
+		"replacement": [{"uid": "0x301", "name@en": "replacement"}]
+	}`, string(resp.Json)))
 }
 
 func TestUniqueTwoWaySwapMutation(t *testing.T) {

--- a/systest/unique_test.go
+++ b/systest/unique_test.go
@@ -503,8 +503,17 @@ func TestUniqueForLangDirective(t *testing.T) {
 	           email: string .`
 	dg := setUpDgraph(t)
 	require.NoError(t, dg.SetupSchema(schema))
-	rdf := `_:a <name@hi> "अमित" .	`
+	// Regression test for https://github.com/dgraph-io/dgraph/issues/9815. Language is part of
+	// value identity, so equal values under different language tags can coexist.
 	_, err := dg.Mutate(&api.Mutation{
+		SetNquads: []byte(`_:english <name@en> "same" .
+		                      _:french <name@fr> "same" .`),
+		CommitNow: true,
+	})
+	require.NoError(t, err)
+
+	rdf := `_:a <name@hi> "अमित" .	`
+	_, err = dg.Mutate(&api.Mutation{
 		SetNquads: []byte(rdf),
 		CommitNow: true,
 	})


### PR DESCRIPTION
**Description**

Fixes #9815.

For predicates using both `@unique` and `@lang`, equal values under different
language tags were handled inconsistently.

The database-level uniqueness query generated by `addQueryIfUnique` already
scopes values by language, such as `gxid@en` and `gxid@fr`. However,
`verifyUniqueWithinMutation` compared only the predicate and value, causing
equal values under different languages in the same mutation to be incorrectly
rejected as duplicates.

This change includes the language tag when checking value identity within a
mutation. It also applies the same rule to `isSwap`, preventing a mutation of
one language from being mistaken for releasing a unique value stored under
another language.

Predicates without language tags retain their existing behavior because both
language values are empty.

Regression coverage includes:

- Equal values under the same language are rejected.
- Equal values under different languages are accepted.
- Equal untagged values are rejected.
- Tagged and untagged values are treated independently.
- Swap detection only considers mutations under the same language.
- The reported DQL mutation is covered in `TestUniqueForLangDirective`.

**Checklist**

- [x] The PR title follows the
  [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax, leading
  with `fix:`, `feat:`, `chore:`, `ci:`, etc.
- [ ] Code compiles correctly and linting (via trunk) passes locally
- [x] Tests added for new functionality, or regression tests for bug fixes added as applicable

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dgraph-io/codesmith/dgraph/pr/9820"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790821462&installation_model_id=8575&pr_number=9820&repository=dgraph-io%2Fdgraph&return_to=https%3A%2F%2Fgithub.com%2Fdgraph-io%2Fdgraph%2Fpull%2F9820&signature=359d5d4a3199ec9cf5d29b947d19c482d0eec464bdebf8ba726b90f6a5779216"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->